### PR TITLE
pb git hooks v2.141.0 bottle

### DIFF
--- a/Formula/pb-git-hooks.rb
+++ b/Formula/pb-git-hooks.rb
@@ -3,6 +3,12 @@ class PbGitHooks < Formula
   homepage "https://github.com/PurpleBooth/pb-git-hooks"
   url "https://github.com/PurpleBooth/pb-git-hooks/archive/refs/tags/v2.141.0.tar.gz"
   sha256 "e43a77fcfe2040850f532ef50b8598dd9a0d5932f4d74a7d7508b2cd26aa1c3e"
+  bottle do
+    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
+    cellar :any
+    sha256 "79e8b1187c80ae85875392b7ffd5979704483d74720868e9641c56cb8caee796" => :catalina
+  end
+
   depends_on "rust" => :build
   depends_on "openssl@1.1"
 


### PR DESCRIPTION
- pb-git-hooks: update 2.141.0 bottle.
- Update pb-git-hooks to v2.141.0
