### PR TITLE
fix compaudit v0.27.0 bottle

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -4,6 +4,12 @@ class FixCompaudit < Formula
   url "https://github.com/PurpleBooth/fix-compaudit/archive/refs/tags/v0.27.0.tar.gz"
   sha256 "13f6b4cb47527b05e425c1a0db4b84f2dd1e76bf5ff48fc9fc7853c35e8bc7f1"
 
+  bottle do
+    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
+    cellar :any_skip_relocation
+    sha256 "d4e6142057cc24368bf0610800f6e4998bb1e4f816309c3a00a2cfcc6daaf003" => :catalina
+  end
+
   depends_on "rust" => :build
   depends_on "zsh"
 


### PR DESCRIPTION
- fix-compaudit: update 0.27.0 bottle.
- Update fix-compaudit to v0.27.0
