### PR TITLE
fix gnupg permissions v0.32.0 bottle

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -4,6 +4,12 @@ class FixGnupgPermissions < Formula
   url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/refs/tags/v0.32.0.tar.gz"
   sha256 "0c8ae72357fe9a0fb8e20852dc784f6214cfa93f7e838fa61f6924d82b5c3e97"
 
+  bottle do
+    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
+    cellar :any_skip_relocation
+    sha256 "8d768142b9976aa5d1bab0144313bb57f9705349d56a300add65f3d87a5a935e" => :catalina
+  end
+
   depends_on "rust" => :build
 
   def install

--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,14 +1,8 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/refs/tags/v0.31.0.tar.gz"
-  sha256 "ec42fd39688fe7a070738d47a9da0dff507c97a15e9256495c85836bf73b9685"
-
-  bottle do
-    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
-    cellar :any_skip_relocation
-    sha256 "346f02f1a2c4dc53692b7f5d499475a90c2ca61d6c6b111dd4b6c721384a24ca" => :catalina
-  end
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/refs/tags/v0.32.0.tar.gz"
+  sha256 "0c8ae72357fe9a0fb8e20852dc784f6214cfa93f7e838fa61f6924d82b5c3e97"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
- fix-gnupg-permissions: update 0.32.0 bottle.
- Update fix-gnupg-permissions to v0.32.0
