### PR TITLE
git duet wrap for sops v0.31.0 bottle

### DIFF
--- a/Formula/git-duet-wrap-for-sops.rb
+++ b/Formula/git-duet-wrap-for-sops.rb
@@ -4,6 +4,12 @@ class GitDuetWrapForSops < Formula
   url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.31.0.tar.gz"
   sha256 "3f78e32832c58a8397fec68b7d5b12f63a6f00cff45ee556885118b993540ea0"
 
+  bottle do
+    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
+    cellar :any_skip_relocation
+    sha256 "a91886c785ee2feba446e5a08e8ae6477f7859a9dca46913fa92170b240aacbf" => :catalina
+  end
+
   depends_on "rust" => :build
 
   def install

--- a/Formula/git-duet-wrap-for-sops.rb
+++ b/Formula/git-duet-wrap-for-sops.rb
@@ -1,14 +1,8 @@
 class GitDuetWrapForSops < Formula
   desc "Keeps your git authors file encrypted"
   homepage "https://github.com/PurpleBooth/git-duet-wrap-for-sops"
-  url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.30.0.tar.gz"
-  sha256 "40aca26990014d91bf4f4a74ec6519dbe762b00a35110a7668d97c5a30aafe35"
-
-  bottle do
-    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
-    cellar :any_skip_relocation
-    sha256 "dd017b05fc2ea29df555c4d5ce0f06439bd6ee83c08c7f02efcdf2798b01f733" => :catalina
-  end
+  url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.31.0.tar.gz"
+  sha256 "3f78e32832c58a8397fec68b7d5b12f63a6f00cff45ee556885118b993540ea0"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
- git-duet-wrap-for-sops: update 0.31.0 bottle.
- Update git-duet-wrap-for-sops to v0.31.0
