### PR TITLE
git duet wrap for sops v0.36.0 bottle

### DIFF
--- a/Formula/git-duet-wrap-for-sops.rb
+++ b/Formula/git-duet-wrap-for-sops.rb
@@ -1,8 +1,8 @@
 class GitDuetWrapForSops < Formula
   desc "Keeps your git authors file encrypted"
   homepage "https://github.com/PurpleBooth/git-duet-wrap-for-sops"
-  url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.35.0.tar.gz"
-  sha256 "9ddac66e8da744a467406afa95a92420a9cb8ed608d7a76ae2ded92f8204a89d"
+  url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.36.0.tar.gz"
+  sha256 "dc79f01aa0378322ee277728559d974ea3a02928db17a9a78ff369507a6c5976"
 
   depends_on "rust" => :build
 

--- a/Formula/git-duet-wrap-for-sops.rb
+++ b/Formula/git-duet-wrap-for-sops.rb
@@ -4,6 +4,12 @@ class GitDuetWrapForSops < Formula
   url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.36.0.tar.gz"
   sha256 "dc79f01aa0378322ee277728559d974ea3a02928db17a9a78ff369507a6c5976"
 
+  bottle do
+    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
+    cellar :any_skip_relocation
+    sha256 "0117ebbf7de9705aa98eb2a14c2a1c076433df0e7a398c805b756d3fa2cfeabd" => :catalina
+  end
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
- Update git-duet-wrap-for-sops to v0.36.0
- git-duet-wrap-for-sops: update 0.36.0 bottle.
