### PR TITLE
fix gnupg permissions v0.39.0 bottle

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,14 +1,8 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/refs/tags/v0.38.0.tar.gz"
-  sha256 "6be611f47872f7835130031f2a2eca998316184d2d57d1dfefe89795351f11e0"
-
-  bottle do
-    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
-    cellar :any_skip_relocation
-    sha256 "a94ee702e025bcb1292681ef036d19cbb7e5f4a66f47abc690cca6b71c8e8d23" => :catalina
-  end
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/refs/tags/v0.39.0.tar.gz"
+  sha256 "eb0daa4a9b1cb6de599d23ce611bf3d91b7444dbd48e24f535cecf5409ab2f02"
 
   depends_on "rust" => :build
 

--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -4,6 +4,12 @@ class FixGnupgPermissions < Formula
   url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/refs/tags/v0.39.0.tar.gz"
   sha256 "eb0daa4a9b1cb6de599d23ce611bf3d91b7444dbd48e24f535cecf5409ab2f02"
 
+  bottle do
+    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
+    cellar :any_skip_relocation
+    sha256 "7ceb2f04919e8a1492282e5cdc6fdb8391c95a4475e1cf0e71cc0ac66b50cbed" => :catalina
+  end
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
- Update fix-gnupg-permissions to v0.39.0
- fix-gnupg-permissions: update 0.39.0 bottle.
