### PR TITLE
git duet wrap for sops v0.40.0 bottle

### DIFF
--- a/Formula/git-duet-wrap-for-sops.rb
+++ b/Formula/git-duet-wrap-for-sops.rb
@@ -4,6 +4,12 @@ class GitDuetWrapForSops < Formula
   url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.40.0.tar.gz"
   sha256 "caa1575e0ade9ea73f13c4b6af760350c1cea15a2efc24cd02937dbdbad133ce"
 
+  bottle do
+    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
+    cellar :any_skip_relocation
+    sha256 "9e64b4f1a441ac72a380876331f0b65db6cf7d448895af6c59d709d48ab489c7" => :catalina
+  end
+
   depends_on "rust" => :build
 
   def install

--- a/Formula/git-duet-wrap-for-sops.rb
+++ b/Formula/git-duet-wrap-for-sops.rb
@@ -1,14 +1,8 @@
 class GitDuetWrapForSops < Formula
   desc "Keeps your git authors file encrypted"
   homepage "https://github.com/PurpleBooth/git-duet-wrap-for-sops"
-  url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.39.0.tar.gz"
-  sha256 "5c8f9a57473cfa302edd6c549b465f5baf4e6fbb22c7769ee80ceff7fb8e1d35"
-
-  bottle do
-    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
-    cellar :any_skip_relocation
-    sha256 "9de8f0bb77dd413a9be42cfac9266954370cf5c913e8a4308302d6c58bb3d9d7" => :catalina
-  end
+  url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.40.0.tar.gz"
+  sha256 "caa1575e0ade9ea73f13c4b6af760350c1cea15a2efc24cd02937dbdbad133ce"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
- Update git-duet-wrap-for-sops to v0.40.0
- git-duet-wrap-for-sops: update 0.40.0 bottle.
