### PR TITLE
git duet wrap for sops v0.41.0 bottle

### DIFF
--- a/Formula/git-duet-wrap-for-sops.rb
+++ b/Formula/git-duet-wrap-for-sops.rb
@@ -1,14 +1,8 @@
 class GitDuetWrapForSops < Formula
   desc "Keeps your git authors file encrypted"
   homepage "https://github.com/PurpleBooth/git-duet-wrap-for-sops"
-  url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.40.0.tar.gz"
-  sha256 "caa1575e0ade9ea73f13c4b6af760350c1cea15a2efc24cd02937dbdbad133ce"
-
-  bottle do
-    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
-    cellar :any_skip_relocation
-    sha256 "9e64b4f1a441ac72a380876331f0b65db6cf7d448895af6c59d709d48ab489c7" => :catalina
-  end
+  url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.41.0.tar.gz"
+  sha256 "de5d4ca45bbb0f5550dde008b71df1ec47139e987f68be007d6adc2f16833c28"
 
   depends_on "rust" => :build
 

--- a/Formula/git-duet-wrap-for-sops.rb
+++ b/Formula/git-duet-wrap-for-sops.rb
@@ -4,6 +4,12 @@ class GitDuetWrapForSops < Formula
   url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.41.0.tar.gz"
   sha256 "de5d4ca45bbb0f5550dde008b71df1ec47139e987f68be007d6adc2f16833c28"
 
+  bottle do
+    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
+    cellar :any_skip_relocation
+    sha256 "2e7c29f7bc47d8dfab487158d565e0c1073f2ee05d0b0155c29655aafda951dd" => :catalina
+  end
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
- Update git-duet-wrap-for-sops to v0.41.0
- git-duet-wrap-for-sops: update 0.41.0 bottle.
