### PR TITLE
fix gnupg permissions v0.46.0 bottle

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,14 +1,8 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/refs/tags/v0.45.0.tar.gz"
-  sha256 "6f6847f53a62e33a6697fc25c6a50cfcc081b02e3b14f8a4aedd2a7a89d42f46"
-
-  bottle do
-    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
-    cellar :any_skip_relocation
-    sha256 "bc0870e77fa522d3165296ac92ef376edb47126a551b2e75389a4ed76595dd8f" => :catalina
-  end
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/refs/tags/v0.46.0.tar.gz"
+  sha256 "9bbd59a4d6b639e3ff78203463990b5c3596cd7067aeb80a4eee9c65f0f479d1"
 
   depends_on "rust" => :build
 

--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -4,6 +4,12 @@ class FixGnupgPermissions < Formula
   url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/refs/tags/v0.46.0.tar.gz"
   sha256 "9bbd59a4d6b639e3ff78203463990b5c3596cd7067aeb80a4eee9c65f0f479d1"
 
+  bottle do
+    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
+    cellar :any_skip_relocation
+    sha256 "63ce907ce21d8c52a0709b5c6da73b5e7701050f848eb0b38fc0b6ddc7e0a8ca" => :catalina
+  end
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
- Update fix-gnupg-permissions to v0.46.0
- fix-gnupg-permissions: update 0.46.0 bottle.
