### PR TITLE
git duet wrap for sops v0.44.0 bottle

### DIFF
--- a/Formula/git-duet-wrap-for-sops.rb
+++ b/Formula/git-duet-wrap-for-sops.rb
@@ -1,14 +1,8 @@
 class GitDuetWrapForSops < Formula
   desc "Keeps your git authors file encrypted"
   homepage "https://github.com/PurpleBooth/git-duet-wrap-for-sops"
-  url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.43.0.tar.gz"
-  sha256 "6c4794a41d21c92fb41357ac2d39a5f9176f96cbfe249bca67906daef2f7c00f"
-
-  bottle do
-    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
-    cellar :any_skip_relocation
-    sha256 "7d0eb28a4411303c780ce2b5200c1c92b113dff81652e32fd5f2b9c136f94a16" => :catalina
-  end
+  url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.44.0.tar.gz"
+  sha256 "55665b354e67f5f7c2811188cfeb91889aff4d235f43cf68d701c7298a588cb1"
 
   depends_on "rust" => :build
 

--- a/Formula/git-duet-wrap-for-sops.rb
+++ b/Formula/git-duet-wrap-for-sops.rb
@@ -4,6 +4,12 @@ class GitDuetWrapForSops < Formula
   url "https://github.com/PurpleBooth/git-duet-wrap-for-sops/archive/refs/tags/v0.44.0.tar.gz"
   sha256 "55665b354e67f5f7c2811188cfeb91889aff4d235f43cf68d701c7298a588cb1"
 
+  bottle do
+    root_url "https://dl.bintray.com/purplebooth/bottles-repo"
+    cellar :any_skip_relocation
+    sha256 "d250e69acb0f1831a877a155ac3033615136dd2484a1ab8d8f97f2b2db96fe07" => :catalina
+  end
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
- Update git-duet-wrap-for-sops to v0.44.0
- git-duet-wrap-for-sops: update 0.44.0 bottle.
