### PR TITLE
fix: Update git-mit to v5.7.6

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.7.5.tar.gz"
-  sha256 "250e311b7cb7d5a6e67192ae14de49ac75438e4ca1f2f7fa63037730291099bd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.7.5"
-    sha256 cellar: :any,                 catalina:     "9a3f1951e5c44d663c61e9b41d39b61134bf7f9f078870ea3a16cf41a083e77c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d0e2299e99566be0b24def9acb14c70315de03b9cdf8d17f39e8770c914cc666"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.7.6.tar.gz"
+  sha256 "2e6707a33c1cca67ad070ecc4423e39ec203bd1f6ae12aa975407fc377721c6a"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.7.6](https://github.com/PurpleBooth/git-mit/compare/v5.7.5...v5.7.6) (2021-09-27)

### Build

- Versio update versions ([`d35682f`](https://github.com/PurpleBooth/git-mit/commit/d35682fc87743db0035dddf7df293bf4b8ce7bae))

### Ci

- Use config ([`8d14a4f`](https://github.com/PurpleBooth/git-mit/commit/8d14a4f8880936bd297524e04404b355a83fb52d))

### Fix

- Bump mit-lint from 0.2.0 to 1.0.0 ([`c176883`](https://github.com/PurpleBooth/git-mit/commit/c1768839f3d519b00cf30d47f05113999e934b23))

