### PR TITLE
fix: Update git-mit to v5.8.0

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.7.6.tar.gz"
-  sha256 "2e6707a33c1cca67ad070ecc4423e39ec203bd1f6ae12aa975407fc377721c6a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.7.6"
-    sha256 cellar: :any,                 catalina:     "d340cfd6817c34a277d02755bab7d8bb46f9effad6834bde728276e5e0a9c4cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8788e0c2c1166671193b3892e44fbf2fb3967f14f7c60ed0a8ea7364f8a71270"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.8.0.tar.gz"
+  sha256 "cb84905cfa5d4c9aa13ed8f978b34856ca6880e481c66629ed7b1a40f03bc004"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.8.0](https://github.com/PurpleBooth/git-mit/compare/v5.7.6...v5.8.0) (2021-09-29)

### Build

- Versio update versions ([`a255081`](https://github.com/PurpleBooth/git-mit/commit/a2550810b7114a39f8cb470da99a7b7deb8e9e9d))

### Ci

- Remove formatting checking ([`f805b05`](https://github.com/PurpleBooth/git-mit/commit/f805b056486e2b3007951426fe7399d97136bcd9))

### Feat

- Nicer error messages ([`32f1505`](https://github.com/PurpleBooth/git-mit/commit/32f1505e2587cb1995272f5e4a4fa8a310790787))

### Refactor

- Where possible use dialoge ([`356c254`](https://github.com/PurpleBooth/git-mit/commit/356c254c63ba3ee49c2c803a7e52c9de31b31efb))

