### PR TITLE
fix: Update git-mit to v5.8.7

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.8.5.tar.gz"
-  sha256 "bb59675ab8adee1c1f2b20db476a794aecc7567d369cfd18e3770344fb8653e3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.8.5"
-    sha256 cellar: :any,                 catalina:     "e177b6832e59cf0c1ce950ba41f174429d1a5286133ed5314ec5c77166dee542"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "44c32a5a321f648b080d40eff1b201620a94e63a3bf1db1e975dd902262a2cbb"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.8.7.tar.gz"
+  sha256 "6fac1c29df8ac2e841d28cbe5a5a247970a0a350a1714eefcc76b1909fa3c52d"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.8.7](https://github.com/PurpleBooth/git-mit/compare/v5.8.6...v5.8.7) (2021-09-30)

### Build

- Versio update versions ([`b22d91c`](https://github.com/PurpleBooth/git-mit/commit/b22d91c6e104f91f4e48374e035ea459240b7f07))

### Fix

- Stop using yanked package ([`bdba8eb`](https://github.com/PurpleBooth/git-mit/commit/bdba8ebbcdc04b9ff84c842040e7aebb6e771314))

### Refactor

- Remove empty file ([`9419f54`](https://github.com/PurpleBooth/git-mit/commit/9419f540e7c5114d81ff238a783314dd549c4b60))
- Structure code uniformly ([`74f85e6`](https://github.com/PurpleBooth/git-mit/commit/74f85e65741acb704620f4b829d46b9a63b3dc44))
- Swap closure for ufc ([`c8a6a13`](https://github.com/PurpleBooth/git-mit/commit/c8a6a13af423718e4c231797f2dd41fe465deb92))
- Swap lambdas for UFC where possible ([`a7ee129`](https://github.com/PurpleBooth/git-mit/commit/a7ee129e645b51c1fd2eacfd12da4df3c3af4439))

