### PR TITLE
fix: Update git-mit to v5.9.0

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.8.7.tar.gz"
-  sha256 "6fac1c29df8ac2e841d28cbe5a5a247970a0a350a1714eefcc76b1909fa3c52d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.8.7"
-    sha256 cellar: :any,                 catalina:     "50fcc2cec9349579b43492915700db767bc324aca509b1597d92fe9fa9dbd8c4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d28a28a22082be26ce09f7c27f9a10e8af8bde616762d6f967cf154c3e7808be"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.0.tar.gz"
+  sha256 "52186763e71b690124719df0c31092c66ec8c64b34c896bac0c059042c2c5e0b"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.9.0](https://github.com/PurpleBooth/git-mit/compare/v5.8.7...v5.9.0) (2021-09-30)

### Build

- Versio update versions ([`0b75635`](https://github.com/PurpleBooth/git-mit/commit/0b75635ad213a34dd21b1c88dc3221cc68dc90df))

### Feat

- Use standard outupt for success ([`fbd5455`](https://github.com/PurpleBooth/git-mit/commit/fbd5455d2c3aa9f2bbe332eb5a986c866883c749))

