### PR TITLE
fix: Update git-mit to v5.9.4

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.3.tar.gz"
-  sha256 "6ec7acd055590c53814715153fbaff2620931e97b1180b088b40fe387ef3ed17"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.9.3"
-    sha256 cellar: :any,                 catalina:     "cc6cf530bba6899284c313573890ca5eae4f2cccc981e9945a707afb04e695ed"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "998571111dd4f232473b71ae0954beda3da5475026f44f44fe5cccbe5a298546"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.4.tar.gz"
+  sha256 "e25e790975e8bfc1c2d108a267fb43e5d4c12947d2daa884032039174380e4ee"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.9.4](https://github.com/PurpleBooth/git-mit/compare/v5.9.3...v5.9.4) (2021-10-04)

### Build

- Versio update versions ([`4ca7c0b`](https://github.com/PurpleBooth/git-mit/commit/4ca7c0b52abc31b945933ecf7641d8197c696506))

### Ci

- Bump ncipollo/release-action from 1.8.9 to 1.8.10 ([`9c0acc9`](https://github.com/PurpleBooth/git-mit/commit/9c0acc950eb8ef33eb219fd8199ed8984db29c6e))

### Fix

- Centralise the implementation for git-mit's author loading ([`a013f18`](https://github.com/PurpleBooth/git-mit/commit/a013f183e9e1d3e104aad51a469cc49506b6198d))

### Refactor

- Move author loading config into a central location ([`9b40eb5`](https://github.com/PurpleBooth/git-mit/commit/9b40eb545d1bb2b3514c622edf4fbfcbd511cd24))

