### PR TITLE
fix: Update git-mit to v5.9.5

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.4.tar.gz"
-  sha256 "e25e790975e8bfc1c2d108a267fb43e5d4c12947d2daa884032039174380e4ee"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.9.4"
-    sha256 cellar: :any,                 catalina:     "e9bc6b0787e7fba794998ebf0b7741036ecb87f81086ee90b8a3abd0565a7da4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "155d334e71637fdd010f2167054bd5ded48b0b167cd16eec06d199d77f379234"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.5.tar.gz"
+  sha256 "61ef3749b688698c7938c8482b0b8ebf60799c0a3a06556cd0cd5bab47858453"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.9.5](https://github.com/PurpleBooth/git-mit/compare/v5.9.4...v5.9.5) (2021-10-04)

### Build

- Versio update versions ([`e15a159`](https://github.com/PurpleBooth/git-mit/commit/e15a159c56bf95569273e11634d56d69c47fd52f))

### Fix

- Make scope more clear ([`695e932`](https://github.com/PurpleBooth/git-mit/commit/695e932313afc1389c769d51f20318b6b174015d))

