### PR TITLE
fix: Update git-mit to v5.9.6

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.5.tar.gz"
-  sha256 "61ef3749b688698c7938c8482b0b8ebf60799c0a3a06556cd0cd5bab47858453"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.9.5"
-    sha256 cellar: :any,                 catalina:     "76904779d15742142f4aa89a9e6330fdaa53107ae5bbc287fc3916448a9ffe19"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7b030cfc2db9c901394d87c312f4bbcb21c729740839d49fca84aab92f3ba313"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.6.tar.gz"
+  sha256 "f655beeaa3316fa7c2b8c372815fc1504646d73d93bfd48c25eb173081cba431"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.9.6](https://github.com/PurpleBooth/git-mit/compare/v5.9.5...v5.9.6) (2021-10-05)

### Build

- Versio update versions ([`9dd511c`](https://github.com/PurpleBooth/git-mit/commit/9dd511c31a02a82eaba07d11999b384bfd12d8f4))

### Fix

- Bump git2 from 0.13.22 to 0.13.23 ([`3596cc2`](https://github.com/PurpleBooth/git-mit/commit/3596cc2cf3f22e39b438f9bf1019afd6c680fde9))

