### PR TITLE
fix: Update git-mit to v5.9.7

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.6.tar.gz"
-  sha256 "f655beeaa3316fa7c2b8c372815fc1504646d73d93bfd48c25eb173081cba431"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.9.6"
-    sha256 cellar: :any,                 catalina:     "c431ca15d2ba25d4e2d5c4b7d0309ae6ecf5feecdbf38c61515ce966754cbbbf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a51b6609a45bfff93d6994e44df5179f7f90b8e58335f05d055406b922a19427"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.7.tar.gz"
+  sha256 "4ddc03d641a7a38c0dc3f46aa461c8485f5462ff6bd9fd0302185339aa805100"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"
@@ -27,8 +21,7 @@ class GitMit < Formula
     system "cargo", "install", "--root", prefix, "--path", "./git-mit-install/"
 
     Pathname.glob("**/bash_completion/*").each do |file|
-      base = file.basename(".bash")
-      bash_completion.install file => base
+      bash_completion.install file
     end
 
     Pathname.glob("**/fish_completion/*").each do |file|


### PR DESCRIPTION
## Changelog
### [v5.9.7](https://github.com/PurpleBooth/git-mit/compare/v5.9.6...v5.9.7) (2021-10-05)

### Build

- Versio update versions ([`59d51ff`](https://github.com/PurpleBooth/git-mit/commit/59d51ffbfd44f75252fae6bf1d4536d593e5d079))

### Ci

- Check for windows lint failures ([`68b59e5`](https://github.com/PurpleBooth/git-mit/commit/68b59e5647083dee9652e9dbd4a8d3007133b79d))
- Remove unused allow ([`16eca54`](https://github.com/PurpleBooth/git-mit/commit/16eca54b9cce8f979e0855373736284ce7adde3b))
- Quote arguments ([`7db8e14`](https://github.com/PurpleBooth/git-mit/commit/7db8e14745636108a7343332444655880e52d7ff))
- Only run yaml lint on ubuntu ([`6a6cb27`](https://github.com/PurpleBooth/git-mit/commit/6a6cb27461d1f1155746e39e01e7dd85150fa1ae))

### Fix

- Bash completions can end without the .bash ([`39a05af`](https://github.com/PurpleBooth/git-mit/commit/39a05afa8eb29e5300618bad62a4f396adcc8deb))
- Remove lint error ([`781fa61`](https://github.com/PurpleBooth/git-mit/commit/781fa61c5947a4534a9e6e9ed7abaf74de808684))

