### PR TITLE
fix: Update git-mit to v5.9.8

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.6.tar.gz"
-  sha256 "f655beeaa3316fa7c2b8c372815fc1504646d73d93bfd48c25eb173081cba431"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.9.6"
-    sha256 cellar: :any,                 catalina:     "c431ca15d2ba25d4e2d5c4b7d0309ae6ecf5feecdbf38c61515ce966754cbbbf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a51b6609a45bfff93d6994e44df5179f7f90b8e58335f05d055406b922a19427"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.8.tar.gz"
+  sha256 "59258582ad7a9ab3a37136cdb194b27a9acfc00f793ecd12d93275b87012e33a"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"
@@ -27,8 +21,7 @@ class GitMit < Formula
     system "cargo", "install", "--root", prefix, "--path", "./git-mit-install/"
 
     Pathname.glob("**/bash_completion/*").each do |file|
-      base = file.basename(".bash")
-      bash_completion.install file => base
+      bash_completion.install file
     end
 
     Pathname.glob("**/fish_completion/*").each do |file|


### PR DESCRIPTION
## Changelog
### [v5.9.8](https://github.com/PurpleBooth/git-mit/compare/v5.9.7...v5.9.8) (2021-10-06)

### Build

- Versio update versions ([`3ea2ea6`](https://github.com/PurpleBooth/git-mit/commit/3ea2ea6406f407351dab75fd3139e4302a14e8a1))

### Ci

- Try using the reusable workflows from gh ([`c22fe27`](https://github.com/PurpleBooth/git-mit/commit/c22fe278257e17fd2033d0bcf0d2ed7a5e692b20))
- Pull out security audit workflow ([`6a9d6fe`](https://github.com/PurpleBooth/git-mit/commit/6a9d6feeefbfb63269e243c091915b39b2e2a419))
- Correct the security audit secrets ([`0f3a80e`](https://github.com/PurpleBooth/git-mit/commit/0f3a80e85bde3c17a410110813555b975bb04fcd))
- Pass github token through to workflow ([`d1f609e`](https://github.com/PurpleBooth/git-mit/commit/d1f609e119f0719a75ab62d1a1b55e45ba698581))
- Set the token ([`0a776b0`](https://github.com/PurpleBooth/git-mit/commit/0a776b00086f3cff4547cf7ebbdf98deea057a94))
- Remove token ([`932cb13`](https://github.com/PurpleBooth/git-mit/commit/932cb13261e74e9aeb2c0db2a960088e315d4ea5))
- Pass in the github token ([`0a1358f`](https://github.com/PurpleBooth/git-mit/commit/0a1358fa9c3558053e1289686fa1b4923c5dde02))
- Add security audit ([`feb6359`](https://github.com/PurpleBooth/git-mit/commit/feb63596dac03af8c5dc5ab9fe888acfa71d9cc3))
- Add install deps ([`87f3556`](https://github.com/PurpleBooth/git-mit/commit/87f3556a96df671ada45ad536a7841089208a263))
- Stablise ci ([`a1c286b`](https://github.com/PurpleBooth/git-mit/commit/a1c286b301051a209734ff43df9097916607632f))
- Comment out rust check ([`42e4959`](https://github.com/PurpleBooth/git-mit/commit/42e495920571ec9507cd7642a22563b4626ba2db))
- Formatting ([`340950c`](https://github.com/PurpleBooth/git-mit/commit/340950c106334fe640b9445665521810c4d45444))
- Remove capitalisation ([`16c2342`](https://github.com/PurpleBooth/git-mit/commit/16c23423d976f4580993af94fdfba35b63933705))
- Revert back to the known good ci ([`96ac671`](https://github.com/PurpleBooth/git-mit/commit/96ac671e1768512c88edd8367965f527290fa5ef))

### Fix

- Bump miette from 3.1.0 to 3.2.0 ([`e650f87`](https://github.com/PurpleBooth/git-mit/commit/e650f873aaf556b03fbc1b3605143c168b3f0d23))
- Update outputs for tests ([`a687326`](https://github.com/PurpleBooth/git-mit/commit/a687326ddc58f4d8dec67588617fa6b1c581bf08))

