### PR TITLE
fix: Update git-mit to v5.9.9

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.8.tar.gz"
-  sha256 "59258582ad7a9ab3a37136cdb194b27a9acfc00f793ecd12d93275b87012e33a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.9.8"
-    sha256 cellar: :any,                 catalina:     "6d9e9ef9f3afeab026733abf8f8076146dbaf19d119a014b7d11f8ebade92bc1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "425ef693b99303aa2e45f880af25affa261b2b2b4fb3f9079211fa9132650590"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.9.tar.gz"
+  sha256 "0d466edc4958ab7fc3bab2e04cead37fa7e37c6c156f3679924bbba2350fd979"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.9.9](https://github.com/PurpleBooth/git-mit/compare/v5.9.8...v5.9.9) (2021-10-06)

### Build

- Versio update versions ([`c90211e`](https://github.com/PurpleBooth/git-mit/commit/c90211e35725ebaef62f5c71d4213672e43b92d7))

### Fix

- File being loaded from wrong directory ([`4d4eb08`](https://github.com/PurpleBooth/git-mit/commit/4d4eb08ad72731ec477dda2e02a2b5e411b3de62))

