### PR TITLE
fix: Update git-mit to v5.9.10

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.9.tar.gz"
-  sha256 "0d466edc4958ab7fc3bab2e04cead37fa7e37c6c156f3679924bbba2350fd979"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.9.9"
-    sha256 cellar: :any,                 catalina:     "f53fe8fca359a6b8444e0c2e19b4e5ee1990cfb28b1ef28a0fad0ee425c72026"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a57f2e862fac161783f309aa085afb12888b6876c53aeded8895e6f07336e0db"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.10.tar.gz"
+  sha256 "d38a6bfcc4a25dd899a159e5ceb1aa24d75907e91e6b3bf5ee516bc110f11643"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.9.10](https://github.com/PurpleBooth/git-mit/compare/v5.9.9...v5.9.10) (2021-10-07)

### Build

- Versio update versions ([`d78ffb3`](https://github.com/PurpleBooth/git-mit/commit/d78ffb38ec79f227134d68e20e7b5e28203987c9))

### Chore

- Add 'revert' and 'ignore' types to commit ([`cbfc5c9`](https://github.com/PurpleBooth/git-mit/commit/cbfc5c92ff000a93927e4b7d99dc938c0d44a0a4))

### Ci

- Bump nick-invision/retry from 2.4.1 to 2.5.0 ([`0324782`](https://github.com/PurpleBooth/git-mit/commit/03247825713ffa32845a46e4c04e87a1c5304652))

### Fix

- Bump mit-lint from 2.2.0 to 2.2.1 ([`716ecae`](https://github.com/PurpleBooth/git-mit/commit/716ecaed447452a47ee84b7ef4e9f41a6291bdae))

