### PR TITLE
fix: Update git-mit to v5.10.0

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.9.11.tar.gz"
-  sha256 "1b4ce614437c6eab6c4a53e503461d29e0307c130672b7caa7509153d1417ad7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.9.11"
-    sha256 cellar: :any,                 catalina:     "61a2b31cb74fff5394f46d8438d97165e87d5957fbc34496f3234dfa457142ed"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8d97e0b92b141f7e62675e423faef671b42ca8b877201068ca64c02f0ea5d2d4"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.10.0.tar.gz"
+  sha256 "504a9eba3c6f6030ecc6d0124c5e5d44a84936b0a90c1e13762d65880b81573b"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"
@@ -26,17 +20,57 @@ class GitMit < Formula
     system "cargo", "install", "--root", prefix, "--path", "./git-mit-relates-to/"
     system "cargo", "install", "--root", prefix, "--path", "./git-mit-install/"
 
-    Pathname.glob("**/bash_completion/*").each do |file|
-      bash_completion.install file
-    end
+    # Install bash completion
+    output = Utils.safe_popen_read("#{bin}/mit-commit-msg", "completion", "bash")
+    (bash_completion/"mit-commit-msg").write output
+    output = Utils.safe_popen_read("#{bin}/mit-pre-commit", "completion", "bash")
+    (bash_completion/"mit-pre-commit").write output
+    output = Utils.safe_popen_read("#{bin}/mit-prepare-commit-msg", "completion", "bash")
+    (bash_completion/"mit-prepare-commit-msg").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit", "completion", "bash")
+    (bash_completion/"git-mit").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit-config", "completion", "bash")
+    (bash_completion/"git-mit-config").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit-relates-to", "completion", "bash")
+    (bash_completion/"git-mit-relates-to").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit-install", "completion", "bash")
+    (bash_completion/"git-mit-install").write output
 
-    Pathname.glob("**/fish_completion/*").each do |file|
-      fish_completion.install file
-    end
+    # Install zsh completion
+    output = Utils.safe_popen_read("#{bin}/mit-commit-msg", "completion", "zsh")
+    (zsh_completion/"_mit-commit-msg").write output
+    output = Utils.safe_popen_read("#{bin}/mit-pre-commit", "completion", "zsh")
+    (zsh_completion/"_mit-pre-commit").write output
+    output = Utils.safe_popen_read("#{bin}/mit-prepare-commit-msg", "completion", "zsh")
+    (zsh_completion/"_mit-prepare-commit-msg").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit", "completion", "zsh")
+    (zsh_completion/"_git-mit").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit-config", "completion", "zsh")
+    (zsh_completion/"_git-mit-config").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit-relates-to", "completion", "zsh")
+    (zsh_completion/"_git-mit-relates-to").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit-install", "completion", "zsh")
+    (zsh_completion/"_git-mit-install").write output
 
-    Pathname.glob("**/zsh_completion/*").each do |file|
-      zsh_completion.install file
-    end
+    # Install fish completion
+    output = Utils.safe_popen_read("#{bin}/specdown", "completion", "fish")
+    (fish_completion/"specdown.fish").write output
+
+    # Install fish completion
+    output = Utils.safe_popen_read("#{bin}/mit-commit-msg", "completion", "fish")
+    (fish_completion/"mit-commit-msg.fish").write output
+    output = Utils.safe_popen_read("#{bin}/mit-pre-commit", "completion", "fish")
+    (fish_completion/"mit-pre-commit.fish").write output
+    output = Utils.safe_popen_read("#{bin}/mit-prepare-commit-msg", "completion", "fish")
+    (fish_completion/"mit-prepare-commit-msg.fish").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit", "completion", "fish")
+    (fish_completion/"git-mit.fish").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit-config", "completion", "fish")
+    (fish_completion/"git-mit-config.fish").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit-relates-to", "completion", "fish")
+    (fish_completion/"git-mit-relates-to.fish").write output
+    output = Utils.safe_popen_read("#{bin}/git-mit-install", "completion", "fish")
+    (fish_completion/"git-mit-install.fish").write output
 
     Pathname.glob("**/*.man.md").each do |file|
       base = file.basename(".man.md")


### PR DESCRIPTION
## Changelog
### [v5.10.0](https://github.com/PurpleBooth/git-mit/compare/v5.9.11...v5.10.0) (2021-10-09)

### Build

- Use the new completions in installs ([`f5c4a47`](https://github.com/PurpleBooth/git-mit/commit/f5c4a474b15a80f997f65383331cf46a7a180616))
- Update patterns versio is using ([`dca8a31`](https://github.com/PurpleBooth/git-mit/commit/dca8a3161277dab195928623aca315cfe43a3f52))
- Versio update versions ([`f99ef6f`](https://github.com/PurpleBooth/git-mit/commit/f99ef6f6b68f9f34d909308b03c3b371186203c8))

### Ci

- Setup a windows config directory in the tests ([`47b338d`](https://github.com/PurpleBooth/git-mit/commit/47b338daa636deac499d13a2c3a704ec707e2372))

### Feat

- Move completion generation from build.rs to cli option ([`ce26795`](https://github.com/PurpleBooth/git-mit/commit/ce2679538a2fc55f7821e931b8fca225ab8238aa))

### Fix

- Allow args/opts without subcommand ([`2725c7b`](https://github.com/PurpleBooth/git-mit/commit/2725c7badb5d6f3f9c70e7c1c5a86c18f9f4253c))
- Add some tests for the new completion functionality ([`f557873`](https://github.com/PurpleBooth/git-mit/commit/f5578737e29dbcae69f58cb8339bf37ee5a65504))
- In case of panic, use miette ([`a8cc19b`](https://github.com/PurpleBooth/git-mit/commit/a8cc19b88dc9f5be9fc535d2a4b7a18477eedfe9))
- Prune old versions ([`886a0e7`](https://github.com/PurpleBooth/git-mit/commit/886a0e73acea9005ead69d3f115f40b7dc09a83b))
- Switch to clipboard libary that is maintained ([`6c41557`](https://github.com/PurpleBooth/git-mit/commit/6c4155705fecae1e2ecb4f7e9ba36b6554ae4764))
- Make the error messages on unconfigured git-mit a bit nicer ([`9252d94`](https://github.com/PurpleBooth/git-mit/commit/9252d94da7c49a4d69b9f8bb5e5b5454579f3051))
- Remove completion uploading step ([`d106712`](https://github.com/PurpleBooth/git-mit/commit/d1067125962a65983215b7e53fcc04e0fc952a53))

### Refactor

- Remove -c from --completion(conflict with --config in git-mit) ([`4393e36`](https://github.com/PurpleBooth/git-mit/commit/4393e368dc3b06d9a5a15fd904475aa3e7550d83))

