### PR TITLE
fix: Update ellipsis to v0.6.18

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.17.tar.gz"
-  sha256 "30853bb2c5438e816e0021bd7db439b3879de30eeb1508b39fb2d600ca034033"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.17"
-    sha256 cellar: :any_skip_relocation, catalina:     "1bd2a07b62bd042c9cfb2589041f5b052b6eff2d928a01fb49180602689acb3c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4219184dcfec0245f48b992c2dbeaa49ce6561088f9a82dae86404282d320a98"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.18.tar.gz"
+  sha256 "196d553ef00090a40885e1c7818b6a5601ccad9bfc8eaad94e1ffa2814a1ea96"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
# Changelog
All notable changes to this project will be documented in this file.

## [0.6.18] - 2021-10-11

### Bug Fixes

- Bump thiserror from 1.0.29 to 1.0.30

### Refactor

- Follow clippy advice
- Correct test runner path

### Build

- Versio update versions

### Ci

- Bump ncipollo/release-action from 1.8.8 to 1.8.9
- Bump ncipollo/release-action from 1.8.9 to 1.8.10
- Use centalised ci

<!-- generated by git-cliff -->
