### PR TITLE
fix: Update git-mit to v5.10.3

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.10.2.tar.gz"
-  sha256 "79a2f4a14ef626aa439d6c3b249eac311ce8374ce12ba58c9747c117fbc0d5a9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.10.2"
-    sha256 cellar: :any,                 catalina:     "719c2da3d63953bb972337aed0c3d2aeb64b8b507e0fbc20778c3c019cdf9180"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "26fb3015e5f9cdb1932ca9b09d80cd36ebe4d8ce7d1d45deeff5a872036d24b7"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.10.3.tar.gz"
+  sha256 "529c88f979a6a9301179615f03c00be889218a50ef1110976a61fdd57c3872c3"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.10.3](https://github.com/PurpleBooth/git-mit/compare/v5.10.2...v5.10.3) (2021-10-12)

### Build

- Versio update versions ([`c3e35bd`](https://github.com/PurpleBooth/git-mit/commit/c3e35bdd4a5f8ffe538ff1330af2835e52194ed8))

### Ci

- Remove duplicated miette ([`de540b4`](https://github.com/PurpleBooth/git-mit/commit/de540b41baa5b45d98c75f31afe5396b86628679))

### Docs

- Update issue templates ([`1b97f0a`](https://github.com/PurpleBooth/git-mit/commit/1b97f0a951920dfe43920e15be5d92c55f189d4e))

### Fix

- Bump debian from 11.0 to 11.1 ([`3a22f90`](https://github.com/PurpleBooth/git-mit/commit/3a22f90c364a4039da2ea7b3564efe47a2ee7221))

### Refactor

- Install miette using a library ([`e0635c0`](https://github.com/PurpleBooth/git-mit/commit/e0635c09e88f8a3643f2c4a6a0302fc3cab0bc91))
- Tidy imports ([`b5f5ceb`](https://github.com/PurpleBooth/git-mit/commit/b5f5cebd626b81b973e4d85c78c969e2209bd41a))
- Move completion into a typed method ([`f1ee1ef`](https://github.com/PurpleBooth/git-mit/commit/f1ee1ef353f1edffae16b41aa851750e661bbc39))
- Use the little completion thing ([`822c69e`](https://github.com/PurpleBooth/git-mit/commit/822c69e28a72337ec80e7cc21f2043d1787dddf8))
- Follow clippy advice ([`aeddc3a`](https://github.com/PurpleBooth/git-mit/commit/aeddc3a0974598d81aeafa1cccc8160369f66fa0))

