### PR TITLE
fix: Update git-mit to v5.10.4

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.10.3.tar.gz"
-  sha256 "529c88f979a6a9301179615f03c00be889218a50ef1110976a61fdd57c3872c3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.10.3"
-    sha256 cellar: :any,                 catalina:     "49319a24f3bc54223ce3307f991e199637684c6e8a8ee9673dfbc6cd53899964"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4d553bf89352b6b8116e9b23a68f213d6f400bed11b6b5b8a88755e9d96151cd"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.10.4.tar.gz"
+  sha256 "16eede6366d08c2fb52af71a0761b178951a20f26f06ad6159c9c7fd94c29cbb"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.10.4](https://github.com/PurpleBooth/git-mit/compare/v5.10.3...v5.10.4) (2021-10-13)

### Build

- Versio update versions ([`5beb61d`](https://github.com/PurpleBooth/git-mit/commit/5beb61d0c0fdf5cac454fde7f49d7afddd5ec06d))

### Fix

- Bump mit-commit from 1.30.0 to 1.30.2 ([`54e6129`](https://github.com/PurpleBooth/git-mit/commit/54e612971bf96abcb701913dc9a228dd53872a35))

