### PR TITLE
fix: Update git-mit to v5.10.6

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.10.5.tar.gz"
-  sha256 "0c810cd98559649c24abc79d250b4e97b4f592d65d05d45992214f93c7e6b445"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.10.5"
-    sha256 cellar: :any,                 catalina:     "d2dcccb68934b077d7db170114c6dd252291cc7911f5cfc11391f8e47fb68fcf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "905509276555433b03b286b5fa9a865eba4ebd604829f8e48800a6421934b52f"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.10.6.tar.gz"
+  sha256 "88e43c6cc701dc2a15de57bc3228573ea61d479901da2f3bb6a7c204f39b00ec"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.10.6](https://github.com/PurpleBooth/git-mit/compare/v5.10.5...v5.10.6) (2021-10-15)

### Build

- Versio update versions ([`efbee2b`](https://github.com/PurpleBooth/git-mit/commit/efbee2b1679c6e52f0ccef7acc882ddcfe281c31))

### Fix

- Bump mit-commit from 1.30.2 to 1.31.0 ([`2031fef`](https://github.com/PurpleBooth/git-mit/commit/2031fefde3bec3bf3ae251af00bdb8c59aacde5c))

