### PR TITLE
fix: Update git-mit to v5.10.8

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.10.7.tar.gz"
-  sha256 "336090967c1931eb9786cff8230d9c937d844def7054fd3409499611479cfb2b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.10.7"
-    sha256 cellar: :any,                 catalina:     "405dbc444d06ffd67eda07a60d1ccb8920bd628bbfad878122d2420da3e1dd69"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2684bd971cc7f880ed805828262ee58f3e5bccb52fe4a73700f811772ec57f94"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.10.8.tar.gz"
+  sha256 "7cdf10c7a5d186a183b511fd2c329616d68e1bf57a4d056e9ea0f75206204a60"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.10.8](https://github.com/PurpleBooth/git-mit/compare/v5.10.7...v5.10.8) (2021-10-16)

### Build

- Versio update versions ([`9337f14`](https://github.com/PurpleBooth/git-mit/commit/9337f1495e7e62f8b903767bfafd96b220ac2996))

### Ci

- Bump actions/checkout from 2.3.4 to 2.3.5 ([`f40ce6a`](https://github.com/PurpleBooth/git-mit/commit/f40ce6ad935962329ba25d7c84439f65567de265))

### Fix

- Bump mit-lint from 2.2.3 to 2.2.4 ([`1778e99`](https://github.com/PurpleBooth/git-mit/commit/1778e998897fc91893218e384ca5fad2059d2540))

