### PR TITLE
fix: Update git-mit to v5.11.0

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.10.8.tar.gz"
-  sha256 "7cdf10c7a5d186a183b511fd2c329616d68e1bf57a4d056e9ea0f75206204a60"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.10.8"
-    sha256 cellar: :any,                 catalina:     "9e73fb2d15ae4e6542afa437db0d2da52fcedcf999a7ce466100800a2efbf583"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "61b43ec318d175e88722697853ef9421fed88e5bbeac9c17f1836a71e3b09d07"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.0.tar.gz"
+  sha256 "8d2704ce7a8093e3d5eb9fb6e506e81cd0303210963a1821b1cf4cb5c9d6e056"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.11.0](https://github.com/PurpleBooth/git-mit/compare/v5.10.8...v5.11.0) (2021-10-16)

### Build

- Versio update versions ([`1ed52de`](https://github.com/PurpleBooth/git-mit/commit/1ed52de25132dece05330fb148ec0844d100b911))

### Ci

- Enable speculative checks ([`df593f2`](https://github.com/PurpleBooth/git-mit/commit/df593f2cdb98a9a85d1fe8e42289e6869edce234))
- Switch to changelog action ([`990064c`](https://github.com/PurpleBooth/git-mit/commit/990064cec36effa34b428c72921f2bcc530b6acc))
- Bump PurpleBooth/changelog-action from 0.1.0 to 0.1.1 ([`30904c4`](https://github.com/PurpleBooth/git-mit/commit/30904c4876b8fc803ff8d5bc45b89f9f34bfafd4))
- Simplify mergify config ([`209a86e`](https://github.com/PurpleBooth/git-mit/commit/209a86ed2038f243144f72e302db809589fe2c02))
- Cancel older runs ([`53cfac4`](https://github.com/PurpleBooth/git-mit/commit/53cfac4a1263010d36af3c15b20c2a80e5660ab9))
- Include the runner os in group ([`64f63cd`](https://github.com/PurpleBooth/git-mit/commit/64f63cd2fec3a44c79eb4f6a4a123a532a1c956e))
- Remove concurrency ([`cd643b4`](https://github.com/PurpleBooth/git-mit/commit/cd643b462bc7e2acb26c1fb66bc2ab8446fe1de2))

### Fix

- Bump mit-commit from 1.33.1 to 1.33.2 ([`968248c`](https://github.com/PurpleBooth/git-mit/commit/968248c598aac2fff50980e31025ab43e44b005a))

### Revert

- Include the runner os in group ([`39fe5f0`](https://github.com/PurpleBooth/git-mit/commit/39fe5f02026aee8c7e4e90706fe4718b8bd61725))

