### PR TITLE
fix: Update git-mit to v5.11.1

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.0.tar.gz"
-  sha256 "8d2704ce7a8093e3d5eb9fb6e506e81cd0303210963a1821b1cf4cb5c9d6e056"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.11.0"
-    sha256 cellar: :any,                 catalina:     "2eb85417426ecf87d045373d049157b9b0972bfdd89ff63196055497a3a71ead"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f5fd7e0be9babb7099ee20ffa5f73e352dfe4b7637d0c9f0ac2d6ebdbfeb964d"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.1.tar.gz"
+  sha256 "6ecd6e5450489cf8995b606f9c3cf8088a5afdd45c4e3f375e5bf15e91a409a8"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.11.1](https://github.com/PurpleBooth/git-mit/compare/v5.11.0...v5.11.1) (2021-10-16)

### Build

- Versio update versions ([`5a6df07`](https://github.com/PurpleBooth/git-mit/commit/5a6df07e3dc8680b7e865bf82c9874795cede1ad))

### Ci

- Use centralised docker build ([`2092887`](https://github.com/PurpleBooth/git-mit/commit/2092887c1f2a6795b8180d5f5ba40446f51c9262))
- Centralise the commit check ([`363e67b`](https://github.com/PurpleBooth/git-mit/commit/363e67bdc8d58f099afcc22ee2475de55422cbe4))
- Switch to centralised markdown ([`8de41d3`](https://github.com/PurpleBooth/git-mit/commit/8de41d37afb2fea5625f5d7587644e8c4a9e858b))
- Use centralised rust check ([`7e198c3`](https://github.com/PurpleBooth/git-mit/commit/7e198c33727460fe9b388eb8cb79498d8cdfcfe1))

### Fix

- Use shared specdown repo ([`9fc0fe3`](https://github.com/PurpleBooth/git-mit/commit/9fc0fe378df79a4bff46c533bae08eeebadd9aa9))

