### PR TITLE
fix: Update git-mit to v5.11.2

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.1.tar.gz"
-  sha256 "6ecd6e5450489cf8995b606f9c3cf8088a5afdd45c4e3f375e5bf15e91a409a8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.11.1"
-    sha256 cellar: :any,                 catalina:     "46afc18d1309ccadb27a3bde5bfdc119bb21239c47be7588ab9c6046bd7923f6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "be2e2746e336252b51af6a77c38b30fb9cbc3a6011e5983e199d745b47d78b9b"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.2.tar.gz"
+  sha256 "febaad046bf28384d1f84dd39849743264916573245c0954be3f24a1711dceac"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.11.2](https://github.com/PurpleBooth/git-mit/compare/v5.11.1...v5.11.2) (2021-10-16)

### Build

- Versio update versions ([`38c726a`](https://github.com/PurpleBooth/git-mit/commit/38c726a81e5130d0f925cd066f870cc87b1fefb7))

### Ci

- Add dependabot as author ([`a731431`](https://github.com/PurpleBooth/git-mit/commit/a731431500b01933a0ac00f050e65d9b8dda4816))
- Version the pipelines used ([`4cedce1`](https://github.com/PurpleBooth/git-mit/commit/4cedce179c7f78d3d62b28950fdd6ee016a52eca))

### Fix

- Use centralised release action ([`a6e02a6`](https://github.com/PurpleBooth/git-mit/commit/a6e02a627cb7352102a53cfe9461258042e17f58))

