### PR TITLE
fix: Update git-mit to v5.11.3

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.2.tar.gz"
-  sha256 "febaad046bf28384d1f84dd39849743264916573245c0954be3f24a1711dceac"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.11.2"
-    sha256 cellar: :any,                 catalina:     "ee164f840b39dbb46ac0fce947a9efeb1b5170e0af0da552a7ae04b93bed435c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ef7981f2a4a286ecbd99ed6f71523a73a813a8d587d01464e34109e281669460"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.3.tar.gz"
+  sha256 "676e16e5d54f30d30630230c16399aa677c9ca922a4213484d13fb4edb3c7c22"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.11.3](https://github.com/PurpleBooth/git-mit/compare/v5.11.2...v5.11.3) (2021-10-17)

### Build

- Versio update versions ([`0a7c06c`](https://github.com/PurpleBooth/git-mit/commit/0a7c06ce45f0a77127d9e138b94ac104131c480e))

### Ci

- Use standard docker build ([`82d70b0`](https://github.com/PurpleBooth/git-mit/commit/82d70b04089065758931a57b97293ca135d2cb74))
- Correct docker action ([`7795964`](https://github.com/PurpleBooth/git-mit/commit/7795964f1c123a5ade9793dd4ca6ca0eb273efd3))
- Set the docker push version ([`a88cfb4`](https://github.com/PurpleBooth/git-mit/commit/a88cfb4354114ca7398ac3e35013bd09b0700fa6))
- Add the generate formula to the central repo ([`0b2c85d`](https://github.com/PurpleBooth/git-mit/commit/0b2c85d9a658585ccb1befa1a399a8866ee89a94))

### Fix

- Remove docker image scanning ([`fdb9f43`](https://github.com/PurpleBooth/git-mit/commit/fdb9f43b0f4c84d733d3326d16f4ab525e22337c))
- Update dockerfile to upgrade and use completions ([`c6cfb8a`](https://github.com/PurpleBooth/git-mit/commit/c6cfb8aafb771427bbf6a4acef743a36f933b6ae))
- Bump pinned versions ([`425d22c`](https://github.com/PurpleBooth/git-mit/commit/425d22c271f58237a5aa9a0b5c895af3ef9ceecc))
- Remove dependency on vulnerabile chrono library ([`443b5b8`](https://github.com/PurpleBooth/git-mit/commit/443b5b8da223f07cf5996e2064fc66d61e34f229))

