### PR TITLE
fix: Update whatismyip to v0.9.16

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.15.tar.gz"
-  sha256 "38c260191977b7755486f18628ea43602341f7d96739f8e07e9eacf3a68a70bc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.15"
-    sha256 cellar: :any_skip_relocation, catalina:     "76ba320605bb7786106699e630180186153cd71455d4d7b9fe9249ab89f83f06"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "79b73f81893899102aeeb8754e1c4688c4c48cecc497cc04ccf6b83fa3182788"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.16.tar.gz"
+  sha256 "c41e500c5525a3313e4699a8dc5eb9a9f62b053624cffb38940edc0d79a7d930"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.16](https://github.com/PurpleBooth/whatismyip/compare/v0.9.15...v0.9.16) (2021-10-19)

### Build

- Versio update versions ([`5808fd9`](https://github.com/PurpleBooth/whatismyip/commit/5808fd9aa1ef8c4fb7f6df267956251c54b4d529))

### Ci

- Enable workflow dispatch ([`be831ed`](https://github.com/PurpleBooth/whatismyip/commit/be831edbf23a579eca6e180c368a5577d8a3c434))
- Bump ncipollo/release-action from 1.8.9 to 1.8.10 ([`3e80236`](https://github.com/PurpleBooth/whatismyip/commit/3e802366129517458c15e041445797be9c03e949))
- Switch to centraliesd workflow ([`6aea802`](https://github.com/PurpleBooth/whatismyip/commit/6aea8029e64a841bda6f9791bc786d863173eb4c))
- Correct the mergify ([`38a8af8`](https://github.com/PurpleBooth/whatismyip/commit/38a8af81961f48599e1f451810557e74bbd104f3))
- Bump actions/checkout from 2.3.4 to 2.3.5 ([`4975a3f`](https://github.com/PurpleBooth/whatismyip/commit/4975a3fea457cb00d080d3b1f94add84b20fa68c))
- Enable speculative checks ([`3589528`](https://github.com/PurpleBooth/whatismyip/commit/3589528b54bfcef27eaa767e1e1e77f09c5fad94))
- Pass previous version for changelog ([`4db13bb`](https://github.com/PurpleBooth/whatismyip/commit/4db13bb71b2a37563b6cae0a4a935e88a65b71f8))
- Release using common pipeline ([`06377ed`](https://github.com/PurpleBooth/whatismyip/commit/06377ed9a2cb03843e0571af9896bb8dd83a2e8f))

### Fix

- Update clap ([`c811b53`](https://github.com/PurpleBooth/whatismyip/commit/c811b537c129849846a51021295d2ff391c33477))

### Refactor

- Set the lints to run on nightly ([`26e9e3f`](https://github.com/PurpleBooth/whatismyip/commit/26e9e3f6c972c03c6ee6bf020fa99d7d0ff2a78c))
- Follow clippy advice ([`8a25e7d`](https://github.com/PurpleBooth/whatismyip/commit/8a25e7dbfd82f478f1969230cbe8b7a9b39dc37d))

