### PR TITLE
fix: Update git-mit to v5.11.4

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.3.tar.gz"
-  sha256 "676e16e5d54f30d30630230c16399aa677c9ca922a4213484d13fb4edb3c7c22"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.11.3"
-    sha256 cellar: :any,                 catalina:     "f0b2d44f0c746772fa2f1baf5a9c60a07ca9e9d29b9c2cec47599c69a5062ca8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "85dfc2f60dfa7ae9357a63f28a6a81c741820c74147bd147d0a6eaabdc6332a9"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.4.tar.gz"
+  sha256 "d426862623426475cc41df5890735ad2633921e57f70a02f6cd613dfa28b6a62"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.11.4](https://github.com/PurpleBooth/git-mit/compare/v5.11.3...v5.11.4) (2021-10-19)

### Build

- Versio update versions ([`1f253ba`](https://github.com/PurpleBooth/git-mit/commit/1f253ba5459b9a8e9150739e9ce93f5f56929582))

### Ci

- Authenticate before pushing ([`824ef43`](https://github.com/PurpleBooth/git-mit/commit/824ef43f4844b1713eb6a45568dbb89be62f0e1d))

### Fix

- Upgrade clap ([`d8a88eb`](https://github.com/PurpleBooth/git-mit/commit/d8a88eb50236dc439ab491613104a5b2f8ae7d09))

