### PR TITLE
fix: Update ellipsis to v0.6.19

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.18.tar.gz"
-  sha256 "196d553ef00090a40885e1c7818b6a5601ccad9bfc8eaad94e1ffa2814a1ea96"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.18"
-    sha256 cellar: :any_skip_relocation, catalina:     "7b6a28539fb0b04a321a37269393552b27cfc02165069a50dbc9ae969ee8107f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6c11d1f1b2df0ea6f358e8f143a8d0fbc392bd03802531a36efd0bece0401643"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.19.tar.gz"
+  sha256 "7e631df0c207e61ef760f873ba00eb8e1fa4993803277a9de8fd73fe0e1696bc"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.19](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.19) (2021-10-19)

### Build

- Versio update versions ([`bc3620e`](https://github.com/PurpleBooth/ellipsis/commit/bc3620e8d27474c57d9203ebc567c669e24efdfe))

### Ci

- Bump actions/checkout from 2.3.4 to 2.3.5 ([`789508d`](https://github.com/PurpleBooth/ellipsis/commit/789508da48d1743fb993e23e1f5d4d0584f70131))
- Enable speculative checks ([`6150f1f`](https://github.com/PurpleBooth/ellipsis/commit/6150f1f56799f1097bd1a5abd653e322436d7ea7))
- Pass previous version for changelog ([`7c731d3`](https://github.com/PurpleBooth/ellipsis/commit/7c731d39d0e5af788409e579005c283b08dec50b))
- Use specific versions ([`1117034`](https://github.com/PurpleBooth/ellipsis/commit/1117034c9b7f804624f88b39ea1343554529b116))
- Use centralised release ([`58ceec7`](https://github.com/PurpleBooth/ellipsis/commit/58ceec7429abb9457d207f91f3244231227c9e6a))

### Fix

- Bump clap from 3.0.0-beta.4 to 3.0.0-beta.5 ([`694c9c8`](https://github.com/PurpleBooth/ellipsis/commit/694c9c852f4eef3e05dd573ba8bb20e371a79dcd))
- Match new format ([`8020445`](https://github.com/PurpleBooth/ellipsis/commit/8020445d86f32631d6aefb8392ac32c1c8adad6b))

