### PR TITLE
fix: Update git-mit to v5.11.5

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.4.tar.gz"
-  sha256 "d426862623426475cc41df5890735ad2633921e57f70a02f6cd613dfa28b6a62"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.11.4"
-    sha256 cellar: :any,                 catalina:     "dba018d2cb0aa386609536b2116b0f179e7de3ca7f7e67545d04b72425bc4382"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "79b070d42cf3f3e8b3c847b44c3d819668bcdbc925bf05f8dd12570ba185c186"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.5.tar.gz"
+  sha256 "88acb28087c8547af78d1f8f3a54cfcb1f977722822988bdc02cbe911acd81fd"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.11.5](https://github.com/PurpleBooth/git-mit/compare/v5.11.4...v5.11.5) (2021-10-22)

### Build

- Versio update versions ([`9b74896`](https://github.com/PurpleBooth/git-mit/commit/9b74896ae9748de6fee473aa34d2dfb565e953d2))

### Fix

- Bump rust from 1.55.0 to 1.56.0 ([`743b79d`](https://github.com/PurpleBooth/git-mit/commit/743b79dbbc665707cc7367b2fc4e7d66af11436c))

