### PR TITLE
fix: Update git-moves-together to v2.5.1

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.4.3.tar.gz"
-  sha256 "80fd02b775db047acbb98024ff91e5368f5d3e7d1d597a49fbdab4f4dd956d04"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.4.3"
-    sha256 cellar: :any,                 catalina:     "b8e2d2ef49b4dcf2eef815e02c565eb74a74e17f4fc70886e2d0d3e615f87276"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "21442d9ef36f7f686d2e63e78bb49c1907a068aba5efb9a835056f8fec32115a"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.1.tar.gz"
+  sha256 "78206ef2876a8def6f782e5dc34f27fe08b52b5e77d3ceda67d2cba8e79ed075"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.1](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.1) (2021-10-24)

### Build

- Versio update versions ([`c06fae7`](https://github.com/PurpleBooth/git-moves-together/commit/c06fae79d0a9159b580445471e53b481981a6f6a))

### Ci

- Enable speculative checks ([`318fe03`](https://github.com/PurpleBooth/git-moves-together/commit/318fe03300bd8d1d395b4db37931b25180eeb13b))
- Pass previous version for changelog ([`5e7e1ec`](https://github.com/PurpleBooth/git-moves-together/commit/5e7e1ecb1e2a3710ba0ab8652aefbe33992dd61d))
- Use specific version of pipelines ([`729edf4`](https://github.com/PurpleBooth/git-moves-together/commit/729edf41005f574a98f5d94a521efa4334ed3974))
- Correct ref ([`3d7ea82`](https://github.com/PurpleBooth/git-moves-together/commit/3d7ea8296ad5c00c86f30b1ded5cf663e74f7291))
- Use the centralised release action ([`5683097`](https://github.com/PurpleBooth/git-moves-together/commit/5683097bcd291c5e47adf94749ac52299efc3761))
- Bump PurpleBooth/versio-release-action from 0.1.2 to 0.1.4 ([`b9659ad`](https://github.com/PurpleBooth/git-moves-together/commit/b9659adbeedcbf7582f875f2f806b43e69376016))

### Docs

- Add a code of conduct ([`be66332`](https://github.com/PurpleBooth/git-moves-together/commit/be66332de7fc8658c5b76a2ea54568662236af31))
- Update issue templates ([`2206266`](https://github.com/PurpleBooth/git-moves-together/commit/22062661b73cddbe3b68cc6e9c0057ded3dc635e))
- Correct formatting ([`ca6ad99`](https://github.com/PurpleBooth/git-moves-together/commit/ca6ad99af911875a88124f2503cededd4333a773))

### Fix

- Bump clap from 3.0.0-beta.4 to 3.0.0-beta.5 ([`7bdd0d2`](https://github.com/PurpleBooth/git-moves-together/commit/7bdd0d209935149d1d50b18d033f71232f9bc3a6))
- Remove chrono ([`b874fd7`](https://github.com/PurpleBooth/git-moves-together/commit/b874fd78f24eb3865ce396d2d2cafc87fc3b711c))

