### PR TITLE
fix: Update git-mit to v5.11.6

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.5.tar.gz"
-  sha256 "88acb28087c8547af78d1f8f3a54cfcb1f977722822988bdc02cbe911acd81fd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.11.5"
-    sha256 cellar: :any,                 catalina:     "c5c7841525ef041ecf47565b6fa3236cdb2c160699786106aaf2d4fdb0faac63"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "100498830bdb5d38e00c8fa8380dadf5ac7373ca9185e2d38f8b70a1c2438431"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.6.tar.gz"
+  sha256 "8f492c513ab64c02b64c67baba94017360c5bee2ed576015f30962259aa763e1"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.11.6](https://github.com/PurpleBooth/git-mit/compare/v5.11.5...v5.11.6) (2021-10-26)

### Build

- Versio update versions ([`40f62a6`](https://github.com/PurpleBooth/git-mit/commit/40f62a6cb4a07f73106aa04470020d1664e90cf0))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.2 to 0.1.4 ([`eecbdcf`](https://github.com/PurpleBooth/git-mit/commit/eecbdcf5df74f36515e3dbf627ec26fc193b6ace))
- Bump nick-invision/retry from 2.5.0 to 2.5.1 ([`969d113`](https://github.com/PurpleBooth/git-mit/commit/969d113d12de60d32b433c790c79704041c58945))
- Update mergify config ([`5eabf2e`](https://github.com/PurpleBooth/git-mit/commit/5eabf2e83dfdfdc11086c6b7948feea40bb6aba2))

### Fix

- Bump time from 0.3.3 to 0.3.4 ([`0cccd46`](https://github.com/PurpleBooth/git-mit/commit/0cccd46040b9e019aa65df247b2f156ce9fcd812))

