### PR TITLE
fix: Update whatismyip to v0.9.17

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.16.tar.gz"
-  sha256 "c41e500c5525a3313e4699a8dc5eb9a9f62b053624cffb38940edc0d79a7d930"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.16"
-    sha256 cellar: :any_skip_relocation, catalina:     "e23a0e894f42bbb5564a371c95a29c7e922bf9649e3309f45a3a5597a2747d08"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "96204707595305311a0e8b5b7c53c9ddb7232f5dcb6a6a53c4c3146a9a3f5e06"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.17.tar.gz"
+  sha256 "a61783b9dc4fc4da8e47c1b62485a448457efca2167b3691424f824ba4799c57"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.17](https://github.com/PurpleBooth/whatismyip/compare/v0.9.16...v0.9.17) (2021-10-29)

### Build

- Versio update versions ([`f15383e`](https://github.com/PurpleBooth/whatismyip/commit/f15383ee73dc259c02816d66831c2aaa34d3dcf6))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.2 to 0.1.4 ([`28eb734`](https://github.com/PurpleBooth/whatismyip/commit/28eb7347e846f29ac378999750b5769744a3ce0e))
- Mergify ([`9414b8f`](https://github.com/PurpleBooth/whatismyip/commit/9414b8f7d47fb042821ecedeeb182e9f6de00af6))

### Fix

- Bump tokio from 1.12.0 to 1.13.0 ([`8856526`](https://github.com/PurpleBooth/whatismyip/commit/8856526f2e70de1b98d6773e6dce4240ecc0f5b2))

