### PR TITLE
fix: Update git-moves-together to v2.5.2

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.1.tar.gz"
-  sha256 "78206ef2876a8def6f782e5dc34f27fe08b52b5e77d3ceda67d2cba8e79ed075"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.1"
-    sha256 cellar: :any,                 catalina:     "ebee8fea719c377e06681516cb7c58674d44a6d7e636c0034a7e7900dbdb7a34"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8acf351d9035b578b7d8f18213eafee049f8b40517556c133436166b374776da"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.2.tar.gz"
+  sha256 "85e7bd04a66089c97978ad3fd71848c6efb91d1062b0b9387d64721408c48ba6"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.2](https://github.com/PurpleBooth/git-moves-together/compare/v2.5.1...v2.5.2) (2021-10-30)

### Build

- Versio update versions ([`233065d`](https://github.com/PurpleBooth/git-moves-together/commit/233065d94410e446ed9fc8fda4ccd36af5778b49))

### Ci

- Configuration update ([`167ae06`](https://github.com/PurpleBooth/git-moves-together/commit/167ae06bae08599edca826baa47cd97d883087c5))
- Formatting ([`1200ea5`](https://github.com/PurpleBooth/git-moves-together/commit/1200ea56f9f9e3fcb894a96c5f85704782a5c0cf))
- Switch to latest version of pipeline ([`34c4dc6`](https://github.com/PurpleBooth/git-moves-together/commit/34c4dc67a894af2c93b674f11ee92c22c7d1b093))

### Fix

- Bump time from 0.3.3 to 0.3.4 ([`4c99ed6`](https://github.com/PurpleBooth/git-moves-together/commit/4c99ed6948e401f1a593c04d8f0002c39093edb6))

### Refactor

- Add some warnings ([`baa8545`](https://github.com/PurpleBooth/git-moves-together/commit/baa85459bc3649a12858941d05c1ff76f6440714))

### Test

- Use a modern version of specdown ([`da91385`](https://github.com/PurpleBooth/git-moves-together/commit/da91385d68d0c769b8f2cac5e0acab65d9fda7d1))

