### PR TITLE
fix: Update git-moves-together to v2.5.3

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.2.tar.gz"
-  sha256 "85e7bd04a66089c97978ad3fd71848c6efb91d1062b0b9387d64721408c48ba6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.2"
-    sha256 cellar: :any,                 catalina:     "10cd4421a256ee05d0504cc4981d5bac1d9fe203cfd6a53aafaf932eb41d15ce"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ba1750a678897fe677c45055d1f3a7a86fcb60409b17d56129b8ae17d026ad40"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.3.tar.gz"
+  sha256 "255d3fd04a94c35e33127e5436ae7337c1bbf6ca476c54c5003f0ab04dd67adf"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.3](https://github.com/PurpleBooth/git-moves-together/compare/v2.5.2...v2.5.3) (2021-11-01)

### Build

- Versio update versions ([`5ffc835`](https://github.com/PurpleBooth/git-moves-together/commit/5ffc83554250240c033b695961c0ac040eb23534))

### Fix

- Bump tokio from 1.12.0 to 1.13.0 ([`f6f5726`](https://github.com/PurpleBooth/git-moves-together/commit/f6f57264a53f1f64da5761e3382258b4e79a9e8a))

