### PR TITLE
fix: Update git-mit to v5.11.8

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.7.tar.gz"
-  sha256 "e0d2e7ccbefc56ea7b234872e41624b648f5d452615165c3b7746cf489139564"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.11.7"
-    sha256 cellar: :any,                 catalina:     "0ac5b3eac641ea3d1807b5bd8619842f166574d0e48ff3346046899a9e296362"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "807736b4fe9b40fd7673f66e809a3a294e01f11066ebce8631051565353ad88b"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.8.tar.gz"
+  sha256 "6035d684b0866efa10d762402af948693c58b4d27caf7b68ac7d3577272c047d"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.11.8](https://github.com/PurpleBooth/git-mit/compare/v5.11.7...v5.11.8) (2021-11-01)

### Build

- Versio update versions ([`757b4e8`](https://github.com/PurpleBooth/git-mit/commit/757b4e8952cc3364f9a79532457df32423d08c54))

### Fix

- Bump versions ([`9e5d3f8`](https://github.com/PurpleBooth/git-mit/commit/9e5d3f8d5ab6fdc6b685b8e89e4e7d1aef87f3c6))

### Refactor

- Follow advice of built in warnings ([`9058556`](https://github.com/PurpleBooth/git-mit/commit/90585567528ea1d0f82f3496ecb91c43f2d455de))

