### PR TITLE
fix: Update ellipsis to v0.6.20

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.19.tar.gz"
-  sha256 "7e631df0c207e61ef760f873ba00eb8e1fa4993803277a9de8fd73fe0e1696bc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.19"
-    sha256 cellar: :any_skip_relocation, catalina:     "7e94ff16b025832d123640d693941c5665057bb9b3c4f811f2822a8534d91a22"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "50673805393add7407ce6e03bf4fd2c1a31a6442dc7e105bcac0f20a4516db30"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.20.tar.gz"
+  sha256 "4c69147e81d18dd6a26ea0ad30b92ffcdf4bfb10def3332a8fb9a97004068420"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.20](https://github.com/PurpleBooth/ellipsis/compare/v0.6.19...v0.6.20) (2021-11-02)

### Build

- Versio update versions ([`5e6c6b2`](https://github.com/PurpleBooth/ellipsis/commit/5e6c6b2a97e93e22b48327781c8b966a2a4bf353))

### Ci

- Switch to main ([`885baf8`](https://github.com/PurpleBooth/ellipsis/commit/885baf800a544f115f13cfa5c970ac00e1f71c25))
- Bump PurpleBooth/versio-release-action from 0.1.2 to 0.1.4 ([`6645d48`](https://github.com/PurpleBooth/ellipsis/commit/6645d48dcfc6fb6a2e75c15adc9fecfcfb06bb56))
- Mergify ([`5d66cf8`](https://github.com/PurpleBooth/ellipsis/commit/5d66cf81c777e8569f703762cb1ab25f98bc9dd4))

### Fix

- Bump anyhow from 1.0.44 to 1.0.45 ([`b6cfc84`](https://github.com/PurpleBooth/ellipsis/commit/b6cfc84fd48aeb298ead98af91368a651eeb1fa7))

