### PR TITLE
fix: Update git-mit to v5.11.9

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.8.tar.gz"
-  sha256 "6035d684b0866efa10d762402af948693c58b4d27caf7b68ac7d3577272c047d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.11.8"
-    sha256 cellar: :any,                 catalina:     "2d464c70c7083df5b273003d0daca2c0032ea8047383ab9366547501217f211a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "64f038c4ded70d9bdc7249b21d4bf3ec259b2a18f126e321100645fa633ed8ea"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.11.9.tar.gz"
+  sha256 "0d381e9fe5697563b4ef45b61d6b18c01f49701776f07055d21ad465a27c1c63"
   depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.11.9](https://github.com/PurpleBooth/git-mit/compare/v5.11.8...v5.11.9) (2021-11-02)

### Build

- Versio update versions ([`72f2855`](https://github.com/PurpleBooth/git-mit/commit/72f2855a4c3cc18a911811c5878104c653b4cc2a))

### Fix

- Bump rust from 1.56.0 to 1.56.1 ([`0ad1a40`](https://github.com/PurpleBooth/git-mit/commit/0ad1a403e54353716de5aebff0d4bc391c2a812d))

### Refactor

- Remove some copies ([`c0fa9ac`](https://github.com/PurpleBooth/git-mit/commit/c0fa9ac8d89b57cd55a1f651a4a112d604e54869))

