### PR TITLE
fix: Update whatismyip to v0.9.18

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.17.tar.gz"
-  sha256 "a61783b9dc4fc4da8e47c1b62485a448457efca2167b3691424f824ba4799c57"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.17"
-    sha256 cellar: :any_skip_relocation, catalina:     "ed8406aabb300f0ca62aba5972727027cac2c5d055d97846fa555d7b473a07ff"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f7908d0dd346bc3509ebd408f3c704025714550556dfd68a84f9bc7852d97c18"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.18.tar.gz"
+  sha256 "7d9799bfacf0be29219d67b5f8cfbffee769b4f9291e879ed63691716f5ce7d9"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.18](https://github.com/PurpleBooth/whatismyip/compare/v0.9.17...v0.9.18) (2021-11-04)

### Build

- Versio update versions ([`333e121`](https://github.com/PurpleBooth/whatismyip/commit/333e121e11aa8cd3c715dcd4bf6e6caaaba5ff55))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.4 to 0.1.5 ([`4fec7ad`](https://github.com/PurpleBooth/whatismyip/commit/4fec7ad10b34a65cdbacb11fda6ad8f9855310b1))

### Fix

- Bump anyhow from 1.0.44 to 1.0.45 ([`131cca4`](https://github.com/PurpleBooth/whatismyip/commit/131cca4f554d64a6e212ec44b0478a445dc590a5))

### Refactor

- Enable more warnings ([`ab0429f`](https://github.com/PurpleBooth/whatismyip/commit/ab0429fed51312481470099e1396eddcffd28f34))

