### PR TITLE
fix: Update hungry-distance to v0.1.10

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.9.tar.gz"
-  sha256 "1e2a58744768dafebfc100c939076cbee2e20560e133f81fc30e86ae9d05f582"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.9"
-    sha256 cellar: :any_skip_relocation, catalina:     "7b28e4006fdff9cda9b783651cfca39ce70281bba194479e4043ec0a470efa6e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "957f4c63f4a1ace1efe6a0b253714bdae265ddcab54e3593ea8ac3ed0d677beb"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.10.tar.gz"
+  sha256 "175e4ac85281de2b0145a01ddef2ac90b6f66e3e72ac615eb531b9c028c3d1c2"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.10](https://github.com/PurpleBooth/hungry-distance/compare/v0.1.9...v0.1.10) (2021-11-04)

### Build

- Update version on README ([`462a166`](https://github.com/PurpleBooth/hungry-distance/commit/462a1664e958c021b5b7d3dc74666a3e75af512a))
- Correct versio settings ([`246fb5d`](https://github.com/PurpleBooth/hungry-distance/commit/246fb5d2785baedb999ca1a91a8f73129028bb55))
- Versio update versions ([`edf8cf6`](https://github.com/PurpleBooth/hungry-distance/commit/edf8cf6fc3f1a02eaba2e5dd556d7f5b18dd5f4f))

### Ci

- Bump chaaz/versio-actions from 1.1 to 1.2 ([`7d89e9b`](https://github.com/PurpleBooth/hungry-distance/commit/7d89e9b18708ab53abf9abe8250c2285bf0f25b5))
- Bump crazy-max/ghaction-import-gpg from 3.2.0 to 4 ([`040e609`](https://github.com/PurpleBooth/hungry-distance/commit/040e609a4ced3097bca736164ac89d9ec179bdf2))
- Rename inputs to match new version ([`f97425b`](https://github.com/PurpleBooth/hungry-distance/commit/f97425bc6fe76e2f4d66da678c5e7f86869d30ea))
- Bump ncipollo/release-action from 1.8.8 to 1.8.9 ([`97b6ce1`](https://github.com/PurpleBooth/hungry-distance/commit/97b6ce1768bf58d36fe380f3e37463059ccaf336))
- Bump ncipollo/release-action from 1.8.9 to 1.8.10 ([`d60c4a9`](https://github.com/PurpleBooth/hungry-distance/commit/d60c4a9767704ec3f74c2c1a646ec7f83d26e451))
- Use centralised workflows ([`98e194c`](https://github.com/PurpleBooth/hungry-distance/commit/98e194c4fdd5482e4acc66126a95a422ad13bf23))
- Enable speculative checks ([`2279f47`](https://github.com/PurpleBooth/hungry-distance/commit/2279f478740a4a670acde359e09a9184600f04ed))
- Use regex for checks ([`c404ac0`](https://github.com/PurpleBooth/hungry-distance/commit/c404ac07bb2bd0698225679995d76c806cc15a5c))
- Correct patterns ([`c3a56be`](https://github.com/PurpleBooth/hungry-distance/commit/c3a56be855a8739bd12bebcaf2f870ccc80cc216))
- Remove specdown ([`78dd67d`](https://github.com/PurpleBooth/hungry-distance/commit/78dd67d5a77b6024dbfb5221620a5309b2174969))
- Remove duplicated conditions ([`0371576`](https://github.com/PurpleBooth/hungry-distance/commit/0371576b0a6febf515c28b46f8bf692bd3d1f427))
- Bump actions/checkout from 2.3.4 to 2.3.5 ([`cd50cd6`](https://github.com/PurpleBooth/hungry-distance/commit/cd50cd69e0efcdee17b5a27e015481bc6069e9a8))
- Pass previous version for changelog ([`be97729`](https://github.com/PurpleBooth/hungry-distance/commit/be977296ceb082a11d2dfaa80f0a47b3026458de))
- Use common release action ([`2a197ef`](https://github.com/PurpleBooth/hungry-distance/commit/2a197ef8bcd1e9d05645bce4de0d486380d66d88))
- Bump PurpleBooth/versio-release-action from 0.1.2 to 0.1.4 ([`bbba824`](https://github.com/PurpleBooth/hungry-distance/commit/bbba82427cade77f8903616093d79e90e4c1dbe9))
- Prevent early merging of PRs ([`5db7ae5`](https://github.com/PurpleBooth/hungry-distance/commit/5db7ae50d8090ecb627db6e4fb72ff53b6f0078f))
- Bump PurpleBooth/versio-release-action from 0.1.4 to 0.1.5 ([`5c6dde2`](https://github.com/PurpleBooth/hungry-distance/commit/5c6dde267dfd1ab8fa142215acd52be9266d496f))

### Docs

- Update changelog links ([`6857910`](https://github.com/PurpleBooth/hungry-distance/commit/6857910b8f720f0ac008bfdf201519e08e3bf5af))

### Fix

- Bump clap from 3.0.0-beta.4 to 3.0.0-beta.5 ([`d7dd365`](https://github.com/PurpleBooth/hungry-distance/commit/d7dd36574e36a0eb1426d4a4cb3bf624932b292c))

### Refactor

- Add more lints ([`1a47055`](https://github.com/PurpleBooth/hungry-distance/commit/1a470558fa1bed313f9d8e6803f5a551c294c411))

