### PR TITLE
fix: Update git-mit to v5.12.1

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.0.tar.gz"
-  sha256 "6b18203b0c861fc50e87c8cae485bb9beaaad78ed5f78bcc418c84455a3bf98b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.0"
-    sha256 cellar: :any,                 catalina:     "6b91f3e7cc7923294b8dd3a0dc9f154b000b28b6f8d3e82c09a07af568c28101"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9f3064ab5ded82afdfc0b78500feec29ad6f218fb2598988ec9e3e927910a434"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.1.tar.gz"
+  sha256 "a1da43426c2ac3cc1abaee5f67bce94a6537d38065b64a3e7e65c8beb2d28f0a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.1](https://github.com/PurpleBooth/git-mit/compare/v5.12.0...v5.12.1) (2021-11-06)

### Build

- Switch from make to just ([`7012c22`](https://github.com/PurpleBooth/git-mit/commit/7012c2260f7cf3df6df5d20d76c681588e58f509))
- Versio update versions ([`1f59196`](https://github.com/PurpleBooth/git-mit/commit/1f59196002b3bf507e99048f2d90c96fb04398d9))

### Ci

- Switch to main instead of version since dependabot won't upgrade ([`383180f`](https://github.com/PurpleBooth/git-mit/commit/383180fae2db08aba3fb1261e90a8c1326ebf20c))

### Fix

- Bump versions ([`30c3d94`](https://github.com/PurpleBooth/git-mit/commit/30c3d944ef7d024fd476d841589a7671656f3a4d))
- Remove reference to yaml ([`4cb6dde`](https://github.com/PurpleBooth/git-mit/commit/4cb6dde8780826ed77779df6ddb9bafde5f66a29))

### Refactor

- Remove unused make target ([`f08cdf8`](https://github.com/PurpleBooth/git-mit/commit/f08cdf82566033624c941b2031636b14a5884274))
- Move setup to the the commands that need it ([`566e980`](https://github.com/PurpleBooth/git-mit/commit/566e9803d92052cca74af9a2302bec9f0b085c4d))

