### PR TITLE
fix: Update git-moves-together to v2.5.4

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.3.tar.gz"
-  sha256 "255d3fd04a94c35e33127e5436ae7337c1bbf6ca476c54c5003f0ab04dd67adf"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.3"
-    sha256 cellar: :any,                 catalina:     "8a9434bacf704ed0d7514bedfe173401e49fab8a1ffb031aca0a808a6ec83909"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f95aee7ea8f1632be478ecc8d106adc51566e1999f7c5e032cfb50311d69ee2c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.4.tar.gz"
+  sha256 "e2cac344792997665fefb44d846801f8548643f7a611f813b4b1f2854b261ebc"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.4](https://github.com/PurpleBooth/git-moves-together/compare/v2.5.3...v2.5.4) (2021-11-08)

### Build

- Versio update versions ([`f9c14d2`](https://github.com/PurpleBooth/git-moves-together/commit/f9c14d27a92b1e26c1c98b600b55d7a185256906))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.4 to 0.1.5 ([`385853f`](https://github.com/PurpleBooth/git-moves-together/commit/385853ffd1763e0053eb079671153d867051838c))

### Fix

- Bump comfy-table from 4.1.1 to 5.0.0 ([`202ab0c`](https://github.com/PurpleBooth/git-moves-together/commit/202ab0c5803a6cfa407e69b5871a400d6c34d68b))

