### PR TITLE
fix: Update fast-conventional to v0.1.1

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,0 +1,17 @@
+class FastConventional < Formula
+  desc "Fill in conventional commit messages quickly"
+  homepage "https://github.com/PurpleBooth/fast-conventional"
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v0.1.1.tar.gz"
+  sha256 "d629dd3ca18e9d37ddbfd666be955b879c74f91016559fce0b889fa9328dc96d"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+  end
+
+  test do
+    system "#{bin}/fast-conventional", "-h"
+    system "#{bin}/fast-conventional", "-V"
+  end
+end


### PR DESCRIPTION
## Changelog
### [v0.1.1](https://github.com/PurpleBooth/fast-conventional/compare/v0.1.0...v0.1.1) (2021-11-09)

### Build

- Remove bump file ([`bb46fc5`](https://github.com/PurpleBooth/fast-conventional/commit/bb46fc5a1b1869163707c03255e9c09c0ee1d964))
- Versio update versions ([`7c79453`](https://github.com/PurpleBooth/fast-conventional/commit/7c794534833a4b762a49f4807dd4d55a5e6d2f69))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.4 to 0.1.5 ([`4b28476`](https://github.com/PurpleBooth/fast-conventional/commit/4b284765a2c32c4cd417cfb20612a245d4028131))

### Docs

- Make the examples a bit nicer ([`b492eaf`](https://github.com/PurpleBooth/fast-conventional/commit/b492eaf880f56726316e35193468524b955fdd0d))

### Fix

- Bump version ([`9091222`](https://github.com/PurpleBooth/fast-conventional/commit/90912221c6a7538d6a57eb903bb268a51c7db16c))
- Update the version in the readme ([`6aa5433`](https://github.com/PurpleBooth/fast-conventional/commit/6aa543367e1430747c3fe9d2c1ac20d7e277f5f6))

