### PR TITLE
fix: Update fast-conventional to v0.1.2

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,16 +1,11 @@
 class FastConventional < Formula
   desc "Fill in conventional commit messages quickly"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v0.1.1.tar.gz"
-  sha256 "d629dd3ca18e9d37ddbfd666be955b879c74f91016559fce0b889fa9328dc96d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-0.1.1"
-    sha256 cellar: :any_skip_relocation, catalina:     "3ab90d57bc6797211891032e14bdf6d22713484dc067a15526b2aec1c8a17ad6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a598598e1093018bd30f9637428fc061f002a9998014a8d88302ab069c08b43a"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v0.1.2.tar.gz"
+  sha256 "5c70e9656af6e1525e80d73a2f405ebbf8976843d7ed9ced6d812eaf63d18e16"
 
   depends_on "rust" => :build
+  depends_on "specdown/repo/specdown" => :test
 
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
@@ -19,5 +14,6 @@ class FastConventional < Formula
   test do
     system "#{bin}/fast-conventional", "-h"
     system "#{bin}/fast-conventional", "-V"
+    system "specdown run --temporary-workspace-dir --add-path \"#{bin}\" \"#{prefix}\/README.md\""
   end
 end


### PR DESCRIPTION
## Changelog
### [v0.1.2](https://github.com/PurpleBooth/fast-conventional/compare/v0.1.1...v0.1.2) (2021-11-09)

### Build

- Versio update versions ([`57bc758`](https://github.com/PurpleBooth/fast-conventional/commit/57bc758eca3d17fbabf1c0e19f9ff0774635a4dc))

### Fix

- Run tests as part of homebrew install ([`056836d`](https://github.com/PurpleBooth/fast-conventional/commit/056836df8aa400da481509af1fa0c49d7c488c70))

