### PR TITLE
fix: Update fast-conventional to v0.1.3

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,16 +1,12 @@
 class FastConventional < Formula
   desc "Fill in conventional commit messages quickly"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v0.1.1.tar.gz"
-  sha256 "d629dd3ca18e9d37ddbfd666be955b879c74f91016559fce0b889fa9328dc96d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-0.1.1"
-    sha256 cellar: :any_skip_relocation, catalina:     "3ab90d57bc6797211891032e14bdf6d22713484dc067a15526b2aec1c8a17ad6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a598598e1093018bd30f9637428fc061f002a9998014a8d88302ab069c08b43a"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v0.1.3.tar.gz"
+  sha256 "9ac5c1578cd4804d2d0c0c2753685cdfeaa877fcdf4ef98b3c81291d6ef8e449"
 
   depends_on "rust" => :build
+  depends_on "specdown/repo/specdown" => :test
+  depends_on "socat" => :test
 
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
@@ -19,5 +15,6 @@ class FastConventional < Formula
   test do
     system "#{bin}/fast-conventional", "-h"
     system "#{bin}/fast-conventional", "-V"
+    system "specdown run --temporary-workspace-dir --add-path \"#{bin}\" \"#{prefix}\/README.md\""
   end
 end


### PR DESCRIPTION
## Changelog
### [v0.1.3](https://github.com/PurpleBooth/fast-conventional/compare/v0.1.2...v0.1.3) (2021-11-10)

### Build

- Versio update versions ([`15986b2`](https://github.com/PurpleBooth/fast-conventional/commit/15986b2f355dbe91d6c1035a9c6fc16ad8cad897))

### Docs

- Add a nice image of it running ([`650cf55`](https://github.com/PurpleBooth/fast-conventional/commit/650cf553685182c5bddc518738ef98de9016989f))
- Update gif ([`4f71def`](https://github.com/PurpleBooth/fast-conventional/commit/4f71def4a282a14a06a5d8bd109e480797870a88))
- Formatting ([`b37ec29`](https://github.com/PurpleBooth/fast-conventional/commit/b37ec2967a3fd340391bf4a28fb2973df79ea6ed))

### Fix

- Add missing test dependency ([`1bfbebc`](https://github.com/PurpleBooth/fast-conventional/commit/1bfbebc06e233410adab7e61f942e335c6ee3f86))

