### PR TITLE
fix: Update fast-conventional to v0.1.4

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,16 +1,12 @@
 class FastConventional < Formula
   desc "Fill in conventional commit messages quickly"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v0.1.1.tar.gz"
-  sha256 "d629dd3ca18e9d37ddbfd666be955b879c74f91016559fce0b889fa9328dc96d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-0.1.1"
-    sha256 cellar: :any_skip_relocation, catalina:     "3ab90d57bc6797211891032e14bdf6d22713484dc067a15526b2aec1c8a17ad6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a598598e1093018bd30f9637428fc061f002a9998014a8d88302ab069c08b43a"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v0.1.4.tar.gz"
+  sha256 "548ad56cfd5782fb51ee1213eb1f829e92a0e28bc701fd095e7e91e298bd529d"
 
   depends_on "rust" => :build
+  depends_on "socat" => :test
+  depends_on "specdown/repo/specdown" => :test
 
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
@@ -19,5 +15,6 @@ class FastConventional < Formula
   test do
     system "#{bin}/fast-conventional", "-h"
     system "#{bin}/fast-conventional", "-V"
+    system "specdown run --temporary-workspace-dir --add-path \"#{bin}\" \"#{prefix}\/README.md\""
   end
 end


### PR DESCRIPTION
## Changelog
### [v0.1.4](https://github.com/PurpleBooth/fast-conventional/compare/v0.1.3...v0.1.4) (2021-11-10)

### Build

- Versio update versions ([`abca9c9`](https://github.com/PurpleBooth/fast-conventional/commit/abca9c9014e9890f3048a7d15f4821c0132d3cad))

### Fix

- Correct formatting of homebrew formula ([`c6479fe`](https://github.com/PurpleBooth/fast-conventional/commit/c6479fe842de22b3975a731567f8452ec4cefda1))

