### PR TITLE
fix: Update fast-conventional to v1.0.0

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Fill in conventional commit messages quickly"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v0.1.4.tar.gz"
-  sha256 "548ad56cfd5782fb51ee1213eb1f829e92a0e28bc701fd095e7e91e298bd529d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-0.1.4"
-    sha256 cellar: :any_skip_relocation, catalina:     "7379e98b36c1456781ee6713dd478a9d3683b3b64e0342d50ca53971b054592a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5fef407337f7b0b882524c7599601907764826d0148ea4ad2260684e56fb0f3c"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.0.tar.gz"
+  sha256 "a54a3a16b457c7caaa05d7790cadb20f854433d6799b802bb55de04e499978f9"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.0](https://github.com/PurpleBooth/fast-conventional/compare/v0.1.4...v1.0.0) (2021-11-10)

### Build

- Add basic config ([`074f8df`](https://github.com/PurpleBooth/fast-conventional/commit/074f8dfbc1bdfe8770b71239f9b2d9823f237d0d))
- Versio update versions ([`35850e7`](https://github.com/PurpleBooth/fast-conventional/commit/35850e760b071d5351b14cb8706d0f968bc8ce6b))

### Docs

- Improve the instructions for installing ([`3ac92eb`](https://github.com/PurpleBooth/fast-conventional/commit/3ac92eb602abcfe1b7114d6bc4f3e2f9617baafc))

### Fix

- **Breaking Change:** Remove unused parameters ([`28d6c03`](https://github.com/PurpleBooth/fast-conventional/commit/28d6c03b06363db48e3a04a80b777b0bbd9d3a8e))

