### PR TITLE
fix: Update git-moves-together to v2.5.5

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.4.tar.gz"
-  sha256 "e2cac344792997665fefb44d846801f8548643f7a611f813b4b1f2854b261ebc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.4"
-    sha256 cellar: :any,                 catalina:     "845cd39e5b0b395f9957faffaaac0d71be0479d309c4d18372c6ef95e847aac5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b0cdb391c059fc4d009350507fc5eece06a7b29eb031d037295ae01b9f321421"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.5.tar.gz"
+  sha256 "38ae4cda300f5a2d55e7cf3e47e802ee25c19fc9d9df7e06a8f81f8df7efd0f3"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.5](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.5) (2021-11-12)

### Build

- Versio update versions ([`45ae3f4`](https://github.com/PurpleBooth/git-moves-together/commit/45ae3f44f3fa16d91fc080fddb27e5bfca37325d))

### Fix

- Bump time from 0.3.4 to 0.3.5 ([`22a095f`](https://github.com/PurpleBooth/git-moves-together/commit/22a095f2eb6bd0a03612f45de7bc11b2b5b100b6))

