### PR TITLE
fix: Update git-mit to v5.12.4

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.3.tar.gz"
-  sha256 "d5d5e8c7a0d3e8063930508452b346df13df305783a33a90741d282fa5524ee0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.3"
-    sha256 cellar: :any,                 catalina:     "95d23a6e9027b2244fff5fc3d1a9780cf15d82bcc051e5b6448c90987f5ff7e7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c5dda21886269e96b97c05d81478d7d0f0d9e64efabd389c8754b142a5b05fe2"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.4.tar.gz"
+  sha256 "8e1bd55ecf48956eb3df60c989c92352df1ea01a08fc1ffdc05130bf016adf5c"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.4](https://github.com/PurpleBooth/git-mit/compare/...v5.12.4) (2021-11-16)

### Build

- Versio update versions ([`4e018cc`](https://github.com/PurpleBooth/git-mit/commit/4e018cc99c9be8e39c332f980e56e3f9d0b1cff4))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.5 to 0.1.6 ([`91194dd`](https://github.com/PurpleBooth/git-mit/commit/91194dd90dc5637ec9309e60f8cd28513f911350))
- Bump PurpleBooth/generate-formula-action from 0.1.3 to 0.1.4 ([`894fae0`](https://github.com/PurpleBooth/git-mit/commit/894fae05ced50c70cab068be2c666ebcbfe1e6fc))
- Add in scope ([`212bbc7`](https://github.com/PurpleBooth/git-mit/commit/212bbc77514594b355b12b1cee9da844711cf250))

### Fix

- Bump tokio from 1.13.0 to 1.13.1 ([`2e1cc2a`](https://github.com/PurpleBooth/git-mit/commit/2e1cc2af807f69561c6f3567082bae88ef6bebc8))

