### PR TITLE
fix: Update git-moves-together to v2.5.6

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.5.tar.gz"
-  sha256 "38ae4cda300f5a2d55e7cf3e47e802ee25c19fc9d9df7e06a8f81f8df7efd0f3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.5"
-    sha256 cellar: :any,                 catalina:     "da68d83914fc49d18db23aa0e393fe582d310e2dab3f4abdad8af42938993718"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "282d09996185241a9c56f849c9dddaa0f51f0e03b9919349958c3f0f75b4cdb8"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.6.tar.gz"
+  sha256 "0913cae29f2fed2b9abd70b4b4072b96b392e5d0f10f4457962544c11c27e02d"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.6](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.6) (2021-11-16)

### Build

- Versio update versions ([`ca9b325`](https://github.com/PurpleBooth/git-moves-together/commit/ca9b325432889d913fbd082f2aa11edfcc5aa0ee))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.5 to 0.1.6 ([`14dd905`](https://github.com/PurpleBooth/git-moves-together/commit/14dd9053d3b74da16474ab4749884b174c9ef23f))
- Add scope ([`7fb40e2`](https://github.com/PurpleBooth/git-moves-together/commit/7fb40e28bb9c29b655aad18479dd2934fb498721))

### Fix

- Bump tokio from 1.13.0 to 1.13.1 ([`f16e2a1`](https://github.com/PurpleBooth/git-moves-together/commit/f16e2a1cba3e99c8cc6f1496608f1cf6c97fc7ee))

