### PR TITLE
fix: Update whatismyip to v0.9.19

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.18.tar.gz"
-  sha256 "7d9799bfacf0be29219d67b5f8cfbffee769b4f9291e879ed63691716f5ce7d9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.18"
-    sha256 cellar: :any_skip_relocation, catalina:     "f973db7e060a32a5a0a5a7123b38d1d7853c72969465a0e219785eb0834f309c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2b650c6bf85468cc7d856f15423e971e14b7f31e8264df297122d295bc924d70"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.19.tar.gz"
+  sha256 "a858f757dab402ca9e6e979a2f5ed7ccd728d1b14e7ad10f957c04789622d7bd"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.19](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.19) (2021-11-16)

### Build

- Versio update versions ([`80b31e9`](https://github.com/PurpleBooth/whatismyip/commit/80b31e94dcc873f027397f64fb5efdcef5a4f16f))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.5 to 0.1.6 ([`ddf48eb`](https://github.com/PurpleBooth/whatismyip/commit/ddf48eb69ec8fe8e02923f6954221bf946295ec6))
- Add scope ([`3dc7462`](https://github.com/PurpleBooth/whatismyip/commit/3dc7462e34244f1504f38e426a79a7e2de95c315))

### Fix

- Bump tokio from 1.13.0 to 1.13.1 ([`dc1a42e`](https://github.com/PurpleBooth/whatismyip/commit/dc1a42ee0c8e004368967c30f205b0f08f95d261))

