### PR TITLE
fix: Update git-mit to v5.12.6

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.5.tar.gz"
-  sha256 "348781af25159cd0bd659c8b202e17fe770ad96bba12b9416663812a94525831"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.5"
-    sha256 cellar: :any,                 catalina:     "41f35cde7e0f89f0bb22df96575d04c366da668a106a81bd2497e68c9d999e1e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a101ffdd32890519264d4dbe9608fb79af59054f5256a90b5056ea9bf162edcc"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.6.tar.gz"
+  sha256 "8faddbc8caa615650380a2dc5cfecac1b648d2af30cba628417c4c5c01fc8876"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.6](https://github.com/PurpleBooth/git-mit/compare/...v5.12.6) (2021-11-16)

### Build

- Versio update versions ([`0c01307`](https://github.com/PurpleBooth/git-mit/commit/0c01307e5804cd9220c2b9be9682af53da403c79))

### Fix

- Bump tokio from 1.13.1 to 1.14.0 ([`83f42a1`](https://github.com/PurpleBooth/git-mit/commit/83f42a16e99096e3092d9a52df478b0ba0aa0d62))

