### PR TITLE
fix: Update git-moves-together to v2.5.7

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.6.tar.gz"
-  sha256 "0913cae29f2fed2b9abd70b4b4072b96b392e5d0f10f4457962544c11c27e02d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.6"
-    sha256 cellar: :any,                 catalina:     "56cf488a0182df30204cfd804feb0acd71a0eef484aef71ae5666d90639dc7e0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3963aa245092a945246911f9a2455ca8bcd208dcc5fa6ffdd8e8bd9fe72c8826"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.7.tar.gz"
+  sha256 "321ee9479340f9effa2d7ddeaf77ba9c5f5e85e1edc1d60bf6f0eb9b6ac855be"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.7](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.7) (2021-11-16)

### Build

- Versio update versions ([`8f93692`](https://github.com/PurpleBooth/git-moves-together/commit/8f93692cf324c38f5920aa6fdb770500ead4ae47))

### Ci

- Allow mergify to be running the release train ([`ed65183`](https://github.com/PurpleBooth/git-moves-together/commit/ed6518343ee56418466ac68548151e2b40409710))

### Fix

- Bump git2 from 0.13.23 to 0.13.24 ([`a6c2d4e`](https://github.com/PurpleBooth/git-moves-together/commit/a6c2d4e5b5d1acd90008efcec29eefaee780ef36))

