### PR TITLE
fix: Update git-moves-together to v2.5.8

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.7.tar.gz"
-  sha256 "321ee9479340f9effa2d7ddeaf77ba9c5f5e85e1edc1d60bf6f0eb9b6ac855be"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.7"
-    sha256 cellar: :any,                 catalina:     "8fab89fc517efaa9a0e9a9f04dde50a6a58dfcd06d0c86df1c9fc4803cee5451"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1851d5917f819a1fae71cc750041c8b7eceff1789412df9d0e3d2052b201d134"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.8.tar.gz"
+  sha256 "7de6c2a57c59deb7585c0d9bf7dcc757d011d1b7087c71b5f023b0b574a028b1"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.8](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.8) (2021-11-16)

### Build

- Versio update versions ([`57abe7e`](https://github.com/PurpleBooth/git-moves-together/commit/57abe7e3a10007ea94b2524e588e25feb57d5fe9))

### Docs

- Use common changelog template ([`936663d`](https://github.com/PurpleBooth/git-moves-together/commit/936663df7cb1a238248506363dee29f4ee3a55e5))

### Fix

- Bump tokio from 1.13.1 to 1.14.0 ([`464fab8`](https://github.com/PurpleBooth/git-moves-together/commit/464fab8a7bf3b787f38c777bddc8d530df981eef))

