### PR TITLE
fix: Update whatismyip to v0.9.20

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.19.tar.gz"
-  sha256 "a858f757dab402ca9e6e979a2f5ed7ccd728d1b14e7ad10f957c04789622d7bd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.19"
-    sha256 cellar: :any_skip_relocation, catalina:     "906799cc2122d9ba365fbe0c85e1cc34ca8d2795f27edb561b3cc82b06396b52"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "66ff7bb4c14ce9f224833e88bf88aa5e8c217c8966452f34dbc5362d9424573c"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.20.tar.gz"
+  sha256 "580b297a110318f68329702f386e89ca25141f70667a7190726d546c589d20d0"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.20](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.20) (2021-11-16)

### Build

- Versio update versions ([`909b4be`](https://github.com/PurpleBooth/whatismyip/commit/909b4be3f36bb438570d9d95039a86fa8526d27e))

### Fix

- Bump tokio from 1.13.1 to 1.14.0 ([`324272a`](https://github.com/PurpleBooth/whatismyip/commit/324272ac25f34e30b7756d7c90c6030ee2e3c0d5))

