### PR TITLE
fix: Update git-mit to v5.12.7

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.6.tar.gz"
-  sha256 "8faddbc8caa615650380a2dc5cfecac1b648d2af30cba628417c4c5c01fc8876"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.6"
-    sha256 cellar: :any,                 catalina:     "4f37945702feab63015e406754d969aac83b6ffb16b46998bb6de19ce16c19e9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1be456266f99f5a9da13564d0dd2fffacedf91f00de1dc30eaec0bcf81499632"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.7.tar.gz"
+  sha256 "ce9457b4b0480d791c842b85f21895dbbb4ace2672bc48d0f53d13dcc237abb0"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.7](https://github.com/PurpleBooth/git-mit/compare/...v5.12.7) (2021-11-17)

### Build

- Versio update versions ([`dec07e5`](https://github.com/PurpleBooth/git-mit/commit/dec07e5a6dfb026a121bdd8616e8087864509c84))

### Docs

- Use standardised changelog ([`0ffa1d6`](https://github.com/PurpleBooth/git-mit/commit/0ffa1d6fc14ddb9f933a96036ad3173d963713b5))

### Fix

- Bump mit-lint from 3.0.2 to 3.0.3 ([`65b3084`](https://github.com/PurpleBooth/git-mit/commit/65b3084194c431444906a715d9b027151aff8fc8))

