### PR TITLE
fix: Update ellipsis to v0.6.21

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.20.tar.gz"
-  sha256 "4c69147e81d18dd6a26ea0ad30b92ffcdf4bfb10def3332a8fb9a97004068420"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.20"
-    sha256 cellar: :any_skip_relocation, catalina:     "703d697687dc2ac0531ee8b89f3114a550ae325f161a4d124b15182ccdd85eb9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a394d74db5998e22944b727bf0e765502932e2e8a1cf0f192e22189fa7c0881c"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.21.tar.gz"
+  sha256 "c88d59669cefad06a3aea07b4c8d0ffd1dca0d8bbb995aa1f38cb2aa2d697dd4"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.21](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.21) (2021-11-19)

### Build

- Versio update versions ([`c846eb6`](https://github.com/PurpleBooth/ellipsis/commit/c846eb62fae801a7dd743e6c0f0f1d420d72aa30))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.4 to 0.1.5 ([`b1cc848`](https://github.com/PurpleBooth/ellipsis/commit/b1cc848611126c836b9badb5435bfbec21647df5))
- Bump PurpleBooth/versio-release-action from 0.1.5 to 0.1.6 ([`27992a0`](https://github.com/PurpleBooth/ellipsis/commit/27992a05676ad3e5becaa930f7f59220387a5339))

### Fix

- Bump anyhow from 1.0.45 to 1.0.47 ([`05fa208`](https://github.com/PurpleBooth/ellipsis/commit/05fa208722ba0ba10b966d67c2c736b1f459195c))

