### PR TITLE
fix: Update whatismyip to v0.9.21

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.20.tar.gz"
-  sha256 "580b297a110318f68329702f386e89ca25141f70667a7190726d546c589d20d0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.20"
-    sha256 cellar: :any_skip_relocation, catalina:     "e679c3582f4294f22b4571a0f359f1803b2a84ba81e19749eb957c1fd8578bac"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c8e18f2a6e7b4f70ed6b61d190e828687ff0aa476faefbdf20f5dd4481d8100b"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.21.tar.gz"
+  sha256 "f1c8565f77055ede4209a0949be0c67f80fc22b381e7c50df104057d2c4a1a42"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.21](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.21) (2021-11-22)

### Build

- Versio update versions ([`ab0cf61`](https://github.com/PurpleBooth/whatismyip/commit/ab0cf61c12b854565ef7bbe05e977fe3ad664d9c))

### Fix

- Bump anyhow from 1.0.45 to 1.0.47 ([`23a746f`](https://github.com/PurpleBooth/whatismyip/commit/23a746f1c9777724825cf0ee488387e68625d92a))
- Bump anyhow from 1.0.47 to 1.0.48 ([`0070358`](https://github.com/PurpleBooth/whatismyip/commit/0070358ce24e76a3cea155827ddfdfd0cccda67d))

