### PR TITLE
fix: Update ed-system-search to v1.1.8

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.7.tar.gz"
-  sha256 "3a98ecf8098da6b377016928db04eea0c8aabffa50102d71bc91efb1b0cff269"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.7"
-    sha256 cellar: :any_skip_relocation, catalina:     "a6a4334ae458e2bbe9a237943df1efffc4275861dd09e4f20b8af5029ab0c577"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9073f486217d658e3f6e4a3cb2c63b1e5e77fa25774efadc73ae12643cd34e3f"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.8.tar.gz"
+  sha256 "caccdcfdff132ce2216967f9d4e57b72808bfc6d10aa82e7097a821f897ab044"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.8](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.8) (2021-11-26)

### Build

- Versio update versions ([c253826](c253826b49319c1de6cff2ab66d10817b1d320e0))

### Ci

- Use centralised homebrew pr formula ([3e43c9b](3e43c9bb2a05b68b7ac10521eefee9048cd52f4d))
- Bump actions/cache from 2.1.6 to 2.1.7 ([5cfc051](5cfc0515ab8814c0a52265773eb0664d93ce94a7))

### Fix

- Bump serde_json from 1.0.71 to 1.0.72 ([af67a70](af67a70e1ca6041505a6a6b5cd3bf081c4f55fd5))

