### PR TITLE
fix: Update ellipsis to v0.6.22

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.21.tar.gz"
-  sha256 "c88d59669cefad06a3aea07b4c8d0ffd1dca0d8bbb995aa1f38cb2aa2d697dd4"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.21"
-    sha256 cellar: :any_skip_relocation, catalina:     "012a517d6066f6d241f9caf7722a927c37c09a75713b2e8957aa7ff632a20651"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "677ea8c6f1e1c44a650cd5a5a176b5af4ccd8399db7bb3d974b23ff6b853a091"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.22.tar.gz"
+  sha256 "5914db8de7175e5279165f626cdf103eab73dd4dab9374a4a349f0a26d196454"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.22](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.22) (2021-11-29)

### Build

- Versio update versions ([`c2cc18d`](https://github.com/PurpleBooth/ellipsis/commit/c2cc18db64b794dc74b41d22c144bb76d5f8758b))

### Fix

- Bump anyhow from 1.0.47 to 1.0.48 ([`1357ee6`](https://github.com/PurpleBooth/ellipsis/commit/1357ee68a0a360318cf470cb182e33dbffb918ef))
- Bump anyhow from 1.0.48 to 1.0.51 ([`0dab9bf`](https://github.com/PurpleBooth/ellipsis/commit/0dab9bfbee3732b3fb4fd4267c3c0d0ce0efe66d))

