### PR TITLE
fix: Update game-of-life to v1.53.45

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.44.tar.gz"
-  sha256 "3f45bdf881cb69a1e9c5b042aeedceacad382967b7fc358981e2de147e7dc92b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.44"
-    sha256 cellar: :any_skip_relocation, catalina:     "8034f45f0c83e303a5b352ca5b90b6be14406e0cb12a8ab20fdfed735137d66d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e6917fd26f12a103edcb0ee3adfe9eb38bc25443754f32ac12d06c00767a3715"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.45.tar.gz"
+  sha256 "1c888637b50a6490defa5c052f42c74c3ddbdb259ade9fd815a2b18917b485f8"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.45](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.45) (2021-12-01)

### Build

- Versio update versions ([`117a5fa`](https://github.com/PurpleBooth/game-of-life/commit/117a5faee3f10c53521ed1d4a47bde04b5d410a3))

### Ci

- Switch to main ([`8c766df`](https://github.com/PurpleBooth/game-of-life/commit/8c766dfff7471f07e6d7f3f45bcdf420506a521b))
- Bump PurpleBooth/versio-release-action from 0.1.2 to 0.1.4 ([`9439dbd`](https://github.com/PurpleBooth/game-of-life/commit/9439dbd86f3fe8f34fd1562cf56ceb11751d6fda))
- Mergify ([`04ce865`](https://github.com/PurpleBooth/game-of-life/commit/04ce865680407381b5bd290e8eb9821cd3f7947b))
- Configuration update ([`8b4337e`](https://github.com/PurpleBooth/game-of-life/commit/8b4337ea12f5eae8b533b28a40f5fe6624935233))
- Mergify is pending until it is finished ([`22350bd`](https://github.com/PurpleBooth/game-of-life/commit/22350bd05d4c340ef5d7dd670c86a962fd16c287))
- Add pending ([`7a9194c`](https://github.com/PurpleBooth/game-of-life/commit/7a9194c363f7715a2e479fe6cf8f17d9deb1e632))
- Bump PurpleBooth/versio-release-action from 0.1.4 to 0.1.5 ([`6517cf6`](https://github.com/PurpleBooth/game-of-life/commit/6517cf6946a90e6d3dd4cfb79cce4ed18ce88b74))
- Bump PurpleBooth/versio-release-action from 0.1.5 to 0.1.6 ([`6ced727`](https://github.com/PurpleBooth/game-of-life/commit/6ced727d1babacaf439709c14b2ff27085c886d2))
- Bump PurpleBooth/versio-release-action from 0.1.6 to 0.1.7 ([`21afa40`](https://github.com/PurpleBooth/game-of-life/commit/21afa404c8f1b673de8c7e661b73f82e57b19e0d))

### Fix

- Bump clap from 2.33.3 to 2.34.0 ([`78b892b`](https://github.com/PurpleBooth/game-of-life/commit/78b892bed296790db6b1e7f320392b2753523d5b))

### Refactor

- Add compiler warnings ([`4577b08`](https://github.com/PurpleBooth/game-of-life/commit/4577b08dbed982016a5b2b238d1b7ba9c4824f40))

