### PR TITLE
fix: Update git-mit to v5.12.8

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.7.tar.gz"
-  sha256 "ce9457b4b0480d791c842b85f21895dbbb4ace2672bc48d0f53d13dcc237abb0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.7"
-    sha256 cellar: :any,                 catalina:     "afa27ff02116e0867a703e45272e6e912ea0826d5c2870e5654c8c34a75aeb06"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "279f18b1b9a315e5db8f399f4f7649485089faf463aab3b60500b0a6b53f1c3d"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.8.tar.gz"
+  sha256 "1ec8f68d9a3b9ee8226536a877e9c349056711c1b16778f0fd0fa4e51cfd1ff1"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.8](https://github.com/PurpleBooth/git-mit/compare/...v5.12.8) (2021-12-02)

### Build

- Versio update versions ([`3f69111`](https://github.com/PurpleBooth/git-mit/commit/3f69111b02d64497985cc201c1200bd704f41b5a))

### Ci

- Bump actions/cache from 2.1.6 to 2.1.7 ([`cd2fec5`](https://github.com/PurpleBooth/git-mit/commit/cd2fec5f549787324dc0037339bbe8f2046e1dfa))
- Bump ncipollo/release-action from 1.8.10 to 1.9.0 ([`2d84127`](https://github.com/PurpleBooth/git-mit/commit/2d84127b62ea02f6a0c5dd86e5f517fdeb556e4f))
- Bump PurpleBooth/changelog-action from 0.3.0 to 0.3.1 ([`69f5cc9`](https://github.com/PurpleBooth/git-mit/commit/69f5cc93883cb25a7e94da42c14cea229cec8595))
- Bump PurpleBooth/generate-formula-action from 0.1.4 to 0.1.5 ([`29f6fdf`](https://github.com/PurpleBooth/git-mit/commit/29f6fdfb7d90b90ccc9f143ea117a3b9ce4b8918))
- Bump PurpleBooth/versio-release-action from 0.1.6 to 0.1.7 ([`1b09a52`](https://github.com/PurpleBooth/git-mit/commit/1b09a52a67d155cdd6b7292dddf2cee96e9bdece))

### Fix

- Bump git2 from 0.13.24 to 0.13.25 ([`e274972`](https://github.com/PurpleBooth/git-mit/commit/e27497269a3d8d0f13600368c55eba4006bead0b))

