### PR TITLE
fix: Update fast-conventional to v1.0.1

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
-  desc "Fill in conventional commit messages quickly"
+  desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.0.tar.gz"
-  sha256 "a54a3a16b457c7caaa05d7790cadb20f854433d6799b802bb55de04e499978f9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.0"
-    sha256 cellar: :any_skip_relocation, catalina:     "e2ac16233106a2392ac414b5d08c2ac5f544dd22cd6ecaa926fc31603f33bd53"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6fa2e083f4876ccf634e1ac41dcb8c69943799ceb8c2415b3d51d768efb54624"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.1.tar.gz"
+  sha256 "a5b5709aa599012c4cd3734871301d905b89c4dd513067733be2615fe5c05a28"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.1](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.1) (2021-12-09)

### Build

- Versio update versions ([`71d9af0`](https://github.com/PurpleBooth/fast-conventional/commit/71d9af0ebe458c15ed31830d939453a95eec3a31))

### Ci

- Add cargo token to pipeline ([`efc99cb`](https://github.com/PurpleBooth/fast-conventional/commit/efc99cb552c9173709441ef96df547c2dc687f9a))
- Bump PurpleBooth/versio-release-action from 0.1.5 to 0.1.6 ([`360f0bc`](https://github.com/PurpleBooth/fast-conventional/commit/360f0bc6c690a88e35373d38406550975e9fe81b))
- Bump PurpleBooth/versio-release-action from 0.1.6 to 0.1.7 ([`fc0f88d`](https://github.com/PurpleBooth/fast-conventional/commit/fc0f88d623a9347aef84f5ff7793d2d25d8cc555))

### Docs

- Improve the subtitle ([`9d1cc9d`](https://github.com/PurpleBooth/fast-conventional/commit/9d1cc9d8ab8a51ee9e38edd7a633ae93efd0ba8a))
- Give a consistent tag line ([`3ded809`](https://github.com/PurpleBooth/fast-conventional/commit/3ded809f1283f89071331cecfbf61d2cf6935238))
- Move the install docs to the correct location ([`6d2c4a7`](https://github.com/PurpleBooth/fast-conventional/commit/6d2c4a7990be6cb9e327b22160cae749551bfc29))
- Correct formatting ([`148ed44`](https://github.com/PurpleBooth/fast-conventional/commit/148ed440f276cff184498dad2fe5091f25fbd0d9))

### Fix

- Bump serde from 1.0.130 to 1.0.131 ([`5b6d10e`](https://github.com/PurpleBooth/fast-conventional/commit/5b6d10e6e9adf8af2d87f241f22f69bcab425575))

