### PR TITLE
fix: Update hungry-distance to v0.1.11

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.10.tar.gz"
-  sha256 "175e4ac85281de2b0145a01ddef2ac90b6f66e3e72ac615eb531b9c028c3d1c2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.10"
-    sha256 cellar: :any_skip_relocation, catalina:     "5895308f0a3548427de4a0ad77cf37ba2f84aa12478180185099c3df6b89ed84"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "080689798e7b370343728ab81d4f484efe74de162f5ad178b523b987b9d044a8"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.11.tar.gz"
+  sha256 "7e1945977768cdf581cec5b356c633b4243b5e9d2424ac6bbf4591efac8700ff"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.11](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.11) (2021-12-09)

### Build

- Versio update versions ([`7a684b7`](https://github.com/PurpleBooth/hungry-distance/commit/7a684b7ac3b35b6d1b9d2dd7245d808602386c5d))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.5 to 0.1.6 ([`efa0298`](https://github.com/PurpleBooth/hungry-distance/commit/efa0298b6f8babc8a482977b0b7a453f21e756ef))
- Bump PurpleBooth/versio-release-action from 0.1.6 to 0.1.7 ([`952eec6`](https://github.com/PurpleBooth/hungry-distance/commit/952eec615f301842d46f343474d8a8a38557491e))

### Fix

- Bump clap from 3.0.0-beta.5 to 3.0.0-rc.0 ([`730b6d4`](https://github.com/PurpleBooth/hungry-distance/commit/730b6d431e38d7dbfac7fb295520caed30be8361))
- Bump clap version ([`1538d22`](https://github.com/PurpleBooth/hungry-distance/commit/1538d2233dfa807bacccf87135fdfcab06c15e20))

