### PR TITLE
fix: Update ed-system-search to v1.1.9

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.8.tar.gz"
-  sha256 "caccdcfdff132ce2216967f9d4e57b72808bfc6d10aa82e7097a821f897ab044"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.8"
-    sha256 cellar: :any_skip_relocation, catalina:     "b51382a6446ce73882ea4ab099e8474212fcc08d417210e28b9e8203bf68214f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8b2009f738ba6fde9e6041b5caff305319963be6114e1b3dc1cba62d85a3fced"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.9.tar.gz"
+  sha256 "234fe08f34bacc4b81c0e30aac4f813b767124f06efb8270c9d55d0aef624d34"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.9](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.9) (2021-12-09)

### Build

- Versio update versions ([`d484eb7`](https://github.com/PurpleBooth/ed-system-search/commit/d484eb796989cf86bb27b08b04ab6aaf74283bc1))

### Ci

- Add scope ([`545e418`](https://github.com/PurpleBooth/ed-system-search/commit/545e4189f4bd6c0b35ebf324c4a4c503ca60d7ca))
- Bump ncipollo/release-action from 1.8.10 to 1.9.0 ([`7727ef1`](https://github.com/PurpleBooth/ed-system-search/commit/7727ef1eeac32b45ad424c442891c17cf6df1483))
- Bump PurpleBooth/changelog-action from 0.3.0 to 0.3.1 ([`faa6b44`](https://github.com/PurpleBooth/ed-system-search/commit/faa6b44c837fd171f0b3b8beb0172960c8069328))
- Bump PurpleBooth/generate-formula-action from 0.1.4 to 0.1.5 ([`8261efe`](https://github.com/PurpleBooth/ed-system-search/commit/8261efe0f678ab44eec3708df11ca3cbbdbc3739))

### Docs

- Use standard changelog format ([`f6a582d`](https://github.com/PurpleBooth/ed-system-search/commit/f6a582d11bddf396049b5c97f13ee83581173ccf))
- Update new discoveries ([`1b418b6`](https://github.com/PurpleBooth/ed-system-search/commit/1b418b67963475bca61793c365059374fe6e5bda))

### Fix

- Bump clap from 3.0.0-beta.5 to 3.0.0-rc.0 ([`1f28566`](https://github.com/PurpleBooth/ed-system-search/commit/1f285668d12440d5865e895764dc0399c1d4623b))
- Bump clap version ([`f691d6d`](https://github.com/PurpleBooth/ed-system-search/commit/f691d6dd27a64304be9dd87c53bae1a674b537b9))

