### PR TITLE
fix: Update ed-system-search to v1.1.10

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.9.tar.gz"
-  sha256 "234fe08f34bacc4b81c0e30aac4f813b767124f06efb8270c9d55d0aef624d34"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.9"
-    sha256 cellar: :any_skip_relocation, catalina:     "9ebcae7185bc821ba3aa0c1bd2a43f0f8a6867512bc1cd993f17a7f6609a0a11"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ba22317218dace0f929e47a67a6fbfb194573c32d851b0335151cfb88b6a1fda"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.10.tar.gz"
+  sha256 "fc598550a3ff79ad24e465227c674ded26428b50c8d41ab727254d0940c88ae0"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.10](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.10) (2021-12-10)

### Build

- Versio update versions ([`ebfba05`](https://github.com/PurpleBooth/ed-system-search/commit/ebfba056e20f2697d5196fa911928ffbea648af7))

### Fix

- Bump serde from 1.0.130 to 1.0.131 ([`1f0b9cc`](https://github.com/PurpleBooth/ed-system-search/commit/1f0b9cc50b2ad62fe893166edfe53ce36684c0ff))

