### PR TITLE
fix: Update hungry-distance to v0.1.12

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.11.tar.gz"
-  sha256 "7e1945977768cdf581cec5b356c633b4243b5e9d2424ac6bbf4591efac8700ff"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.11"
-    sha256 cellar: :any_skip_relocation, catalina:     "33a2f849234c3a0dbafaed251ef80761704d60e6fee30d4024000f6a0c39376c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c4fb8636e7d46076f23d8ef4e03f8e72aa15650f39c40968a1f7756c907b9f35"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.12.tar.gz"
+  sha256 "439c1e1e992f1ce17905cdc6d004cf3fcebd83eb1180ac60e06a8c9759cad6be"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.12](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.12) (2021-12-10)

### Build

- Versio update versions ([`4f05648`](https://github.com/PurpleBooth/hungry-distance/commit/4f05648c43b42e6a0f4d738da2a249395466dff8))

### Fix

- Bump clap from 3.0.0-rc.1 to 3.0.0-rc.3 ([`ef43d42`](https://github.com/PurpleBooth/hungry-distance/commit/ef43d424be95bbae24df1cccaa4ec134a47dfba3))

