### PR TITLE
fix: Update git-mit to v5.12.9

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.8.tar.gz"
-  sha256 "1ec8f68d9a3b9ee8226536a877e9c349056711c1b16778f0fd0fa4e51cfd1ff1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.8"
-    sha256 cellar: :any,                 catalina:     "10ccfc8d4e5ccf892525dbef066bdf5c6c6bc5fd5d3071414fa381b492452a2f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f7aa39efce23c3f2858b0cc06303fc3df71656c8b6a3584120249c0073c1bb3"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.9.tar.gz"
+  sha256 "8487683a6359a1c922a2568f17f0a5d42f39b1154e5e36eb00e2f589223f2fbd"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.9](https://github.com/PurpleBooth/git-mit/compare/...v5.12.9) (2021-12-11)

### Build

- Run on same image as build ([`5f23d77`](https://github.com/PurpleBooth/git-mit/commit/5f23d77bb89927cd3b79e7f540821f33bd8308f8))
- Support the new version of clap ([`e651f97`](https://github.com/PurpleBooth/git-mit/commit/e651f9784641f1d9282cab7b71c73a3257a7bada))
- Versio update versions ([`9459871`](https://github.com/PurpleBooth/git-mit/commit/945987133c56231d45d9fe7664b05b7203d626c0))

### Chore

- Format the fast conventional file ([`c565941`](https://github.com/PurpleBooth/git-mit/commit/c56594199657d3764ad98a5ab4a06a562874f575))

### Ci

- Bump nick-invision/retry from 2.5.1 to 2.6.0 ([`be33091`](https://github.com/PurpleBooth/git-mit/commit/be33091efaccd69c554f45ceb82a5512f28d2454))

### Fix

- Add two dependencies missing from git-mit's dockerfile ([`f6a551a`](https://github.com/PurpleBooth/git-mit/commit/f6a551a8b9d4cc397e629d63901c8d518a8c6044))

