### PR TITLE
fix: Update ellipsis to v0.6.23

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.22.tar.gz"
-  sha256 "5914db8de7175e5279165f626cdf103eab73dd4dab9374a4a349f0a26d196454"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.22"
-    sha256 cellar: :any_skip_relocation, catalina:     "853fffa575be4fb4b5295a338e91b779746371257f6d7944dd81d38df57072d8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2fe14af798ce16cba05df5e3b2f0948b50d48e13e6f7ccbb95251e14e2b8fb1d"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.23.tar.gz"
+  sha256 "9f7bbfa0f239f33a6cb8433ed1ea0b839ee65e97fd19d3a3b66bc019fb470141"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.23](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.23) (2021-12-11)

### Build

- Versio update versions ([`57dfb98`](https://github.com/PurpleBooth/ellipsis/commit/57dfb9851d79e2c26b3b206e404dcd02252f91b6))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.6 to 0.1.7 ([`064abd5`](https://github.com/PurpleBooth/ellipsis/commit/064abd5e3707826451632844b66685d5ca63632c))

### Fix

- Bump clap from 3.0.0-beta.5 to 3.0.0-rc.0 ([`abea44b`](https://github.com/PurpleBooth/ellipsis/commit/abea44bee6e8d6fbac68cedde15bf36df834f872))
- Bump clap from 3.0.0-rc.0 to 3.0.0-rc.1 ([`5b149b8`](https://github.com/PurpleBooth/ellipsis/commit/5b149b8493bca1e669dd1aac83fd7d1cbee220df))
- Bump serde from 1.0.130 to 1.0.131 ([`07e696d`](https://github.com/PurpleBooth/ellipsis/commit/07e696d7f4919b1808b8659be1e49e7b0bbc7214))
- Bump clap from 3.0.0-rc.1 to 3.0.0-rc.3 ([`5fd8678`](https://github.com/PurpleBooth/ellipsis/commit/5fd86788e0efca3a6e3ae7873c60f5f3cb5e08f2))
- Bump clap version ([`742b423`](https://github.com/PurpleBooth/ellipsis/commit/742b423e87ccdbe10c39841453f5316e4855b120))

