### PR TITLE
fix: Update ed-system-search to v1.1.11

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.10.tar.gz"
-  sha256 "fc598550a3ff79ad24e465227c674ded26428b50c8d41ab727254d0940c88ae0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.10"
-    sha256 cellar: :any_skip_relocation, catalina:     "24b95240610a3b0e5da296be7010e2e2ac5618f70734a5060538011733851e9c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "002b1a5f502fba84bb15431484aa39001ab69a8ce9e1673379da27dcb21ba725"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.11.tar.gz"
+  sha256 "3084aab970efc2bf61082bd29a237d771bc6ef3f89b226fb3ea7a8db1e3bb63d"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.11](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.11) (2021-12-13)

### Build

- Versio update versions ([`ba9b571`](https://github.com/PurpleBooth/ed-system-search/commit/ba9b571d33cdf86cadb4ac1093902a10884ea9f4))

### Fix

- Bump clap from 3.0.0-rc.1 to 3.0.0-rc.4 ([`551b8e3`](https://github.com/PurpleBooth/ed-system-search/commit/551b8e3e811ab8174cc238b371d157b5dd5b46bd))

