### PR TITLE
fix: Update git-mit to v5.12.10

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.9.tar.gz"
-  sha256 "8487683a6359a1c922a2568f17f0a5d42f39b1154e5e36eb00e2f589223f2fbd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.9"
-    sha256 cellar: :any,                 catalina:     "8320701b6be3b84e0fc0ff4cd43af89ae7c4a34c3f4171bc60557aeaa8f52722"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d070b101d55b16fc09a5638f8f6a6292203f2bda6585ac2abf0a5f8141813560"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.10.tar.gz"
+  sha256 "4322ff47562cd8739b2b30136779e269e5ad3501c97acc9e8151e174e1b7983e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.10](https://github.com/PurpleBooth/git-mit/compare/...v5.12.10) (2021-12-13)

### Build

- Versio update versions ([`4e12f2d`](https://github.com/PurpleBooth/git-mit/commit/4e12f2d9829590307aa88d2b55c420a08ebc9ab3))

### Fix

- Bump serde_yaml from 0.8.21 to 0.8.23 ([`4a888e3`](https://github.com/PurpleBooth/git-mit/commit/4a888e342767f2006a4222fccd5691bbed3d73a5))

