### PR TITLE
fix: Update ellipsis to v0.6.24

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.23.tar.gz"
-  sha256 "9f7bbfa0f239f33a6cb8433ed1ea0b839ee65e97fd19d3a3b66bc019fb470141"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.23"
-    sha256 cellar: :any_skip_relocation, catalina:     "5efc23d49a188636118ed1070ac20c1ea2739a91d345e0cc824ae6aa81af4260"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "33de3ad1e1547ce4e5dd7c71c01813ae5997e7a3aa9a59b7459f07d4722f5819"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.24.tar.gz"
+  sha256 "f340a3003cba739065889795b6e96995aed72e6e4a09ce3b0d396e54cb607ff8"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.24](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.24) (2021-12-13)

### Build

- Versio update versions ([`93cc93c`](https://github.com/PurpleBooth/ellipsis/commit/93cc93ce7c6e63f27c79cb6558d61fbf2cd937bd))

### Fix

- Bump serde_yaml from 0.8.21 to 0.8.23 ([`4169200`](https://github.com/PurpleBooth/ellipsis/commit/4169200c4ea0a63f8b2309129aeb2ba82a1fec4d))

