### PR TITLE
fix: Update hungry-distance to v0.1.13

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.12.tar.gz"
-  sha256 "439c1e1e992f1ce17905cdc6d004cf3fcebd83eb1180ac60e06a8c9759cad6be"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.12"
-    sha256 cellar: :any_skip_relocation, catalina:     "d071243706a61aaa5ece450076b03d8bfee5e30949a9f84a34953a234b450d13"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "537d560496063f741b13fbc395e55be1eab8e37ac2bec2995919e8b4206d9bc0"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.13.tar.gz"
+  sha256 "bdb49a0a3c5b188bcfe9aacc22d6e1e6b42f25333ddd9ef88e350ff2f62ea4e6"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.13](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.13) (2021-12-17)

### Build

- Versio update versions ([`50a225d`](https://github.com/PurpleBooth/hungry-distance/commit/50a225db38af4a7e2389dda69bc5c6a45b1c99ea))

### Fix

- Bump clap ([`f4913d2`](https://github.com/PurpleBooth/hungry-distance/commit/f4913d27b9dc876ca3f101377a6de9a160c54c7e))
- Bump clap from 3.0.0-rc.4 to 3.0.0-rc.5 ([`0955af2`](https://github.com/PurpleBooth/hungry-distance/commit/0955af20bb57c8a024f57d8a5ec92701a1d2908e))
- Bump clap from 3.0.0-rc.5 to 3.0.0-rc.7 ([`27531b4`](https://github.com/PurpleBooth/hungry-distance/commit/27531b4a823990385066a82bc0683cdaa4f1caaa))

