### PR TITLE
fix: Update whatismyip to v0.9.26

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.21.tar.gz"
-  sha256 "f1c8565f77055ede4209a0949be0c67f80fc22b381e7c50df104057d2c4a1a42"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.21"
-    sha256 cellar: :any_skip_relocation, catalina:     "f6673329606e23429d333fa7310b53d586f4c2e23b6ac51e16273ec1f2328cb9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ffce25950a97b242e1b04ed9c1892d6149f3a8ce4d618e52cb5a5e9307bda170"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.26.tar.gz"
+  sha256 "01b351efc495aba93e9edef3ceb2cc21fae6c7e551f222f942cabf40270295d1"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.26](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.26) (2021-12-20)

### Build

- Versio update versions ([`b5a551d`](https://github.com/PurpleBooth/whatismyip/commit/b5a551d1c34aca43b523727eaf7982db57b599ee))

### Fix

- Bump tokio from 1.14.0 to 1.15.0 ([`0bd39b2`](https://github.com/PurpleBooth/whatismyip/commit/0bd39b2e1ae07e5791fc7d7a354b6622183df19f))
- Bump futures from 0.3.18 to 0.3.19 ([`29bab76`](https://github.com/PurpleBooth/whatismyip/commit/29bab76c69b1df70dca8e0ef7dec9a9ff7468249))

