### PR TITLE
fix: Update whatismyip to v0.9.27

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.26.tar.gz"
-  sha256 "01b351efc495aba93e9edef3ceb2cc21fae6c7e551f222f942cabf40270295d1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.26"
-    sha256 cellar: :any_skip_relocation, big_sur:      "a547f16f0160909eca193bf39896142ad42c64d7c6ac74225416e6c34d9cc9b9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "452c619dc8e43ff1aabe3fbf0dcef50bfd93d9abd956bd8a1c88093d2322b360"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.27.tar.gz"
+  sha256 "0f402ec8ee912ba7793ac5e253850a6303fe1635bdf46ba62ee3255d4e23fde9"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.27](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.27) (2021-12-24)

### Build

- Versio update versions ([`707eca9`](https://github.com/PurpleBooth/whatismyip/commit/707eca93080b36ac8c71997c690d115411d59d21))

### Fix

- Bump anyhow from 1.0.51 to 1.0.52 ([`83713a9`](https://github.com/PurpleBooth/whatismyip/commit/83713a9c839859f7919a5dd696ccbef818efa9c2))

