### PR TITLE
fix: Update hungry-distance to v0.1.14

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.13.tar.gz"
-  sha256 "bdb49a0a3c5b188bcfe9aacc22d6e1e6b42f25333ddd9ef88e350ff2f62ea4e6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.13"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0e83e012553b5636ff18bb9372728642f97ce984a35a6bf307682ea7e88f2009"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e596bfa68afd1acd3d9f5c9d8d13619b5803433b866d7b7884e185b782b28c66"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.14.tar.gz"
+  sha256 "32ee142e2fe12004709d500126bf231b03c73c2b6937c03f3b3d21ecc23bdcc2"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.14](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.14) (2021-12-28)

### Build

- Versio update versions ([`97382f3`](https://github.com/PurpleBooth/hungry-distance/commit/97382f35c482eb5f17789aa877ade6bab501946f))

### Fix

- Bump clap from 3.0.0-rc.7 to 3.0.0-rc.8 ([`69df75b`](https://github.com/PurpleBooth/hungry-distance/commit/69df75bc7afe38be32683bbd8c2894e8da8dc219))
- Bump clap from 3.0.0-rc.8 to 3.0.0-rc.9 ([`60e912b`](https://github.com/PurpleBooth/hungry-distance/commit/60e912b7119c5c9f8f0dabb144b46f3bb1473078))

