### PR TITLE
fix: Update hungry-distance to v0.1.15

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.14.tar.gz"
-  sha256 "32ee142e2fe12004709d500126bf231b03c73c2b6937c03f3b3d21ecc23bdcc2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.14"
-    sha256 cellar: :any_skip_relocation, big_sur:      "91ad9197f881a392c937bbe956fbd54199c986b02812f74a7cedc33db848a96f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e50b1188f7c6b44499e69b3206d2f812478a821355c1c2cd2782ae6e60f770fd"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.15.tar.gz"
+  sha256 "70eccc0a904dc68e252222b16e188e8063c7eae4428702f147c9c9e1f13b4e35"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.15](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.15) (2021-12-31)

### Build

- Versio update versions ([`5a209c6`](https://github.com/PurpleBooth/hungry-distance/commit/5a209c6a5fa761da1ad981617b089c45ef32ac1c))

### Fix

- Bump clap from 3.0.0-rc.9 to 3.0.0-rc.11 ([`754a82e`](https://github.com/PurpleBooth/hungry-distance/commit/754a82e675f0ef2d67440f34d621078e65a2226d))

