### PR TITLE
fix: Update git-mit to v5.12.13

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.11.tar.gz"
-  sha256 "c8fe1b5ddcf5a739daea418a279cc75064af42c3cfd1ad1c593bb907b6095927"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.11"
-    sha256 cellar: :any,                 big_sur:      "f483182ed86729c70bab47359b1110c68225b6b36ac161726c6e7709d632482f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "81138df5be78c7ce786139418c1db5642e5b77e7263b3d6e107c87fbc884a0b3"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.13.tar.gz"
+  sha256 "2603858fd921a13e67121aa49c63e86413c17f77db7831c2f57d7c1bf3fa9e95"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.13](https://github.com/PurpleBooth/git-mit/compare/...v5.12.13) (2022-01-02)

### Build

- Versio update versions ([`0353d40`](https://github.com/PurpleBooth/git-mit/commit/0353d4048ac390183368496be7a51b24135e49c6))

### Fix

- Rotate keys ([`f47aa49`](https://github.com/PurpleBooth/git-mit/commit/f47aa4917504c98ec858e66143ab653dd6e61720))

