### PR TITLE
fix: Update ellipsis to v0.6.25

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.24.tar.gz"
-  sha256 "f340a3003cba739065889795b6e96995aed72e6e4a09ce3b0d396e54cb607ff8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.24"
-    sha256 cellar: :any_skip_relocation, big_sur:      "3d72329a14e96965b2f3ca3efd878a32119890214938c60022806942061f0db7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "99a2a7b9748bbda4db306577abf49a60e3047dccffd2eefef3a042f962004fb2"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.25.tar.gz"
+  sha256 "3e5d63db60e496f52c45989e80c2084ad8457c2ba1f14c72f9703d84f7bf4956"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.25](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.25) (2022-01-02)

### Build

- Versio update versions ([`6b9001a`](https://github.com/PurpleBooth/ellipsis/commit/6b9001abb2e4adcc97fcf8746574d3557222195d))

### Fix

- Bump clap from 3.0.0-rc.4 to 3.0.0-rc.5 ([`1af530e`](https://github.com/PurpleBooth/ellipsis/commit/1af530ee2c9759a6fa0e85d35f28594e65af8995))
- Bump serde from 1.0.131 to 1.0.132 ([`64ab3e9`](https://github.com/PurpleBooth/ellipsis/commit/64ab3e997903aaa88ccd1c9c0a6707f3a1b3e70f))
- Bump clap from 3.0.0-rc.5 to 3.0.0-rc.7 ([`3e6a9e5`](https://github.com/PurpleBooth/ellipsis/commit/3e6a9e5adeae68ffd2134834f5be0542ce4a5b58))
- Bump clap from 3.0.0-rc.7 to 3.0.0-rc.8 ([`fa217ad`](https://github.com/PurpleBooth/ellipsis/commit/fa217ad076080037534493f3d348bad9a64d5cd4))
- Bump clap version ([`3900333`](https://github.com/PurpleBooth/ellipsis/commit/3900333c84b641c5fc2fa4a550b089f098866086))

