### PR TITLE
fix: Update whatismyip to v0.9.28

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.27.tar.gz"
-  sha256 "0f402ec8ee912ba7793ac5e253850a6303fe1635bdf46ba62ee3255d4e23fde9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.27"
-    sha256 cellar: :any_skip_relocation, big_sur:      "ddf309b9cd2607a3e70dc647eeedc8adbff7c35c68e2f54f2df37f16ab7236b0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "aa6f098d032598ebae5269a53e1c46c3df0aed1c87d6de3468ac54dbc2e21d75"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.28.tar.gz"
+  sha256 "48b0aa819c70857e583464fb1c20705892aa35dec2f84fce6c4977e600fcfb8b"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.28](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.28) (2022-01-02)

### Build

- Versio update versions ([`2160d60`](https://github.com/PurpleBooth/whatismyip/commit/2160d6012220fc81faf5e59d6e4c4a1bab50e6c0))

### Fix

- Bump clap version ([`eaed44a`](https://github.com/PurpleBooth/whatismyip/commit/eaed44a21ddadcaf9fd4d439383babc769601235))

