### PR TITLE
fix: Update fast-conventional to v1.0.2

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.1.tar.gz"
-  sha256 "a5b5709aa599012c4cd3734871301d905b89c4dd513067733be2615fe5c05a28"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.1"
-    sha256 cellar: :any_skip_relocation, catalina:     "b3f5f2dac9340f8b32852056d41b31e256bdbc2254eb4b06ac56e870c19222a0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "dcb1304f24de79f98df24295ad059822abb999913e7e8d0f89ead91ab238ef18"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.2.tar.gz"
+  sha256 "0b42519eacf08d8b86080e6432a526325bf7067d0cacd43a4b3dd86426dee204"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.2](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.2) (2022-01-02)

### Build

- Versio update versions ([`50f5499`](https://github.com/PurpleBooth/fast-conventional/commit/50f5499d72a3b0b53aabc21f9339a86b63454084))

### Fix

- Bump clap_generate from 3.0.0-beta.5 to 3.0.0-rc.3 ([`0966b4a`](https://github.com/PurpleBooth/fast-conventional/commit/0966b4ac7e8f304afbc1690f6031f596426169b8))
- Bump clap_derive from 3.0.0-beta.5 to 3.0.0-rc.4 ([`e20135c`](https://github.com/PurpleBooth/fast-conventional/commit/e20135cc2e54f3115b0539fefaf203851cba12de))
- Bump clap version ([`a6b6d51`](https://github.com/PurpleBooth/fast-conventional/commit/a6b6d51514739b2bc97fdd677c2c21490e357f0b))

