### PR TITLE
fix: Update hungry-distance to v0.1.16

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.15.tar.gz"
-  sha256 "70eccc0a904dc68e252222b16e188e8063c7eae4428702f147c9c9e1f13b4e35"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.15"
-    sha256 cellar: :any_skip_relocation, big_sur:      "f1e8dfe11f30b5f928e691929523b7c688a2f898496b28e9185d11d020cb61b9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "cbe66e72fcd8dac88a53e25d9b7c574f9b865c0a7b2b465aeee2adde1e15e928"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.16.tar.gz"
+  sha256 "63766c39bf1b99e8964a5d2b1bea450be05a4c0e6c3bdc0cf8d4bbc46740fa56"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.16](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.16) (2022-01-02)

### Build

- Versio update versions ([`80d7589`](https://github.com/PurpleBooth/hungry-distance/commit/80d75890699c3b0e243203455196cafb927be561))

### Fix

- Bump clap from 3.0.0-rc.11 to 3.0.0 ([`de655a9`](https://github.com/PurpleBooth/hungry-distance/commit/de655a93cc044d9b3fe4374d7c78d32dba45cd9e))

