### PR TITLE
fix: Update ed-system-search to v1.1.13

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.12.tar.gz"
-  sha256 "444cd2a8a3e9c1b8b302605c2959f2db8547a8be6ade9b2b78e4d68c58662fe6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.12"
-    sha256 cellar: :any_skip_relocation, big_sur:      "74a44a6ce4ece6882d43314b3d440b76986e6ddbb7a52eb0206eea54b026516f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "697ffe9fe6430b96de14c036c7b84aed411927660efed2a572a92c4a45d68a3d"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.13.tar.gz"
+  sha256 "2951eadddd5f0b93d6956b23a0370e20e8018aa09e411ef9995ad7910f6dff25"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.13](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.13) (2022-01-03)

### Build

- Versio update versions ([`cc99c2b`](https://github.com/PurpleBooth/ed-system-search/commit/cc99c2ba1570ff5fd46698607c4bbf17268b95fb))

### Fix

- Bump clap from 3.0.0-rc.4 to 3.0.0-rc.5 ([`cb937f4`](https://github.com/PurpleBooth/ed-system-search/commit/cb937f4bb9425ee5b7381881f424884b1b05722d))
- Bump serde from 1.0.131 to 1.0.132 ([`dddeb6f`](https://github.com/PurpleBooth/ed-system-search/commit/dddeb6f78796e84a47a8401f7ceccdd75b8de675))
- Bump clap from 3.0.0-rc.5 to 3.0.0-rc.7 ([`e57689b`](https://github.com/PurpleBooth/ed-system-search/commit/e57689b3c53cba77851fb48f554fdd2e575c0039))
- Bump clap from 3.0.0-rc.7 to 3.0.0-rc.8 ([`ccea973`](https://github.com/PurpleBooth/ed-system-search/commit/ccea973ee5d24c8fab52f4669f496ae1217c348d))
- Bump clap from 3.0.0-rc.8 to 3.0.0-rc.9 ([`960f9f5`](https://github.com/PurpleBooth/ed-system-search/commit/960f9f5b0c6cba61448dfa239d9b87d4c9ef4dbd))
- Bump clap from 3.0.0-rc.9 to 3.0.0-rc.11 ([`473fa34`](https://github.com/PurpleBooth/ed-system-search/commit/473fa34f57fd963a80903ef0ae7c1ea3a9b40cc6))
- Bump version of clap ([`4111e4b`](https://github.com/PurpleBooth/ed-system-search/commit/4111e4b6c23c48e9c37a39e0df577b33fccf3f15))

