### PR TITLE
fix: Update game-of-life to v1.53.46

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.45.tar.gz"
-  sha256 "1c888637b50a6490defa5c052f42c74c3ddbdb259ade9fd815a2b18917b485f8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.45"
-    sha256 cellar: :any_skip_relocation, catalina:     "712ede35765089eaedc4a7d419207935a6537a09bac8594772b3893617ee750c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a0c9ee20b8d3a1181b210e5c82b16f763dd7ab8c64e00992b5fd2593bf172fd1"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.46.tar.gz"
+  sha256 "1666b4327a40207cb383594a96ecbc1dd06385c142f90eba1690ccfab69e4fb3"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.46](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.46) (2022-01-03)

### Build

- Versio update versions ([`619e963`](https://github.com/PurpleBooth/game-of-life/commit/619e963c2cff5e282a67cb234a9a273ddaa3e0c0))

### Fix

- Bump clap from 2.34.0 to 3.0.0 ([`9e2e6ee`](https://github.com/PurpleBooth/game-of-life/commit/9e2e6ee136c68bf5adc2de4af0b1e577baf389c4))
- Bump clap ([`be49dfd`](https://github.com/PurpleBooth/game-of-life/commit/be49dfd3d23a5fe5e46817a22e5c161a249f2418))

