### PR TITLE
fix: Update fix-compaudit to v0.46.68

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/refs/tags/v0.46.67.tar.gz"
-  sha256 "4cd6dfe5a19e5e41a0bd73ac23ce407507f8f870e09d9e5f7d24de0bde4835fb"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.67"
-    sha256 cellar: :any_skip_relocation, catalina:     "e0dcfbd03d1f739ea852d559a27f9cf9d39ed199fea34f0a94b5e82e55a223df"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ac16d289f85a138deb2a0e5e808d19e38920f23954de10de427ee03730c73a06"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.68.tar.gz"
+  sha256 "f83a44c3e1b2af4aca0c27fdb1ae8fd226fbd457fb74fd9baf46508a2fb0d589"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.68](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.68) (2022-01-03)

### Build

- Versio update versions ([`6f07346`](https://github.com/PurpleBooth/fix-compaudit/commit/6f073462bbc0a3e54b6fd394796ab934700acad0))

### Ci

- Remove unused pipeline ([`9861754`](https://github.com/PurpleBooth/fix-compaudit/commit/9861754d403d86431799f23b040fd8f856376372))
- Remove unused pipeline ([`6dcca16`](https://github.com/PurpleBooth/fix-compaudit/commit/6dcca1623efd879775d719583f51b6fb11998ca9))
- Add new pipeline ([`d2262f0`](https://github.com/PurpleBooth/fix-compaudit/commit/d2262f017620c931d1ac4aff5c50f44d15fb99c5))
- Disable windows builds ([`61de788`](https://github.com/PurpleBooth/fix-compaudit/commit/61de788cf8382ca1cc67fa2bafc9ce057d2037c1))

### Docs

- Formatting ([`23e1ebe`](https://github.com/PurpleBooth/fix-compaudit/commit/23e1ebe082dd8d648d8f8dcd551d06e89de0e589))

### Fix

- Bump versions ([`8f69dd9`](https://github.com/PurpleBooth/fix-compaudit/commit/8f69dd9d9b1f61a172fbaa83de926cb438754140))

