### PR TITLE
fix: Update ellipsis to v0.6.26

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.25.tar.gz"
-  sha256 "3e5d63db60e496f52c45989e80c2084ad8457c2ba1f14c72f9703d84f7bf4956"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.25"
-    sha256 cellar: :any_skip_relocation, big_sur:      "25663c0a5b2a1205d3cf1d0183ac80d35c2c985645cb15b038525a52a2754be4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "99070ec0f09ce05abbe0801b35af052b372fcdfda3c3d7d7d5970e2e318d0876"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.26.tar.gz"
+  sha256 "b7351a0e3b125d7b45714570bd460fa21a61168ddd86e088cc801e367b091a47"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.26](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.26) (2022-01-03)

### Build

- Versio update versions ([`f850a9c`](https://github.com/PurpleBooth/ellipsis/commit/f850a9c5bad4936dedfa3051732437bb0a375b74))

### Fix

- Bump clap from 3.0.0 to 3.0.1 ([`2c24ad4`](https://github.com/PurpleBooth/ellipsis/commit/2c24ad464dfa3d41f5370ff2e19ff5c234772107))

