### PR TITLE
fix: Update game-of-life to v1.53.47

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.46.tar.gz"
-  sha256 "1666b4327a40207cb383594a96ecbc1dd06385c142f90eba1690ccfab69e4fb3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.46"
-    sha256 cellar: :any_skip_relocation, big_sur:      "9fb8e8ee2ef0789621a3988b6071cc622880cb4bbb2b4d8b3e091e94abff8bde"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "18efd597cbd5630b14df718f8aa460eadb82d8941b632149d5c29fb6065abb0e"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.47.tar.gz"
+  sha256 "f31401a785efa6fda5e4c1e9270f1b1942c7316931ada08911b7e12c00e8e6d7"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.47](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.47) (2022-01-04)

### Build

- Versio update versions ([`e5dd6a6`](https://github.com/PurpleBooth/game-of-life/commit/e5dd6a6946a14a03e10fd6c21084ed9ae6b9a202))

### Fix

- Bump clap from 3.0.0 to 3.0.1 ([`f01d932`](https://github.com/PurpleBooth/game-of-life/commit/f01d932a645f4f2234ef7df8d366cfe70b1d37e7))

