### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.35

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/refs/tags/v0.49.34.tar.gz"
-  sha256 "1b0c9114c2ea3ff5bc076cdcdccff67f181d1117c979c1c2a210ba4d32f3cece"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.35.tar.gz"
+  sha256 "68793736f536781d9e5e3a7bedf1a9e5d37767fd98473ebeb627a5b26ba6e79c"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.34"
-    sha256 cellar: :any_skip_relocation, catalina:     "020c1a759a7e528e21c6c238045edec827d169521440f8c80d997c09cf14b4ca"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9555aae1bf245855ad91572d381d2d2a190e39321f0ee5bee31b6692ebfbaa14"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.35](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.35) (2022-01-04)

### Build

- Versio update versions ([`513434e`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/513434eafaa76cbb2aefbeb98e3653787cc2b57c))

### Ci

- Remove unused pipeline ([`b3e2d4b`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/b3e2d4b6d48e1b5c6d1af5362cfb6b37d6ef6981))
- Remove old pipeline ([`01f1a3c`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/01f1a3c37095796d76e247fae0ae788630941bb3))
- Add new pipeline ([`7daf3a7`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/7daf3a705f2d116bc0e75e8ea28a7f65b61ce7cf))
- Disable windows builds ([`86e3a24`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/86e3a24361bf4c7ce4ea338cefc4763260d6cd61))
- Fix the automated merging ([`aff2ab1`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/aff2ab16c612fb29a820467f59c2e3aa4066ca27))

### Docs

- Formatting ([`17d1b12`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/17d1b12adc05e36c4fe8768b724c39ec85bdb3ab))

### Fix

- Bump clap ([`fc65cf3`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/fc65cf303868817b386af6f1e384c684dd9e85f9))

