### PR TITLE
fix: Update git-moves-together to v2.5.14

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.8.tar.gz"
-  sha256 "7de6c2a57c59deb7585c0d9bf7dcc757d011d1b7087c71b5f023b0b574a028b1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.8"
-    sha256 cellar: :any,                 catalina:     "41113a9ff7f22592029be4d25f3f16228f35e9dd659f21e95c65e9ede6969b07"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b24356401f48e65ed4ecffde26226854b2fd6bc326d663c71f476ae6a258b692"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.14.tar.gz"
+  sha256 "ea44feaa76cfbc7baeb35218c780634c9a81bba033a1a0eb328c3e0497b98344"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.14](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.14) (2022-01-04)

### Build

- Versio update versions ([`23c53a9`](https://github.com/PurpleBooth/git-moves-together/commit/23c53a9a009729533701b8a981f7ee167e6fbd39))

### Chore

- Remove bump ([`7f5c661`](https://github.com/PurpleBooth/git-moves-together/commit/7f5c6612812dd38e1601373725fda77d683ccb79))

### Fix

- Rotate keys ([`8dfe3e1`](https://github.com/PurpleBooth/git-moves-together/commit/8dfe3e14db90b38420438bae6faff88e343c4a35))
- Bump clap from 3.0.0 to 3.0.1 ([`0fd4ccf`](https://github.com/PurpleBooth/git-moves-together/commit/0fd4ccf625eddfb47142f72bdc626f12e5de3fa4))

