### PR TITLE
fix: Update git-mit to v5.12.14

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.13.tar.gz"
-  sha256 "2603858fd921a13e67121aa49c63e86413c17f77db7831c2f57d7c1bf3fa9e95"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.13"
-    sha256 cellar: :any,                 big_sur:      "89939e7648bf8c68bc220b6358a81ce8fc54d8e6e690545299f36b0efb0d9e31"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4765b1538eb9abdc8000d2328c07a4cee841b37f669a34f60b3c3a2afa9d5a4a"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.14.tar.gz"
+  sha256 "d0745fb43e246c6e8fdf70b4f1811ac366d88a36d1f0ff6454aaf6b84fccc465"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.14](https://github.com/PurpleBooth/git-mit/compare/...v5.12.14) (2022-01-04)

### Build

- Versio update versions ([`d7a2e34`](https://github.com/PurpleBooth/git-mit/commit/d7a2e34264e1774e64c4c0ceb3efd923f3decfb4))

### Chore

- Remove bump file ([`a7d9e27`](https://github.com/PurpleBooth/git-mit/commit/a7d9e27709c8e7c273103ededa14a25773704ae9))

### Fix

- Bump clap from 3.0.0 to 3.0.1 ([`46f176a`](https://github.com/PurpleBooth/git-mit/commit/46f176af33a9ddf9cbb01fa384a0854b43913f11))

