### PR TITLE
fix: Update git-mit to v5.12.15

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.14.tar.gz"
-  sha256 "d0745fb43e246c6e8fdf70b4f1811ac366d88a36d1f0ff6454aaf6b84fccc465"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.14"
-    sha256 cellar: :any,                 big_sur:      "7e444e142b614a591c9e1d5f8afcf04c09302e79e2b69c36630f1392f75a1268"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4d6977b39784b892be911c76b920e4a846d1191e32fe223840b744d8a0931821"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.15.tar.gz"
+  sha256 "9827ff87eba739975df0fa7fbb3361934174f3a308d53b895794784367e8e8b9"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.15](https://github.com/PurpleBooth/git-mit/compare/...v5.12.15) (2022-01-04)

### Build

- Versio update versions ([`b871f97`](https://github.com/PurpleBooth/git-mit/commit/b871f97bffbb243865a30f62475aa5cf863977d2))

### Fix

- Bump clap_complete from 3.0.0 to 3.0.1 ([`15b3be8`](https://github.com/PurpleBooth/git-mit/commit/15b3be8e1ec0a61ea47224a7651901891ddfe2b2))

