### PR TITLE
fix: Update hungry-distance to v0.1.17

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.16.tar.gz"
-  sha256 "63766c39bf1b99e8964a5d2b1bea450be05a4c0e6c3bdc0cf8d4bbc46740fa56"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.16"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6328414270fde94f57f48338b1e92f6f19219e49115b9fd67256bc7f3c0963e4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "84522d03b6966f0b68946b775ee703742c1a1d8ef6fb04d3685911773e016b92"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.17.tar.gz"
+  sha256 "8d37b404073fca1e712a05fb8c2407da1231287b9c6689937f14ad1582d11d43"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.17](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.17) (2022-01-04)

### Build

- Versio update versions ([`157d4f2`](https://github.com/PurpleBooth/hungry-distance/commit/157d4f26da310c44b159bfff0fb665595e71cabe))

### Fix

- Bump clap from 3.0.0 to 3.0.1 ([`f27f673`](https://github.com/PurpleBooth/hungry-distance/commit/f27f673d9b7fbdece56b8b997fe337ba1907bcac))

