### PR TITLE
fix: Update fast-conventional to v1.0.3

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.2.tar.gz"
-  sha256 "0b42519eacf08d8b86080e6432a526325bf7067d0cacd43a4b3dd86426dee204"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.2"
-    sha256 cellar: :any_skip_relocation, big_sur:      "9321607ff07618cdf6cc042e8c6d5e1ef0a577d04bfc40d49233410a5892e0c2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a0925b2bb2ec3fdc0ea258d5a88218107518ca39aeb38c64c5296a765de1f969"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.3.tar.gz"
+  sha256 "36901a82cee4f21a29ab4a8279bb1358a06cef49b49110970d7eb84d5fc058f1"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.3](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.3) (2022-01-04)

### Build

- Versio update versions ([`4018c1a`](https://github.com/PurpleBooth/fast-conventional/commit/4018c1a91ac7eb84c8aaafca1391334b959a8720))

### Chore

- Add deps as a type ([`b590a33`](https://github.com/PurpleBooth/fast-conventional/commit/b590a3329d17713f0daf97a8da65a9783e9763ca))

### Fix

- Bump clap from 3.0.0 to 3.0.2 ([`db812c6`](https://github.com/PurpleBooth/fast-conventional/commit/db812c6a77eade940499ff5dfcc9a0dc570d09dc))

