### PR TITLE
fix: Update fast-conventional to v1.0.4

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.2.tar.gz"
-  sha256 "0b42519eacf08d8b86080e6432a526325bf7067d0cacd43a4b3dd86426dee204"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.2"
-    sha256 cellar: :any_skip_relocation, big_sur:      "9321607ff07618cdf6cc042e8c6d5e1ef0a577d04bfc40d49233410a5892e0c2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a0925b2bb2ec3fdc0ea258d5a88218107518ca39aeb38c64c5296a765de1f969"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.4.tar.gz"
+  sha256 "d505a5db113b652abadd114895a09585177693ed88a7b90a7091570bf74d691a"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.4](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.4) (2022-01-04)

### Build

- Versio update versions ([`bc75ee5`](https://github.com/PurpleBooth/fast-conventional/commit/bc75ee54832a81fdbf8a6824b765cdb2e3a7640b))

### Fix

- Bump clap_complete from 3.0.0 to 3.0.2 ([`ebee95d`](https://github.com/PurpleBooth/fast-conventional/commit/ebee95d39d29ed222ba7fb83d6e03dd2b434d9bf))

