### PR TITLE
fix: Update whatismyip to v0.9.29

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.28.tar.gz"
-  sha256 "48b0aa819c70857e583464fb1c20705892aa35dec2f84fce6c4977e600fcfb8b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.28"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0c26cf51eda6257e4844d7d5c0be98458025b58001718527b0890f1db8e33e9e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5593cc4f035bf341ebc348997712680c9d9069c1615fefdddca0e36e0b975a42"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.29.tar.gz"
+  sha256 "526e67d059e45932e7bf30f04269a7a01b34a02651ced48c3262422525fefdc6"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.29](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.29) (2022-01-04)

### Build

- Versio update versions ([`52dba56`](https://github.com/PurpleBooth/whatismyip/commit/52dba5617d2118ff4888b7a90ac2de6450abf84f))

### Fix

- Bump clap from 3.0.0 to 3.0.1 ([`59ba8d3`](https://github.com/PurpleBooth/whatismyip/commit/59ba8d3d8a9cf664191896bd9eb98d9fb8a03445))
- Bump clap from 3.0.1 to 3.0.3 ([`aac5035`](https://github.com/PurpleBooth/whatismyip/commit/aac503520e943f375339329f74f90257b966cdee))

