### PR TITLE
fix: Update ellipsis to v0.6.27

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.26.tar.gz"
-  sha256 "b7351a0e3b125d7b45714570bd460fa21a61168ddd86e088cc801e367b091a47"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.26"
-    sha256 cellar: :any_skip_relocation, big_sur:      "9f8a2b7fea0840c8978055d3bfb4f53da2a1fbeee7d7bba780fe75132210cc6c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "43d945138a28f2ada7dfed14f35d07e76cb2b926b291af8eb10fee7d27384257"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.27.tar.gz"
+  sha256 "51885f1f9b055ad664fbe6e14625bde2a1a765c01689c051cc3620675852be18"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.27](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.27) (2022-01-04)

### Build

- Versio update versions ([`912fb82`](https://github.com/PurpleBooth/ellipsis/commit/912fb82f7a66e38891fb2b8e6ef60cff7f35c982))

### Fix

- Bump clap from 3.0.1 to 3.0.4 ([`9affd01`](https://github.com/PurpleBooth/ellipsis/commit/9affd01fbb6ce854d2097e4fef1472d2a3d14127))

