### PR TITLE
fix: Update game-of-life to v1.53.48

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.47.tar.gz"
-  sha256 "f31401a785efa6fda5e4c1e9270f1b1942c7316931ada08911b7e12c00e8e6d7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.47"
-    sha256 cellar: :any_skip_relocation, big_sur:      "823d3d52ddcc33a99aeed970c31db60b020469736f50443eb90d5fd1a7f143a1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ac3cc354c0fbd1b4b397b961ebff1eed0ca10d30abd1c8f63d9a3603039c4a94"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.48.tar.gz"
+  sha256 "fef441422caea466e6a912bd6887640b706ebbd303eaa7a8a62c43a6018acbc2"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.48](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.48) (2022-01-05)

### Build

- Versio update versions ([`d972707`](https://github.com/PurpleBooth/game-of-life/commit/d972707ebc111b90e4dfffdbfbe83e39bdbf5243))

### Fix

- Bump clap from 3.0.1 to 3.0.4 ([`e3228de`](https://github.com/PurpleBooth/game-of-life/commit/e3228de179fb7b7a8c3ad8ce19f462a0e4b8f4c4))

