### PR TITLE
fix: Update ed-system-search to v1.1.15

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.14.tar.gz"
-  sha256 "96b1041ae8e40ad5c3fcd9fbbcd345d6e6be914fa1afc6da687d2d90029b74c0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.14"
-    sha256 cellar: :any_skip_relocation, big_sur:      "1edffa8521f3f0d6f52b2f4fe96bbd4ef37646101e2727a0118ebf88c82e0a89"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c8704e0f5eebaea7ada4328905c7e45272319d1ff27adddecc5f8255a4598a36"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.15.tar.gz"
+  sha256 "b97202dc8bd1ba12ae1ad304d3fd0184dfc224e9c4f7588bbd160ba29b89b7c7"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.15](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.15) (2022-01-05)

### Build

- Versio update versions ([`b331284`](https://github.com/PurpleBooth/ed-system-search/commit/b3312848bf6532bda5907795168a5829021f4209))

### Fix

- Bump clap from 3.0.1 to 3.0.4 ([`28ac12c`](https://github.com/PurpleBooth/ed-system-search/commit/28ac12cfb52d367496c4a3b9d9d49d116175cb7f))

