### PR TITLE
fix: Update hungry-distance to v0.1.18

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.17.tar.gz"
-  sha256 "8d37b404073fca1e712a05fb8c2407da1231287b9c6689937f14ad1582d11d43"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.17"
-    sha256 cellar: :any_skip_relocation, big_sur:      "4423da3464be240a0f011ea94c503967080d5a67692a960ad15cc104b7613640"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "03aed30c09a11583ff56a775c9dcc689ba66387e325d221e28e37d9950841a46"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.18.tar.gz"
+  sha256 "600592c296908b95922103200af92fb061d1b59a4963a44061e3043ab73ec52e"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.18](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.18) (2022-01-05)

### Build

- Versio update versions ([`c9cf88d`](https://github.com/PurpleBooth/hungry-distance/commit/c9cf88d6d32f4f00cc40500d55654b6ce22d8709))

### Fix

- Bump clap from 3.0.1 to 3.0.4 ([`9b5672d`](https://github.com/PurpleBooth/hungry-distance/commit/9b5672d16dbd66718638043fd618160386ed73f7))

