### PR TITLE
fix: Update fast-conventional to v1.0.5

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.3.tar.gz"
-  sha256 "36901a82cee4f21a29ab4a8279bb1358a06cef49b49110970d7eb84d5fc058f1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.3"
-    sha256 cellar: :any_skip_relocation, big_sur:      "c9bd048ec9a946dbc1099f61b63e5d488e908a2be16169cadbb168aa29e01ce9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "58897c14f295fe3f5e05cef47c791b29c3017e2c49e2257925234c66627bcd92"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.5.tar.gz"
+  sha256 "97c2f7b52cf8cbe47ab9db3ba5aa7589d70341e9973a76851bd8e1cb69ab7f8b"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.5](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.5) (2022-01-05)

### Build

- Versio update versions ([`51ad4b8`](https://github.com/PurpleBooth/fast-conventional/commit/51ad4b80906eeaa917cae30c28fe1c11e8b40ba0))

### Fix

- Bump clap from 3.0.2 to 3.0.4 ([`d8f51e4`](https://github.com/PurpleBooth/fast-conventional/commit/d8f51e49eb76316f6f3730339f3d838bfe7ac3cb))

