### PR TITLE
fix: Update whatismyip to v0.9.30

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.29.tar.gz"
-  sha256 "526e67d059e45932e7bf30f04269a7a01b34a02651ced48c3262422525fefdc6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.29"
-    sha256 cellar: :any_skip_relocation, big_sur:      "9bc473ee4b5b9197922ea2256788063d0825bdf1c6729abeeee8fe8cc1a79e9a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1cd8fd3441dff53475adf23e9512b6c7ff5dda5ef28bce9096b5fe40cf99d457"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.30.tar.gz"
+  sha256 "cd22ca40f3d9b8044ce74375e646e4efade6fb4faa31661ffa569409f4fc265f"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.30](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.30) (2022-01-05)

### Build

- Versio update versions ([`56a01f3`](https://github.com/PurpleBooth/whatismyip/commit/56a01f3815fb84ab2a2bcd2ed7caf0673db2102a))

### Fix

- Bump clap from 3.0.3 to 3.0.4 ([`ce32889`](https://github.com/PurpleBooth/whatismyip/commit/ce328891fa90ec0756b4c461265430bf9123e0e5))

