### PR TITLE
fix: Update game-of-life to v1.53.49

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.48.tar.gz"
-  sha256 "fef441422caea466e6a912bd6887640b706ebbd303eaa7a8a62c43a6018acbc2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.48"
-    sha256 cellar: :any_skip_relocation, big_sur:      "f286f5ce26db59cc03acd5e5ecf5f2b7a700a93ef016d46a11b0f536a9a3800e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "05bc61ab3029abe4eed89ceea4f0b5979397e5358dbedfc832e9cf5eef5db775"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.49.tar.gz"
+  sha256 "07dc2a842c61c0cb930bc96f1e6f1bd43d82e455f98fe95d7e8c704b21384cfb"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.49](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.49) (2022-01-06)

### Build

- Versio update versions ([`0842138`](https://github.com/PurpleBooth/game-of-life/commit/08421380e7e05cc1471fc026f21e78997967f74a))

### Fix

- Bump clap from 3.0.4 to 3.0.5 ([`71e69f1`](https://github.com/PurpleBooth/game-of-life/commit/71e69f12b47f5246c5b9d9e5e66c1b76aee0e13d))

