### PR TITLE
fix: Update ed-system-search to v1.1.16

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.15.tar.gz"
-  sha256 "b97202dc8bd1ba12ae1ad304d3fd0184dfc224e9c4f7588bbd160ba29b89b7c7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.15"
-    sha256 cellar: :any_skip_relocation, big_sur:      "25f6b3dd573792660c88df8543c5bde6d3b2c07443361ab4109bfa0701da6ea4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8e6b65d005e1d599783e4c754f00125821724603265e72d56bbdef06f09325e3"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.16.tar.gz"
+  sha256 "20ff69922f71dd3492f6dac036a258793f8ccf1f5066fb8f31467727aa414db6"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.16](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.16) (2022-01-06)

### Build

- Versio update versions ([`cbfc96b`](https://github.com/PurpleBooth/ed-system-search/commit/cbfc96bf1df094fed84c56e7d27d245d91f0e9b1))

### Fix

- Bump clap from 3.0.4 to 3.0.5 ([`0895879`](https://github.com/PurpleBooth/ed-system-search/commit/089587960da6b3741606ac99b0199531941cef69))

