### PR TITLE
fix: Update git-moves-together to v2.5.15

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.14.tar.gz"
-  sha256 "ea44feaa76cfbc7baeb35218c780634c9a81bba033a1a0eb328c3e0497b98344"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.14"
-    sha256 cellar: :any,                 big_sur:      "66b65bec678fd555cfd1c9c144c4f396e5bf204cb2f276edd1a78e6303eea18a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a63960464bfcfb82bf2250d71d878eb446ac4210e4e8bc975891d42a5a55519c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.15.tar.gz"
+  sha256 "777fd2dd6325962791d02d92aa6ed89446a00936b62ee0f9a413c2ab2ffe83de"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.15](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.15) (2022-01-06)

### Build

- Versio update versions ([`9ee48fc`](https://github.com/PurpleBooth/git-moves-together/commit/9ee48fcca18e3332b018a81dbfe5408cd0704978))

### Fix

- Bump clap from 3.0.1 to 3.0.4 ([`b11451f`](https://github.com/PurpleBooth/git-moves-together/commit/b11451f47b24ab7a7f29b349ec5687e228fcc5ee))
- Bump clap from 3.0.4 to 3.0.5 ([`dc6b7e7`](https://github.com/PurpleBooth/git-moves-together/commit/dc6b7e702ebaa8515bcf62f3c8837b37a6753fbd))

