### PR TITLE
fix: Update git-mit to v5.12.17

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.16.tar.gz"
-  sha256 "d329af5fe6a2289513c3e90e2d86a0a0cea17f84f20f4b63242a38f0a743a78e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.16"
-    sha256 cellar: :any,                 big_sur:      "0d33e45726118006a96d1caf91bd3b39502dc58fdef2b20ed268cc9cfe7b2180"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d46b6895410e05716f3d5c8884983801622b679396ac31897693f79dc75adb77"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.17.tar.gz"
+  sha256 "a2cebb2e6d061a694e2ed1e1a2bb753b50bf5ce5358d231944a82ba10dc53017"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.17](https://github.com/PurpleBooth/git-mit/compare/...v5.12.17) (2022-01-06)

### Build

- Versio update versions ([`778a808`](https://github.com/PurpleBooth/git-mit/commit/778a808fa99dc543a5496e5087cace1823d93f7f))

### Fix

- Bump clap from 3.0.4 to 3.0.5 ([`ceb1809`](https://github.com/PurpleBooth/git-mit/commit/ceb1809912ffffbe82020c40f431827d5835c9a2))

