### PR TITLE
fix: Update hungry-distance to v0.1.19

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.18.tar.gz"
-  sha256 "600592c296908b95922103200af92fb061d1b59a4963a44061e3043ab73ec52e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.18"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0949498acbd955aa396b4488a5196321e7516b3e91654819d362a86f7cb6c975"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d09c4f79ef4d36ad3e06c5354b1059d01f353128ba3a0b567693949398d0a462"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.19.tar.gz"
+  sha256 "ef0ac546e3730838b8b60ec70a1919fa3ba43f8e941e572eb16b1a4dad2d9bff"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.19](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.19) (2022-01-06)

### Build

- Versio update versions ([`6d2d543`](https://github.com/PurpleBooth/hungry-distance/commit/6d2d5432d7d7164739535ce0ceafa57102edae82))

### Fix

- Bump clap from 3.0.4 to 3.0.5 ([`118c49f`](https://github.com/PurpleBooth/hungry-distance/commit/118c49fe2230e1099d2b4f333ef7b5065cf84445))

