### PR TITLE
fix: Update whatismyip to v0.9.31

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.30.tar.gz"
-  sha256 "cd22ca40f3d9b8044ce74375e646e4efade6fb4faa31661ffa569409f4fc265f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.30"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6adb563097b555725a892b1bd482247489d76de5ad27b9dc6bf19e608311414a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "517a4215ffe4ec50a59d6f6f3316009c0b22fc9b50ed5c42d66904e66373e1d1"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.31.tar.gz"
+  sha256 "ef5945e1dad49c96d18f6076d41f9335e69df4f0cd7b9772dcae9bfe12b74c01"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.31](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.31) (2022-01-06)

### Build

- Versio update versions ([`7f22859`](https://github.com/PurpleBooth/whatismyip/commit/7f22859d8661e74492ffab2d41c598dbf7235120))

### Fix

- Bump clap from 3.0.4 to 3.0.5 ([`a770398`](https://github.com/PurpleBooth/whatismyip/commit/a77039824333e9a017813e88d498b4bc2706e4c0))

