### PR TITLE
fix: Update fix-compaudit to v0.46.69

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.68.tar.gz"
-  sha256 "f83a44c3e1b2af4aca0c27fdb1ae8fd226fbd457fb74fd9baf46508a2fb0d589"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.68"
-    sha256 cellar: :any_skip_relocation, big_sur:      "18226e1c3f31a9942e421a2854dd9112644efc254592f63bc0c2e6dc697d605a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "64a531f904fbf485b97a3aa43271640d83f8eca2f3fe4be959e17c7b1034ad67"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.69.tar.gz"
+  sha256 "9bc44c393f420e30073b9a0072b3e157f8e9377028a0711e8fd4edaa4ee11988"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.69](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.69) (2022-01-08)

### Build

- Versio update versions ([`1509ac5`](https://github.com/PurpleBooth/fix-compaudit/commit/1509ac566cd43917a12a6c30189bd3a53a8e9481))

### Ci

- Fix the merge automation ([`100a581`](https://github.com/PurpleBooth/fix-compaudit/commit/100a5810af39d47602874da6be24a30733133fa8))

### Fix

- Bump clap from 3.0.0 to 3.0.5 ([`567f499`](https://github.com/PurpleBooth/fix-compaudit/commit/567f499a953408660cb533e0aa10b2b21a47cabe))

