### PR TITLE
fix: Update ed-system-search to v1.1.17

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.16.tar.gz"
-  sha256 "20ff69922f71dd3492f6dac036a258793f8ccf1f5066fb8f31467727aa414db6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.16"
-    sha256 cellar: :any_skip_relocation, big_sur:      "ceebc07744f52fc9c4e68a4441d84786e9beb0a63f92dfdb71512fe280a7bc4e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "568cb05ee36cad5160f3fd9ca60cfb634e70268115df6d5dc8884c02a08fcb13"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.17.tar.gz"
+  sha256 "47d33f6b87175704b44a4a90afe10321a974611735fada7d9bf0f0b533438664"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.17](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.17) (2022-01-10)

### Build

- Versio update versions ([`97afc5e`](https://github.com/PurpleBooth/ed-system-search/commit/97afc5e7931132a4a82815298e78237e9f4d24ea))

### Fix

- Bump miette from 3.2.0 to 3.3.0 ([`15c0c4a`](https://github.com/PurpleBooth/ed-system-search/commit/15c0c4aea76090c5709632cc33c95faef140f9af))

