### PR TITLE
fix: Update git-moves-together to v2.5.16

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.15.tar.gz"
-  sha256 "777fd2dd6325962791d02d92aa6ed89446a00936b62ee0f9a413c2ab2ffe83de"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.15"
-    sha256 cellar: :any,                 big_sur:      "0e696c3339367269c2127e23fc85c6e8509a24bf7fea5db4a2f57de18e4b9395"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "26f711b3adc25b09e32f9add919bf691c1c558a93104f4fce8869350d2ad9962"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.16.tar.gz"
+  sha256 "c64c1d630af3c718a070c5a00646a18a58fdd5384e96b5033729a25765b1f445"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.16](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.16) (2022-01-10)

### Build

- Versio update versions ([`149dda8`](https://github.com/PurpleBooth/git-moves-together/commit/149dda896924343f675f85020f8c8fd757225de1))

### Fix

- Bump tempfile from 3.2.0 to 3.3.0 ([`3b55df5`](https://github.com/PurpleBooth/git-moves-together/commit/3b55df519f91788c24ec7900719ecf82a57f53fe))

