### PR TITLE
fix: Update fix-compaudit to v0.46.70

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.69.tar.gz"
-  sha256 "9bc44c393f420e30073b9a0072b3e157f8e9377028a0711e8fd4edaa4ee11988"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.69"
-    sha256 cellar: :any_skip_relocation, big_sur:      "fb0be2e6b48194dabe0ae90b992ac5b09310c50580103ed34cefd51466a843e7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8c4e881bd84088299143b2e0311b726f63f9537aab601e366968b64385e76224"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.70.tar.gz"
+  sha256 "9d777fd2b2f266f5058be4a5b81af61ecc8945cf5ee6137e7e50e66cb0c50c89"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.70](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.70) (2022-01-10)

### Build

- Versio update versions ([`ed53164`](https://github.com/PurpleBooth/fix-compaudit/commit/ed531642e005a2a9acc212aa8be16da57726ed11))

### Fix

- Bump tempfile from 3.2.0 to 3.3.0 ([`9a0840d`](https://github.com/PurpleBooth/fix-compaudit/commit/9a0840da86656c3b544006dc31f5e9bf23f92e1a))

