### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.36

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.35.tar.gz"
-  sha256 "68793736f536781d9e5e3a7bedf1a9e5d37767fd98473ebeb627a5b26ba6e79c"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.36.tar.gz"
+  sha256 "31184a740438e22965c2eb76f69c6c2e64eb9b29080761b3f9ccdac01cda6d43"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.35"
-    sha256 cellar: :any_skip_relocation, big_sur:      "5df1b3e9f29cdc292f14aebae6abf209674a1a4f0bebec1a668a3aca6148b1da"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4fdd40f27c7db8b07ec64e460518957e455ab2eb7f8626df9f3db012cdaaabb2"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.36](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.36) (2022-01-10)

### Build

- Versio update versions ([`278c032`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/278c03206b2e48fff47a6cdd9529c85074ec009c))

### Fix

- Bump tempfile from 3.2.0 to 3.3.0 ([`10d2387`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/10d2387429066f77639d4d647ea6f6c5a75ae528))
- Bump clap from 3.0.0 to 3.0.5 ([`4f64e99`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/4f64e994028645d93f22a4b7549e07006fa50d9a))

