### PR TITLE
fix: Update git-mit to v5.12.19

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.18.tar.gz"
-  sha256 "3c31627dace2b9decadf0d2161651cfed092cffff8036d97fbadc62e2216c7d7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.18"
-    sha256 cellar: :any,                 big_sur:      "1052ee0344b90727a99ae16d743ddd25e8ac0ef27f9740fae72d2850ad8ee3e9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "195952735c0c9c1f2322ef769f74d89dc7c3243b5d1aaf607683bbe0f5e72142"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.19.tar.gz"
+  sha256 "7fca1edf31a4f537b8e263be5e30afe2612171c44defb374cc17094ff08f54e0"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.19](https://github.com/PurpleBooth/git-mit/compare/...v5.12.19) (2022-01-10)

### Build

- Versio update versions ([`b8c3d45`](https://github.com/PurpleBooth/git-mit/commit/b8c3d45279dc3cf91cb1961935dcb1c626d5ef97))

### Fix

- Bump miette from 3.2.0 to 3.3.0 ([`3cc64b5`](https://github.com/PurpleBooth/git-mit/commit/3cc64b5e7c929894864f17d55473d858a512c777))

