### PR TITLE
fix: Update game-of-life to v1.53.50

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.49.tar.gz"
-  sha256 "07dc2a842c61c0cb930bc96f1e6f1bd43d82e455f98fe95d7e8c704b21384cfb"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.49"
-    sha256 cellar: :any_skip_relocation, big_sur:      "956312dc20edb939744017d4899ed0da1d0f282c25244c56f509fd2664db568b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "01e8e3c3af033542a734b7571c44e0d43e7ef0dd422bf16f48a28f500b8da62a"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.50.tar.gz"
+  sha256 "b1f8ff637963bca7094253a1786dccf3cf2caf8aa13413c04ccd2e8a82e27ed8"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.50](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.50) (2022-01-11)

### Build

- Versio update versions ([`edae443`](https://github.com/PurpleBooth/game-of-life/commit/edae4435e5869338952d0bca5a348d4e50cf9a23))

### Fix

- Bump clap from 3.0.5 to 3.0.6 ([`53d6725`](https://github.com/PurpleBooth/game-of-life/commit/53d6725551131ae07809b45081110e99d922a0bd))

