### PR TITLE
fix: Update fix-compaudit to v0.46.71

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.70.tar.gz"
-  sha256 "9d777fd2b2f266f5058be4a5b81af61ecc8945cf5ee6137e7e50e66cb0c50c89"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.70"
-    sha256 cellar: :any_skip_relocation, big_sur:      "abe1996120b8624b5363c8d997fa47602792daa4bffe3fdb07fd6a9abe065d2d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "cd899ea2652b64daa17af3370d2e4383c1bcf857494721be23c490fbb208aec8"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.71.tar.gz"
+  sha256 "d071d3e01c2c724ffe499be0ec663255112856dd820e1cdff9068d2bcea73d61"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.71](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.71) (2022-01-11)

### Build

- Versio update versions ([`6cd12a3`](https://github.com/PurpleBooth/fix-compaudit/commit/6cd12a355d84db0a5a36e1ececfc6d725145ac9b))

### Fix

- Bump clap from 3.0.5 to 3.0.6 ([`e3760c1`](https://github.com/PurpleBooth/fix-compaudit/commit/e3760c1451f6acede384f5db61e2b4bf81baf1b2))

