### PR TITLE
fix: Update ellipsis to v0.6.28

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.27.tar.gz"
-  sha256 "51885f1f9b055ad664fbe6e14625bde2a1a765c01689c051cc3620675852be18"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.27"
-    sha256 cellar: :any_skip_relocation, big_sur:      "1d928f1d333d2f5567124ea685ad66bdafc101be13f54e5cc5a8f932f1d97710"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "fe8404099bf2af448e3cd8d7789ea41a55ea2ac7d112b95815f94cf0f3aea047"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.28.tar.gz"
+  sha256 "b857c4c1b4913538294b82ac054d8ce344923822ed78088c1d4035d6aee98e3f"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.28](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.28) (2022-01-11)

### Build

- Versio update versions ([`463e911`](https://github.com/PurpleBooth/ellipsis/commit/463e9112fa9a4b24bfe187959bad8ac76df6bda7))

### Fix

- Bump clap from 3.0.4 to 3.0.5 ([`3ee2897`](https://github.com/PurpleBooth/ellipsis/commit/3ee28972ebe24ed54bd345e11453a473631072fe))
- Bump tempfile from 3.2.0 to 3.3.0 ([`e452cb9`](https://github.com/PurpleBooth/ellipsis/commit/e452cb9bbdb9f28715c9efd674e8d31ea2e21b5f))

