### PR TITLE
fix: Update ed-system-search to v1.1.18

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.17.tar.gz"
-  sha256 "47d33f6b87175704b44a4a90afe10321a974611735fada7d9bf0f0b533438664"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.17"
-    sha256 cellar: :any_skip_relocation, big_sur:      "f3f79c292781beaa1636d07d1a0172d58c9fbfc982cc14fd1693a4da26bdd04d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a67a5559e5b06a22d60050b0467efec0f54028e94d4f3783ab6d33d972b8f6ea"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.18.tar.gz"
+  sha256 "a24eda645e330d887eed7e208d23de10f2c2c40cf8cbbcaabb6984554dcf3c53"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.18](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.18) (2022-01-11)

### Build

- Versio update versions ([`bf1dd86`](https://github.com/PurpleBooth/ed-system-search/commit/bf1dd86413196acc91ded7e3fa8827f9dc50959a))

### Fix

- Bump clap from 3.0.5 to 3.0.6 ([`2499efa`](https://github.com/PurpleBooth/ed-system-search/commit/2499efaaa2d261870fc6b7f362ff96d931f782bc))

