### PR TITLE
fix: Update git-moves-together to v2.5.17

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.16.tar.gz"
-  sha256 "c64c1d630af3c718a070c5a00646a18a58fdd5384e96b5033729a25765b1f445"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.16"
-    sha256 cellar: :any,                 big_sur:      "4f3dd8877e522d234f4e8621d9f909478076da1a33568821f9e773547ff4b1a8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d66c192758cf7e90ba3742709834dc1af1bde5d73e9e2ee429d70e47482324b5"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.17.tar.gz"
+  sha256 "dbfd663eaefdd174cb55f79a1893d147cf47155642f25e2a660641b41d342818"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.17](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.17) (2022-01-13)

### Build

- Versio update versions ([`97c66f7`](https://github.com/PurpleBooth/git-moves-together/commit/97c66f7bf650e32e5cf230ea0dea91dc7061a593))

### Fix

- Bump miette from 3.2.0 to 3.3.0 ([`a539dfe`](https://github.com/PurpleBooth/git-moves-together/commit/a539dfeab70de6a934dbf7106627b22c1bc56945))
- Bump clap from 3.0.5 to 3.0.6 ([`0a094dc`](https://github.com/PurpleBooth/git-moves-together/commit/0a094dc74b2cb059b91dea299a5fffd5dcdaae82))
- Bump clap from 3.0.6 to 3.0.7 ([`ed1ad79`](https://github.com/PurpleBooth/git-moves-together/commit/ed1ad7998f62ca77545b8a78e8cc6389fe7d7560))

