### PR TITLE
fix: Update git-mit to v5.12.22

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.21.tar.gz"
-  sha256 "1b43d3ca1ee0c014a0464ec28daa376443b51db18f2453e8f4fc1d4481322315"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.21"
-    sha256 cellar: :any,                 big_sur:      "1e0483bc151f298308e50663b1098add684c336f23e4ac3d406153f66c485a08"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7fddc7b8052593feabcca47ecba97eb533c604b20118ee595e87609e607917dd"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.22.tar.gz"
+  sha256 "eea98bc4d09ead52bb823394e14cc876b6c4b2796ea17c490ee89c1a656f7f7a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.22](https://github.com/PurpleBooth/git-mit/compare/...v5.12.22) (2022-01-14)

### Build

- Versio update versions ([`3cb8b46`](https://github.com/PurpleBooth/git-mit/commit/3cb8b46be084daae71268e32a3a5bb341077d57b))

### Fix

- Bump rust from 1.57.0 to 1.58.0 ([`c1c0831`](https://github.com/PurpleBooth/git-mit/commit/c1c08313ce2b3d17ec9fa4757876ad801dc90506))

