### PR TITLE
fix: Update fast-conventional to v1.0.6

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.5.tar.gz"
-  sha256 "97c2f7b52cf8cbe47ab9db3ba5aa7589d70341e9973a76851bd8e1cb69ab7f8b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.5"
-    sha256 cellar: :any_skip_relocation, big_sur:      "deba3f5c4f7014d377902f5cee62b514882f6a5c102640d5ec21936dfb8ad8ec"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "07863e7ba08bbe5102c4c5038146564618c532f142bcd057522b8d6c59d463ae"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.6.tar.gz"
+  sha256 "e900ac74f6a617e87bdcfe63928b866908a399a45dd5f66dc173812f13cfbd63"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.6](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.6) (2022-01-16)

### Build

- Versio update versions ([`dd64a33`](https://github.com/PurpleBooth/fast-conventional/commit/dd64a33b562ea863c1a196df32455dc0a638616d))

### Fix

- Bump clap from 3.0.4 to 3.0.5 ([`1b77837`](https://github.com/PurpleBooth/fast-conventional/commit/1b7783762c3f2765d8f0963211c48ccf0e044b42))
- Bump miette from 3.2.0 to 3.3.0 ([`bd0dc37`](https://github.com/PurpleBooth/fast-conventional/commit/bd0dc3708cc7ffdc1157ce9911825e65af2ae540))
- Bump clap_complete from 3.0.2 to 3.0.3 ([`cb4bae6`](https://github.com/PurpleBooth/fast-conventional/commit/cb4bae674958acd15dee3200356c9ce6ee8c16c7))

