### PR TITLE
fix: Update whatismyip to v0.9.32

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.31.tar.gz"
-  sha256 "ef5945e1dad49c96d18f6076d41f9335e69df4f0cd7b9772dcae9bfe12b74c01"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.31"
-    sha256 cellar: :any_skip_relocation, big_sur:      "c7f0e659de679733d84bac62c380af6347b58e64968720ce88a312848cfa1bac"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8f663f6e726db9790277606273f2d86545e84462a119ed65b68a540aa38cf4c4"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.32.tar.gz"
+  sha256 "48893e51c08a7ebcc253df990477d86d9444ba825776d306cd776db388320fd5"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.32](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.32) (2022-01-16)

### Build

- Versio update versions ([`62b77e0`](https://github.com/PurpleBooth/whatismyip/commit/62b77e0f3161a7c07d25ca4d9d63664c7e61fe87))

### Fix

- Bump clap from 3.0.5 to 3.0.7 ([`663b5b1`](https://github.com/PurpleBooth/whatismyip/commit/663b5b19780e3e848890978a35dbf770616efefc))

