### PR TITLE
fix: Update hungry-distance to v0.1.20

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.19.tar.gz"
-  sha256 "ef0ac546e3730838b8b60ec70a1919fa3ba43f8e941e572eb16b1a4dad2d9bff"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.19"
-    sha256 cellar: :any_skip_relocation, big_sur:      "35f5df2b3062ba7a923c5af4960c7c42c5b1c76f22d2b2f2b563043e0a8dd9e0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b3b63acb97b2aaa7d71632ac916e5d742d6e4a8431bf2f77a327a0ab33aa2999"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.20.tar.gz"
+  sha256 "ca305339c7d97d5c2a3eafa47da8ad94910fee9f047fa7d7ff5468c31c460d5a"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.20](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.20) (2022-01-16)

### Build

- Versio update versions ([`f75df9b`](https://github.com/PurpleBooth/hungry-distance/commit/f75df9b59672aa98765ccb14b54814671685539e))

### Fix

- Bump clap from 3.0.5 to 3.0.6 ([`44dee5a`](https://github.com/PurpleBooth/hungry-distance/commit/44dee5affa0ed381fd1716d9ad7bad6f3d8abf79))
- Bump clap from 3.0.6 to 3.0.7 ([`db0bca7`](https://github.com/PurpleBooth/hungry-distance/commit/db0bca7bf5dfba0ecc015d274ae262a6646fc675))

