### PR TITLE
fix: Update fix-compaudit to v0.46.72

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.71.tar.gz"
-  sha256 "d071d3e01c2c724ffe499be0ec663255112856dd820e1cdff9068d2bcea73d61"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.71"
-    sha256 cellar: :any_skip_relocation, big_sur:      "f5ecf229e7d0d32323e7c62d47b497ab9984349abff63edac97d3073435e11e1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e696e9a6ebb2bc70adef585ba3024c8c7b087598e29f6a6bba30b872e23b9a4c"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.72.tar.gz"
+  sha256 "69453b400f73172735755f7be1edf6750cc33a9846ebc61a6c018fdbc415a1d3"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.72](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.72) (2022-01-16)

### Build

- Versio update versions ([`dfbdd58`](https://github.com/PurpleBooth/fix-compaudit/commit/dfbdd583919c2ce0413937c04a8cc9e8c368a68b))

### Fix

- Bump clap from 3.0.6 to 3.0.7 ([`a080bd8`](https://github.com/PurpleBooth/fix-compaudit/commit/a080bd83f428af3cbc40d7f2b14c54644c21ef5f))

