### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.37

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.36.tar.gz"
-  sha256 "31184a740438e22965c2eb76f69c6c2e64eb9b29080761b3f9ccdac01cda6d43"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.37.tar.gz"
+  sha256 "910a945303abddf05add436799a4704f97eced62dc36ca2a363b6bbd661b6b09"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.36"
-    sha256 cellar: :any_skip_relocation, big_sur:      "5da5ba097c5c417302be791cf1e15cb0398a05890177cb3b2a6ffc059f00b98a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b9cef57dc507f1a42cbeda83e8f0f4090fb43466a8cdf67fcb2963bef9a11f76"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.37](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.37) (2022-01-16)

### Build

- Versio update versions ([`df736a8`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/df736a80a8341dfe1c79205d484bee119a419d31))

### Fix

- Bump clap from 3.0.5 to 3.0.6 ([`6cad798`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/6cad79899438c10e09949b0a6846ea4011c5733f))
- Bump clap from 3.0.6 to 3.0.7 ([`5e9d234`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/5e9d234318bfa21674d47c24b11d67be4e73883d))

