### PR TITLE
fix: Update ed-system-search to v1.1.19

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.18.tar.gz"
-  sha256 "a24eda645e330d887eed7e208d23de10f2c2c40cf8cbbcaabb6984554dcf3c53"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.18"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6654ae6c639d0f8583473c50351cd80d2c2a040534d949f9cc01adf9484c9350"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "071f0e55db0827031fdd04cdfd99f043595de38303e5d1a12787efac1d9ad663"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.19.tar.gz"
+  sha256 "a9f8bd8882e29ddf3f1d8cbc8b3e6873fce53f2df580de768a0c79da36df47c7"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.19](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.19) (2022-01-16)

### Build

- Versio update versions ([`b7382ce`](https://github.com/PurpleBooth/ed-system-search/commit/b7382ce56c5e498e7e92892a5ef0f6102e4880da))

### Fix

- Bump clap from 3.0.6 to 3.0.7 ([`c451209`](https://github.com/PurpleBooth/ed-system-search/commit/c45120907b4e0dfb49434af84666d3dadf62df2e))

