### PR TITLE
fix: Update ed-system-search to v1.1.20

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.19.tar.gz"
-  sha256 "a9f8bd8882e29ddf3f1d8cbc8b3e6873fce53f2df580de768a0c79da36df47c7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.19"
-    sha256 cellar: :any_skip_relocation, big_sur:      "51c65a21c8da30fb83daba376d3a6ee2bab3e7c858752243ebf7aced04e435f8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b362d56dc4d79c780148d33a22a0ecdd4d460075c05ae15844eea38a429eea30"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.20.tar.gz"
+  sha256 "8c7a5ee03bf6c7a64ab34ab876267802def1f652871d7dc42b7673f0d30e1afc"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.20](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.20) (2022-01-17)

### Build

- Versio update versions ([`b0f235f`](https://github.com/PurpleBooth/ed-system-search/commit/b0f235fa9ae780004afdab950f5f37a027408df5))

### Fix

- Bump serde_json from 1.0.74 to 1.0.75 ([`22a041f`](https://github.com/PurpleBooth/ed-system-search/commit/22a041f3f16b0f7b8cc77ddb86aa30305c8d6ad3))

