### PR TITLE
fix: Update game-of-life to v1.53.51

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.50.tar.gz"
-  sha256 "b1f8ff637963bca7094253a1786dccf3cf2caf8aa13413c04ccd2e8a82e27ed8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.50"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0f513ea291f602a46de413445e4058929fbe3b71473d759eeafd747c288bae04"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1e147f5b1f82a63e4184048f308c263423cb49dd1a0db76a4667d5d579dd4ba3"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.51.tar.gz"
+  sha256 "02b0868bfce6e8e3867666fb6769cbeaf9023f4f818cd82c557b8beb6485e7f2"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.51](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.51) (2022-01-18)

### Build

- Versio update versions ([`5cbcc2a`](https://github.com/PurpleBooth/game-of-life/commit/5cbcc2a0498211f4d5a6f37e8534b3496d3248a1))

### Fix

- Bump clap from 3.0.6 to 3.0.7 ([`5147f03`](https://github.com/PurpleBooth/game-of-life/commit/5147f03f7d9eff1ec550e2ae49a0e4bd5b1af224))
- Bump clap from 3.0.7 to 3.0.8 ([`1a3392c`](https://github.com/PurpleBooth/game-of-life/commit/1a3392c773221e7196445c316721ed13d962a178))

