### PR TITLE
fix: Update git-mit to v5.12.23

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.22.tar.gz"
-  sha256 "eea98bc4d09ead52bb823394e14cc876b6c4b2796ea17c490ee89c1a656f7f7a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.22"
-    sha256 cellar: :any,                 big_sur:      "777005fda30cbe24dfb493cf89f1eff831da5f87c7cafc2938a6f2b6c77b8d59"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "fef511a93fbec77a8d7ce95089a134dbc7ca5589f1d4350b375c22e8ba9394cf"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.23.tar.gz"
+  sha256 "ae5d24f15c0f208947576f705e0bdd66e1c5b358af4347ef1ec5670df08b3911"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.23](https://github.com/PurpleBooth/git-mit/compare/...v5.12.23) (2022-01-18)

### Build

- Versio update versions ([`7233ea5`](https://github.com/PurpleBooth/git-mit/commit/7233ea5f6984b74681ecfbb0ab51f6775e4ca6f7))

### Fix

- Bump clap_complete from 3.0.3 to 3.0.4 ([`cde66f8`](https://github.com/PurpleBooth/git-mit/commit/cde66f87e8d88ec2c5383c600902f80e0a8d5721))
- Bump clap from 3.0.7 to 3.0.9 ([`9b7ee58`](https://github.com/PurpleBooth/git-mit/commit/9b7ee584e9e2f6cdb28ad2e37b73fe2a48bd1d44))

