### PR TITLE
fix: Update git-moves-together to v2.5.18

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.17.tar.gz"
-  sha256 "dbfd663eaefdd174cb55f79a1893d147cf47155642f25e2a660641b41d342818"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.17"
-    sha256 cellar: :any,                 big_sur:      "f2e558308a131525a95146bf5d115e01b7282d209497cda408386847f07926ae"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5728b5d7e1aa72f9fdbadfde1fadd7e0297ac7819b8b4c5ae1ebdcfc785a324c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.18.tar.gz"
+  sha256 "a7233e8b2f25579f11cddb39b6c7f3ebc6ba094f498304d0b9e4d6058427900c"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.18](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.18) (2022-01-19)

### Build

- Versio update versions ([`8b29fb1`](https://github.com/PurpleBooth/git-moves-together/commit/8b29fb123c1cf77e19ef6d065b1623fffe2a370e))

### Fix

- Bump clap from 3.0.7 to 3.0.9 ([`7c4ef84`](https://github.com/PurpleBooth/git-moves-together/commit/7c4ef8400fc802708fd62d93421cdb3e59c83a4b))
- Bump clap from 3.0.9 to 3.0.10 ([`f30fcf8`](https://github.com/PurpleBooth/git-moves-together/commit/f30fcf80a884a9eea0880ef79f504967a96ade89))

