### PR TITLE
fix: Update fast-conventional to v1.0.7

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.6.tar.gz"
-  sha256 "e900ac74f6a617e87bdcfe63928b866908a399a45dd5f66dc173812f13cfbd63"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.6"
-    sha256 cellar: :any_skip_relocation, big_sur:      "bcf9b0c3bba53c31d45b019a21b06393cfc5244b31d2267250dd01c80f090ab1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4014c5f1a287fde399a5459bdbba36aca653ba266b1d7dc77949f9117183184e"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.7.tar.gz"
+  sha256 "cbff3f63633a4389c6f24ce8de5b5d4788e57bb2cc1299482d1201296bb1abaa"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.7](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.7) (2022-01-19)

### Build

- Versio update versions ([`ee42fc6`](https://github.com/PurpleBooth/fast-conventional/commit/ee42fc6f6128c22e90ca3c0613b62e013e67b1e5))

### Fix

- Bump clap from 3.0.5 to 3.0.7 ([`b57a602`](https://github.com/PurpleBooth/fast-conventional/commit/b57a602909a203d788b154576f180e953968e7eb))
- Bump clap_complete from 3.0.3 to 3.0.4 ([`c62be7d`](https://github.com/PurpleBooth/fast-conventional/commit/c62be7de6370764aaa0ae77f1fc4ad7c7b471977))

