### PR TITLE
fix: Update hungry-distance to v0.1.21

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.20.tar.gz"
-  sha256 "ca305339c7d97d5c2a3eafa47da8ad94910fee9f047fa7d7ff5468c31c460d5a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.20"
-    sha256 cellar: :any_skip_relocation, big_sur:      "b068ccb5a040a4cfd80278ea36f607e7c5f3dd1500abb51a3d6463aaa04beac1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "53d8d50e55ab68acb48fff5c006dc5feb4833ac11781d5805bd9b4993e8f7108"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.21.tar.gz"
+  sha256 "efa45ea20a4b3d2d9db58742fcc07ea9ded0e1f059f5fffa333f5e2f138c4501"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.21](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.21) (2022-01-19)

### Build

- Versio update versions ([`ae19c05`](https://github.com/PurpleBooth/hungry-distance/commit/ae19c05097f5c5d13bef05cd063734626fd49d21))

### Fix

- Bump clap from 3.0.7 to 3.0.10 ([`b042f4a`](https://github.com/PurpleBooth/hungry-distance/commit/b042f4a4ae376527a6e6e4f08d1a181cef158d8a))

