### PR TITLE
fix: Update ellipsis to v0.6.29

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.28.tar.gz"
-  sha256 "b857c4c1b4913538294b82ac054d8ce344923822ed78088c1d4035d6aee98e3f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.28"
-    sha256 cellar: :any_skip_relocation, big_sur:      "4c9b2850a008d6f07f2afcaaefb21d90c67054ddeebca22eeb24b5469e2524f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "826da28981088e994875f5843e4caed722911cba62b9bc9552412ce5b05e2a4f"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.29.tar.gz"
+  sha256 "05888f06f59aa4ff95c57fbf21887e5d95565a0c0d5483236e76fd084bf19734"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.29](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.29) (2022-01-19)

### Build

- Versio update versions ([`6cd5f9e`](https://github.com/PurpleBooth/ellipsis/commit/6cd5f9eab025cbec966b1ff9c6cc054e291d4d54))

### Fix

- Bump clap from 3.0.5 to 3.0.7 ([`5bbd738`](https://github.com/PurpleBooth/ellipsis/commit/5bbd73832bbd60c6446afc46e5945872428edf11))
- Bump clap from 3.0.7 to 3.0.10 ([`01e38ee`](https://github.com/PurpleBooth/ellipsis/commit/01e38ee241524cd23194c5d9cef1ad26ddfeed17))

