### PR TITLE
fix: Update ed-system-search to v1.1.21

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.20.tar.gz"
-  sha256 "8c7a5ee03bf6c7a64ab34ab876267802def1f652871d7dc42b7673f0d30e1afc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.20"
-    sha256 cellar: :any_skip_relocation, big_sur:      "47b759c538caa188c1c9cbd1ff0e2b8ab81135eee9f674e754b7c03818271894"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4a88356d2c4ff25aa70333d974e925ba4f52d4106972f8617fa57fa15e58236b"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.21.tar.gz"
+  sha256 "2aedaf8e0a3c079f476bd7c2a41abae04d00175509983e3c7a053d003d5c58a2"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.21](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.21) (2022-01-19)

### Build

- Versio update versions ([`0b84e8c`](https://github.com/PurpleBooth/ed-system-search/commit/0b84e8c6515f7ef1e399b65c7bba25bf866d8c01))

### Fix

- Bump clap from 3.0.7 to 3.0.10 ([`2d743e3`](https://github.com/PurpleBooth/ed-system-search/commit/2d743e3e0c1792aede1b58781b021fdfb1ac9829))

