### PR TITLE
fix: Update whatismyip to v0.9.33

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.32.tar.gz"
-  sha256 "48893e51c08a7ebcc253df990477d86d9444ba825776d306cd776db388320fd5"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.32"
-    sha256 cellar: :any_skip_relocation, big_sur:      "4621f58787abcb9e2fcee2dba57f2ae300ebb79f0b7d32609bc586abd6ec46db"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f5bd233a5d6f8989f5ad988184d6c2cf2938120204a7ef490540e668ad32b970"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.33.tar.gz"
+  sha256 "58071aa6c6e3c6f8df3df382b9db6918c2f008e0fe55c65f26fa5c1fa3331b8a"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.33](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.33) (2022-01-20)

### Build

- Versio update versions ([`621fb0c`](https://github.com/PurpleBooth/whatismyip/commit/621fb0cf83a4f094dd77317edbef697ad1fd2948))

### Fix

- Bump clap from 3.0.7 to 3.0.10 ([`69add9e`](https://github.com/PurpleBooth/whatismyip/commit/69add9eb04026f4317bfe720f6def49c0ac72cdf))
- Follow clippy advice ([`9ec3741`](https://github.com/PurpleBooth/whatismyip/commit/9ec37419b5a1ac833a62757e6a5d02d00a7a4f01))

