### PR TITLE
fix: Update ellipsis to v0.6.30

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.29.tar.gz"
-  sha256 "05888f06f59aa4ff95c57fbf21887e5d95565a0c0d5483236e76fd084bf19734"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.29"
-    sha256 cellar: :any_skip_relocation, big_sur:      "486667b016f72da2efe782c457ae480eedfea169a3827c6dd45fd244c4713699"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4598604c33d26550cf2ab966c8eabde15f79392084159fea31f1c9c1390403b9"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.30.tar.gz"
+  sha256 "152fdf35207de89b198e3066f8bc966667de78a53ce87a354f767b999b768719"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.30](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.30) (2022-01-24)

### Build

- Versio update versions ([`d24e5e3`](https://github.com/PurpleBooth/ellipsis/commit/d24e5e32b09f4eba144ba763383674a4ecc25892))

### Fix

- Bump serde from 1.0.133 to 1.0.134 ([`7ad8523`](https://github.com/PurpleBooth/ellipsis/commit/7ad8523be8fec9d9382fd330524375f046a86a66))

