### PR TITLE
fix: Update fast-conventional to v1.0.8

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.7.tar.gz"
-  sha256 "cbff3f63633a4389c6f24ce8de5b5d4788e57bb2cc1299482d1201296bb1abaa"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.7"
-    sha256 cellar: :any_skip_relocation, big_sur:      "170253e7f11250dd9cc451fcf864b79e525786929c55e935a1d01f95c30bdcc9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "328b4c710425a02033633da56ae02c75051cd346e7eb4676692ace110f5c2804"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.8.tar.gz"
+  sha256 "2ac51c0aa20f63191b1a9a2715fdb7cfddfd5b55c0a6e6c32f3697abd0cf0d9c"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.8](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.8) (2022-01-24)

### Build

- Versio update versions ([`f90a83a`](https://github.com/PurpleBooth/fast-conventional/commit/f90a83aad5b484a3bf44dac815d1363607f3cc65))

### Fix

- Bump clap from 3.0.7 to 3.0.10 ([`3113ecc`](https://github.com/PurpleBooth/fast-conventional/commit/3113ecc71fed309560ad28f92757b27db6b4b337))
- Bump serde from 1.0.133 to 1.0.134 ([`76c6fb8`](https://github.com/PurpleBooth/fast-conventional/commit/76c6fb85ffa220ef73cd128d0ca6f0444c7492b8))

