### PR TITLE
fix: Update ed-system-search to v1.1.22

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.21.tar.gz"
-  sha256 "2aedaf8e0a3c079f476bd7c2a41abae04d00175509983e3c7a053d003d5c58a2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.21"
-    sha256 cellar: :any_skip_relocation, big_sur:      "feea69f0f036a9efb834b09d9103ef942c54d0be2b19152e08dd532e96be34c4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7848b55d77600eb00c1848e6abc5dd1e886f4a63c7314f3c604475eddf69ea04"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.22.tar.gz"
+  sha256 "73269fd8146aea05922f60a693d4f5dea8b20eecce5d1c524c7958b42bac7e9b"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.22](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.22) (2022-01-24)

### Build

- Versio update versions ([`d182250`](https://github.com/PurpleBooth/ed-system-search/commit/d182250d470492e46fa9dc85ba62c0023d5fc4f1))

### Fix

- Bump serde from 1.0.133 to 1.0.135 ([`06442c2`](https://github.com/PurpleBooth/ed-system-search/commit/06442c2e116b4fde1d1a72bd89edcaaab1cfeb0e))

