### PR TITLE
fix: Update git-mit to v5.12.25

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.24.tar.gz"
-  sha256 "035b5818edb20701fb2ff7828f9520206566a7c11572b150f1595b0baa5e8f3f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.24"
-    sha256 cellar: :any,                 big_sur:      "8813420a5233fe7cdcc99d7fa685199a4c0d6f666a2239ff7ee541d4084621ea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2a7251404c86f0eff9dcd48dd150b9e77efa58a44caedf2e0854399a0e2e2002"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.25.tar.gz"
+  sha256 "2df84633d94f6f3e31f3cd0268db3d7166e67a9a162c615c03c9754acb991381"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.25](https://github.com/PurpleBooth/git-mit/compare/...v5.12.25) (2022-01-24)

### Build

- Versio update versions ([`94b865e`](https://github.com/PurpleBooth/git-mit/commit/94b865ef110a56034c10d9dbfff1694498878400))

### Fix

- Bump which from 4.2.2 to 4.2.4 ([`cd307d2`](https://github.com/PurpleBooth/git-mit/commit/cd307d26039cf8c21acbc034e7a3b77d04f5cdd1))

