### PR TITLE
fix: Update game-of-life to v1.53.52

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.51.tar.gz"
-  sha256 "02b0868bfce6e8e3867666fb6769cbeaf9023f4f818cd82c557b8beb6485e7f2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.51"
-    sha256 cellar: :any_skip_relocation, big_sur:      "22fd34b0e36578c4bd1893f0c906a07f2832b0667b6ca7324b353824bc2858d4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "19b91d840960d0a6ad4bfda24d2aab885f1546b2d0c5ca96a6ff599b88f26a86"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.52.tar.gz"
+  sha256 "535877aa06e3bd1f5a2c6c5be7c1fa7aaf8cd6b09118f50640f3be08c4455838"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.52](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.52) (2022-01-25)

### Build

- Versio update versions ([`8d6c9e5`](https://github.com/PurpleBooth/game-of-life/commit/8d6c9e56ec5ae9ba2b85a6b24801c900db717717))

### Fix

- Bump clap from 3.0.8 to 3.0.10 ([`04efb1d`](https://github.com/PurpleBooth/game-of-life/commit/04efb1d55161acf0e7e7b26a82959a3577775a45))
- Bump clap from 3.0.10 to 3.0.12 ([`51e3075`](https://github.com/PurpleBooth/game-of-life/commit/51e30759cc83574e4fe1383a393259e81d5b9e4b))

