### PR TITLE
fix: Update git-moves-together to v2.5.19

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.18.tar.gz"
-  sha256 "a7233e8b2f25579f11cddb39b6c7f3ebc6ba094f498304d0b9e4d6058427900c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.18"
-    sha256 cellar: :any,                 big_sur:      "b0962da69a860f85ece26aced860e05fc02abe19aa2d32f37ceba200a7cd087d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "71a693815551e7876182006cdf02eaee70758c2f1266af5212528cfca4527087"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.19.tar.gz"
+  sha256 "ff28eede011f595322f6bc51b3d86f48c6ff915471259cf3b4eac3ff7fabd10d"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.19](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.19) (2022-01-25)

### Build

- Versio update versions ([`c3ddd67`](https://github.com/PurpleBooth/git-moves-together/commit/c3ddd677d9d84dd93768e8fcf04804687a6df665))

### Fix

- Bump time from 0.3.5 to 0.3.6 ([`b9dc220`](https://github.com/PurpleBooth/git-moves-together/commit/b9dc22067a9c35981463023ac68e92fa83b5eaa5))
- Bump clap from 3.0.10 to 3.0.12 ([`dd7c121`](https://github.com/PurpleBooth/git-moves-together/commit/dd7c1211a583053638632f0b4b3beb19247d5d26))

