### PR TITLE
fix: Update git-mit to v5.12.26

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.25.tar.gz"
-  sha256 "2df84633d94f6f3e31f3cd0268db3d7166e67a9a162c615c03c9754acb991381"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.25"
-    sha256 cellar: :any,                 big_sur:      "c865b021032c796de22e58cb136d44519961cf58d2d47aabc9b9ba70f916cd03"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "eb09a353e90f9a6fe13313b28a2c4eb3f9fc0beb840aa809a2be0978b054faee"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.26.tar.gz"
+  sha256 "4db7dcbf9f3aa5b7186d25a112e81f85733a19a284edf6d7b6d42d704cf6eafe"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.26](https://github.com/PurpleBooth/git-mit/compare/...v5.12.26) (2022-01-25)

### Build

- Versio update versions ([`bfa2543`](https://github.com/PurpleBooth/git-mit/commit/bfa25437a2b0b7eb17fa70aeb1620248cc8b0e5c))

### Fix

- Bump clap from 3.0.10 to 3.0.12 ([`5e80f53`](https://github.com/PurpleBooth/git-mit/commit/5e80f530d571e69599f9674da8038f7be83c12ed))

