### PR TITLE
fix: Update git-moves-together to v2.5.20

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.19.tar.gz"
-  sha256 "ff28eede011f595322f6bc51b3d86f48c6ff915471259cf3b4eac3ff7fabd10d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.19"
-    sha256 cellar: :any,                 big_sur:      "cafd2d6382561550fcb26e9db1ffec9e820659646d74071cb2476a8b2ad322e5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "cfc8c4b07a26f122d18eb31fd5363b9b317525f02895880a23b470709da53565"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.20.tar.gz"
+  sha256 "82a433b638c8cc32e4ba0b40300fa7ae0879805473e75876244b60908de0d9f6"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.20](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.20) (2022-01-26)

### Build

- Versio update versions ([`b66a549`](https://github.com/PurpleBooth/git-moves-together/commit/b66a549bf06959bf1047b100b2a6f3a1b7cfcc7f))

### Fix

- Bump time from 0.3.6 to 0.3.7 ([`0b7ca37`](https://github.com/PurpleBooth/git-moves-together/commit/0b7ca377bdf98af2fedb2e341f9ea9d74ec92706))

