### PR TITLE
fix: Update ed-system-search to v1.1.23

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.22.tar.gz"
-  sha256 "73269fd8146aea05922f60a693d4f5dea8b20eecce5d1c524c7958b42bac7e9b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.22"
-    sha256 cellar: :any_skip_relocation, big_sur:      "bdfe88fb101bf06dd9b4f6b8f8b8ef3a2bde215def2d2615d1f7e04e88181e1d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "18094d17ce04eab05cb79f755a14c45c492130f3d5fcf3106c5542e7a065121d"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.23.tar.gz"
+  sha256 "d3b2da1a2994736b8b7286d74a269183d425aca1517ea97c029facae9560322f"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.23](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.23) (2022-01-26)

### Build

- Versio update versions ([`1f5d816`](https://github.com/PurpleBooth/ed-system-search/commit/1f5d8165a63a5942350e9b0d38c9ba02ccaa6d2d))

### Ci

- Configuration update ([`17c5724`](https://github.com/PurpleBooth/ed-system-search/commit/17c5724d143f5e2660c42ba265a50698ae667d90))

### Fix

- Bump versions ([`8719fe7`](https://github.com/PurpleBooth/ed-system-search/commit/8719fe7ba68fdc84e6ada641f53ce00d3565195b))

