### PR TITLE
fix: Update fast-conventional to v1.0.9

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.8.tar.gz"
-  sha256 "2ac51c0aa20f63191b1a9a2715fdb7cfddfd5b55c0a6e6c32f3697abd0cf0d9c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.8"
-    sha256 cellar: :any_skip_relocation, big_sur:      "118391bf062630d5fa004a4b0456bf3435941afc97ebca7db8a8651601f87875"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "07bec8f56ca528a2acd8de843c7d4ab65529d8b9e81737f0384e6b29d7dc70ed"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.9.tar.gz"
+  sha256 "092ad42105681e4100fb675b2e7eb9da9cc7aa0562e5e7c248bde0924e93cc81"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.9](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.9) (2022-01-26)

### Build

- Versio update versions ([`ca876be`](https://github.com/PurpleBooth/fast-conventional/commit/ca876bebbbbb3a853dac6ed7771b4035db6e1158))

### Ci

- Configuration update ([`a1b0c58`](https://github.com/PurpleBooth/fast-conventional/commit/a1b0c58a8d5cb1f0c76308ff5de0167a6242079c))

### Fix

- Bump clap_complete from 3.0.4 to 3.0.5 ([`269ef64`](https://github.com/PurpleBooth/fast-conventional/commit/269ef64fc76b522024aec01b4da788c273e90bbf))

