### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.38

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.37.tar.gz"
-  sha256 "910a945303abddf05add436799a4704f97eced62dc36ca2a363b6bbd661b6b09"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.38.tar.gz"
+  sha256 "bcb57244f9680a894c513a8a1c303a2417d5b9a58a70978c37076652e7e4c7c0"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.37"
-    sha256 cellar: :any_skip_relocation, big_sur:      "1fd43a445ccf9cd358fdb0e29c96e4b2987f7ed08c45e6f7e373324442314a37"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c53e156d965abeaa058b3be50a1d923b8e77920fd968fd561443a4e15268f217"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.38](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.38) (2022-01-26)

### Build

- Versio update versions ([`f214ddc`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/f214ddc42927910c9644e31b3727a9a0308b2990))

### Ci

- Correct checks ([`02b1659`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/02b165905213ec312a86be55db89602cf96ed1d9))

### Fix

- Bump clap from 3.0.7 to 3.0.10 ([`326ba65`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/326ba6534253f2d6a8d622a2002971917c778d99))
- Bump clap from 3.0.10 to 3.0.12 ([`53a2e4b`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/53a2e4bd7d59331decaf72388b3103d57260153b))

