### PR TITLE
fix: Update ellipsis to v0.6.31

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.30.tar.gz"
-  sha256 "152fdf35207de89b198e3066f8bc966667de78a53ce87a354f767b999b768719"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.30"
-    sha256 cellar: :any_skip_relocation, big_sur:      "1d44de44503f2d2fcd8771334e6f3fa3807aaebcb11aa4f624559a25bb7f057b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "71fa9dfbf3d9aae89467efe28a3f758657d881b3ba8b7d2238bf6e40467880a4"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.31.tar.gz"
+  sha256 "5750c3a9862a7ed846e38dcba8be44a15df45725951b1a903aabcbce3698c07e"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.31](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.31) (2022-01-26)

### Build

- Versio update versions ([`b7c3cdd`](https://github.com/PurpleBooth/ellipsis/commit/b7c3cdd74e61f099ae0f1dfda92c6f943b0b86b0))

### Ci

- Configuration update ([`4c46c75`](https://github.com/PurpleBooth/ellipsis/commit/4c46c751bb144cf44ed9db9235d0ba3bc29a4f63))

### Fix

- Bump anyhow from 1.0.52 to 1.0.53 ([`c7a3218`](https://github.com/PurpleBooth/ellipsis/commit/c7a3218802e757f2c1ba6db9cedf70ecf3077409))

