### PR TITLE
fix: Update git-mit to v5.12.27

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.26.tar.gz"
-  sha256 "4db7dcbf9f3aa5b7186d25a112e81f85733a19a284edf6d7b6d42d704cf6eafe"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.26"
-    sha256 cellar: :any,                 big_sur:      "94f41897322dbdb6671d2d06bc69c48816e1b3f2679449f071d558d19912dbbf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1dce956e068dcf2d0f786c67d1a738ac4ff38f21dd472419863438db5588c83f"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.27.tar.gz"
+  sha256 "b13bb7f697c00993b873505265f2699bebe8b2a02003a8c6ee571d36f945c458"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.27](https://github.com/PurpleBooth/git-mit/compare/...v5.12.27) (2022-01-26)

### Build

- Versio update versions ([`029f035`](https://github.com/PurpleBooth/git-mit/commit/029f03505eaa8c7e3f106f342f2ebd9eb9e28b85))

### Ci

- Configuration update ([`aa7727e`](https://github.com/PurpleBooth/git-mit/commit/aa7727ed88e1bc4ac8c0c2471ca17561bc12d039))

### Fix

- Bump time from 0.3.5 to 0.3.7 ([`7b9986c`](https://github.com/PurpleBooth/git-mit/commit/7b9986cdec20dbe7860f6deb558e19844ba85a92))

