### PR TITLE
fix: Update fast-conventional to v1.0.10

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.9.tar.gz"
-  sha256 "092ad42105681e4100fb675b2e7eb9da9cc7aa0562e5e7c248bde0924e93cc81"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.9"
-    sha256 cellar: :any_skip_relocation, big_sur:      "8555a874f0d067a4ba6f10b4d99586968e9e0c6303ce88b746c6459529fb40f7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b3da14b330726240539cdf62a456c286e45b9836f1f03ce8b70a0046ea2d9ed0"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.10.tar.gz"
+  sha256 "825dffc63f061a3728d8148464bd15f70ecada6c77a2c8faecbfff574cbd2249"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.10](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.10) (2022-01-26)

### Build

- Versio update versions ([`aa1e984`](https://github.com/PurpleBooth/fast-conventional/commit/aa1e984207244044d8eac46479ed70487759a422))

### Fix

- Bump serde from 1.0.134 to 1.0.136 ([`ec6acca`](https://github.com/PurpleBooth/fast-conventional/commit/ec6accae8c0bb63d29df2d679ed4c0948539da70))
- Bump clap from 3.0.10 to 3.0.13 ([`7c4813b`](https://github.com/PurpleBooth/fast-conventional/commit/7c4813b319f513c0420c5319aeb6d8023dda149b))

