### PR TITLE
fix: Update ed-system-search to v1.1.24

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.23.tar.gz"
-  sha256 "d3b2da1a2994736b8b7286d74a269183d425aca1517ea97c029facae9560322f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.23"
-    sha256 cellar: :any_skip_relocation, big_sur:      "bf69b8295c458a9aa216d9bf8c28c96cb14eae1ffc726b1327422f60356854bf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8b1e10c53db903546ec66057a009c024186b2067008ebfa7710b98683fbf4e35"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.24.tar.gz"
+  sha256 "5e55a59fe1bfda0230fe5d9175bec10f31e47d2221a8a8f2d195eb5a1e6fed85"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.24](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.24) (2022-01-27)

### Build

- Versio update versions ([`416d4ee`](https://github.com/PurpleBooth/ed-system-search/commit/416d4eee9951a02b829d397e636fd6b0912b272f))

### Fix

- Bump clap from 3.0.12 to 3.0.13 ([`6a206fb`](https://github.com/PurpleBooth/ed-system-search/commit/6a206fb6367b25355cc10b96bc48550064d6d323))

