### PR TITLE
fix: Update fix-compaudit to v0.46.73

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.72.tar.gz"
-  sha256 "69453b400f73172735755f7be1edf6750cc33a9846ebc61a6c018fdbc415a1d3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.72"
-    sha256 cellar: :any_skip_relocation, big_sur:      "5c97c43e0825ac470ef122dd46f523bcea0c41a511ea04699e3deaa675e79cf1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "be3da446be156263de8cc555b38752b21bb434f939bd336915db476b6109d59d"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.73.tar.gz"
+  sha256 "d50a539a3d73b92ba093adfeb337c72cadd2774133078ef25b62be5f04d869ac"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.73](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.73) (2022-01-27)

### Build

- Versio update versions ([`796b0d6`](https://github.com/PurpleBooth/fix-compaudit/commit/796b0d6006a38f788644d77a8ad586b3e2091d3c))

### Ci

- Improve mergify config ([`466b117`](https://github.com/PurpleBooth/fix-compaudit/commit/466b117ef0f54652125bf23bcc6f4a02d384f92e))

### Fix

- Bump clap from 3.0.7 to 3.0.10 ([`a9d2ccc`](https://github.com/PurpleBooth/fix-compaudit/commit/a9d2ccc4cb6ffca7a32ddfcd82219b5c3c28a6b0))
- Bump clap from 3.0.10 to 3.0.12 ([`8c14fe5`](https://github.com/PurpleBooth/fix-compaudit/commit/8c14fe5d71a1dc1785a5cc9f3303872f9bcd5432))
- Bump clap from 3.0.12 to 3.0.13 ([`b88b671`](https://github.com/PurpleBooth/fix-compaudit/commit/b88b67139df43091c5b88cc1da1d5b82b6f885c5))

