### PR TITLE
fix: Update whatismyip to v0.9.34

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.33.tar.gz"
-  sha256 "58071aa6c6e3c6f8df3df382b9db6918c2f008e0fe55c65f26fa5c1fa3331b8a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.33"
-    sha256 cellar: :any_skip_relocation, big_sur:      "c1bb443946e9b7ff22821df4f6a67b93c7dd57a666fc5b58e388fa82c644ed66"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "cc1b0e31ab4fc0a06d5a12ca154118cf55bcd2ff6c11dcab5039fed827e8375b"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.34.tar.gz"
+  sha256 "795f2e8fe4c8fec0b08385e2b32ff84b8553484cf7f4e1f55ed87debc02aa183"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.34](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.34) (2022-01-27)

### Build

- Versio update versions ([`49f03d9`](https://github.com/PurpleBooth/whatismyip/commit/49f03d9c0b517d1d7797f676b594c2f58d119321))

### Ci

- Configuration update ([`ab697fb`](https://github.com/PurpleBooth/whatismyip/commit/ab697fb9c5a158ad5b6d292c41a004651dc9a580))

### Fix

- Bump anyhow from 1.0.52 to 1.0.53 ([`8c54c99`](https://github.com/PurpleBooth/whatismyip/commit/8c54c99e0be5c619bd532d724dfde73ac72e8f0a))

