### PR TITLE
fix: Update git-moves-together to v2.5.21

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.20.tar.gz"
-  sha256 "82a433b638c8cc32e4ba0b40300fa7ae0879805473e75876244b60908de0d9f6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.20"
-    sha256 cellar: :any,                 big_sur:      "7bc685f096babd641c522d3da55f8006012a05fb7c557baacd7f2f965a80bbab"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "762d6f4f23d8080ff4898bc4abc3089d77de5d4c3982226f5431d32a2f833bc2"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.21.tar.gz"
+  sha256 "a26ea86dcc5a7997cae245a154bd8886d63085f5e4013533c2307dbbf7be091b"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.21](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.21) (2022-01-28)

### Build

- Versio update versions ([`3c9132b`](https://github.com/PurpleBooth/git-moves-together/commit/3c9132b7abe094be50fbff80af47d9a071873325))

### Fix

- Bump clap from 3.0.12 to 3.0.13 ([`b2b36dd`](https://github.com/PurpleBooth/git-moves-together/commit/b2b36dd178e325dbc0e77092ac8675f11aa991f4))
- Bump tokio from 1.15.0 to 1.16.1 ([`77eefb0`](https://github.com/PurpleBooth/git-moves-together/commit/77eefb0099d618968cb8c6b9e6460f2b99c808bf))

