### PR TITLE
fix: Update whatismyip to v0.9.35

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.34.tar.gz"
-  sha256 "795f2e8fe4c8fec0b08385e2b32ff84b8553484cf7f4e1f55ed87debc02aa183"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.34"
-    sha256 cellar: :any_skip_relocation, big_sur:      "aafca07eb7262ec2a97b37aae6f80501b7e3cf55788e7ab0267a55b6495b832d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "fe2d2a9da36d9e3f35fb8bc92321c01adf6df4c79c81629a4c573684724527bc"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.35.tar.gz"
+  sha256 "6a12a9b8fa6cabedce0b83f6e66f9a5e2a0d29c316c605210f6d683c8d04e11a"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.35](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.35) (2022-01-28)

### Build

- Versio update versions ([`d3d7b72`](https://github.com/PurpleBooth/whatismyip/commit/d3d7b72b9443ec4e816e58e1aa8cf0326f5d539c))

### Fix

- Bump clap from 3.0.10 to 3.0.13 ([`178b01f`](https://github.com/PurpleBooth/whatismyip/commit/178b01f6ba15b9dec1ee24e2b77e25ba07a6c974))
- Bump tokio from 1.15.0 to 1.16.1 ([`40d16bd`](https://github.com/PurpleBooth/whatismyip/commit/40d16bdf2ef3b7c64583cdff3083427e28289921))

