### PR TITLE
fix: Update ed-system-search to v1.1.25

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.24.tar.gz"
-  sha256 "5e55a59fe1bfda0230fe5d9175bec10f31e47d2221a8a8f2d195eb5a1e6fed85"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.24"
-    sha256 cellar: :any_skip_relocation, big_sur:      "645782c175654789e0a52fbc6c1eec0e41a0ae895dda1580e8be4ca62f89abb2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5d723a9de2d98a17f9632a2b87be786eb16ae6aaac916a0ce96cb2312f7c7b86"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.25.tar.gz"
+  sha256 "d6208f87cb127082e8013f73fdbee13f31b09c9e363a5b35fadb3edeb38e398f"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.25](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.25) (2022-02-02)

### Build

- Versio update versions ([`5fdc669`](https://github.com/PurpleBooth/ed-system-search/commit/5fdc6697f2092597630347d025556c0683095626))

### Fix

- Bump clap from 3.0.13 to 3.0.14 ([`30c9d1a`](https://github.com/PurpleBooth/ed-system-search/commit/30c9d1a5f213691bbe78d062b5aed82711c80edc))

