### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.39

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.38.tar.gz"
-  sha256 "bcb57244f9680a894c513a8a1c303a2417d5b9a58a70978c37076652e7e4c7c0"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.39.tar.gz"
+  sha256 "bd519ddb1484269c8bbca5352c857efb174e4a766fdb33aea8135781df1ebfe4"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.38"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6dc143a0eef8997e9fd92a47c1e94b3321d91f6b33dd6e218064ab9e50a8f988"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "fa0bf036f4c054abacb995937cc63dd51756e1e92089b19c8516a9c6b6f35cc1"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.39](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.39) (2022-02-02)

### Build

- Versio update versions ([`09ebce1`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/09ebce10b2f84dcc344c5fffe8feadbaa0cab0d4))

### Fix

- Bump clap from 3.0.12 to 3.0.13 ([`30f4450`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/30f44504a4962f436f80c81ef6673d5382df08eb))
- Bump clap from 3.0.13 to 3.0.14 ([`3043208`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/3043208b12c20b917985e05f6a9700646b45e21b))

