### PR TITLE
fix: Update hungry-distance to v0.1.22

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.21.tar.gz"
-  sha256 "efa45ea20a4b3d2d9db58742fcc07ea9ded0e1f059f5fffa333f5e2f138c4501"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.21"
-    sha256 cellar: :any_skip_relocation, big_sur:      "eb29bea007c84a6875817713f56fa868604e9f517a97aed642c6813a8a973c33"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "39fc7bc98c932937688bc8b3194ec07f8e0706d3f1d85857eb20cf6ec442cf11"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.22.tar.gz"
+  sha256 "08c5a5317d4dd739656f1b39fb9e7ebb06e0bd71cfb57cb6c45ed7afe3c7e890"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.22](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.22) (2022-02-02)

### Build

- Versio update versions ([`e238551`](https://github.com/PurpleBooth/hungry-distance/commit/e2385519db050612ab316a6117a95d9ec6214b83))

### Ci

- Add explicit checks ([`56ee7f3`](https://github.com/PurpleBooth/hungry-distance/commit/56ee7f351b0e8f020984efa0f711f5cb4cbf0979))
- Add specdown ([`6eccf36`](https://github.com/PurpleBooth/hungry-distance/commit/6eccf36fa3d2cea5c62d206ec5e5556463c6ea8b))
- Remove specdown ([`3f9338c`](https://github.com/PurpleBooth/hungry-distance/commit/3f9338c684c73873f2a5bdd07d61971116acf5f5))

### Fix

- Bump clap from 3.0.10 to 3.0.13 ([`ef72a25`](https://github.com/PurpleBooth/hungry-distance/commit/ef72a2539d3f875415da85339f4fae78bbf2bfd3))
- Bump clap from 3.0.13 to 3.0.14 ([`fcf74b0`](https://github.com/PurpleBooth/hungry-distance/commit/fcf74b0eeced65f2e55afd2c9a2084ab3fdf9a2b))

