### PR TITLE
fix: Update whatismyip to v0.9.36

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.35.tar.gz"
-  sha256 "6a12a9b8fa6cabedce0b83f6e66f9a5e2a0d29c316c605210f6d683c8d04e11a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.35"
-    sha256 cellar: :any_skip_relocation, big_sur:      "a670061003fdd95085e9b886dc19a516e44b48fe7b7b03ca23f78aa0d3504b7e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0913b43cf5d8e5548152d425d1745d41e3501299ce4066eda5acb78043010358"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.36.tar.gz"
+  sha256 "4552951c1a3109b7d3ec7a7724a3611df1a99ff99d342631b8860e08b2e75c46"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.36](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.36) (2022-02-02)

### Build

- Versio update versions ([`8b669d0`](https://github.com/PurpleBooth/whatismyip/commit/8b669d02098f9bdd745b3ea10c28cb9c5cc0f497))

### Fix

- Bump clap from 3.0.13 to 3.0.14 ([`c8e33e3`](https://github.com/PurpleBooth/whatismyip/commit/c8e33e3b3c6a932483c9e5a193b9c7afa84b99bf))
- Bump trust-dns-resolver from 0.20.3 to 0.20.4 ([`93030c8`](https://github.com/PurpleBooth/whatismyip/commit/93030c8331edafe8528138c38a47225536302026))

