### PR TITLE
fix: Update ellipsis to v0.6.32

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.31.tar.gz"
-  sha256 "5750c3a9862a7ed846e38dcba8be44a15df45725951b1a903aabcbce3698c07e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.31"
-    sha256 cellar: :any_skip_relocation, big_sur:      "aab3d678d2d952917e78c4ae12a5111c666c0a785e91955538a21bbcc516c079"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d02c7f90c696734e88c7ca27377066e0623e80c4db804ccbf660d24ecef74fa2"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.32.tar.gz"
+  sha256 "1732a9778df3c95f94440b625903161b17f2d9b0dc4beb06e374b77a4a829398"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.32](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.32) (2022-02-02)

### Build

- Versio update versions ([`b289bd5`](https://github.com/PurpleBooth/ellipsis/commit/b289bd566754d4fa3f7fea3aa52036eb378a1f77))

### Fix

- Bump serde from 1.0.134 to 1.0.136 ([`417605b`](https://github.com/PurpleBooth/ellipsis/commit/417605b1de384bc94dc99b110ffdaf9828294229))
- Bump clap from 3.0.10 to 3.0.13 ([`8be1685`](https://github.com/PurpleBooth/ellipsis/commit/8be16859f2bc00674f28dedb89669599fcc7aff4))
- Bump clap from 3.0.13 to 3.0.14 ([`b25ba24`](https://github.com/PurpleBooth/ellipsis/commit/b25ba24341281013c5a22c154f82528902ad8bf8))

