### PR TITLE
fix: Update game-of-life to v1.53.53

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.52.tar.gz"
-  sha256 "535877aa06e3bd1f5a2c6c5be7c1fa7aaf8cd6b09118f50640f3be08c4455838"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.52"
-    sha256 cellar: :any_skip_relocation, big_sur:      "dcc8c61677bffab310e0a11e64ca5e223ea5f82681adaa4b233f08280445aef6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "85df1ffa7b300ff6d87bdcb5dcdf890c675518b80e5ed5250bdf5fae10b0211d"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.53.tar.gz"
+  sha256 "1d4f11e1d0af385865a4d597ddb7a6e7a86bf3229f85af4fb9439d336db05516"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.53](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.53) (2022-02-03)

### Build

- Versio update versions ([`4a68087`](https://github.com/PurpleBooth/game-of-life/commit/4a68087b61062976554c2b26617332851ff3b945))

### Fix

- Bump clap from 3.0.12 to 3.0.13 ([`695893b`](https://github.com/PurpleBooth/game-of-life/commit/695893bc236930ae9731d2e993125cbf2698f3f8))
- Bump clap from 3.0.13 to 3.0.14 ([`f1eebd4`](https://github.com/PurpleBooth/game-of-life/commit/f1eebd46912e22f7a237ee60c429e5bd59868f45))
- Bump retry from 1.3.0 to 1.3.1 ([`4256aab`](https://github.com/PurpleBooth/game-of-life/commit/4256aab6e9dd88367154a4b2a40cfbe539eb6315))

