### PR TITLE
fix: Update fast-conventional to v1.0.11

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.10.tar.gz"
-  sha256 "825dffc63f061a3728d8148464bd15f70ecada6c77a2c8faecbfff574cbd2249"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.10"
-    sha256 cellar: :any_skip_relocation, big_sur:      "042dfe48d6cde1d787a3eea708e3153e5dc1ce1219ca1d3830a77a26ad2aef3f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2da4da1157d6e3f3467f480f7dfbc7520211e5d187b7fd335c2b2e8b845ce8a3"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.11.tar.gz"
+  sha256 "7f05fbc208cde57ae78c6877be37ec3bc876f0875ba3ef83782be0ae23360acf"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.11](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.11) (2022-02-07)

### Build

- Bump versions ([`9dca418`](https://github.com/PurpleBooth/fast-conventional/commit/9dca418946d2631ffe6b4a68b4e5d7cf0812d841))
- Versio update versions ([`c38ec97`](https://github.com/PurpleBooth/fast-conventional/commit/c38ec97d762e798f815f77eb29e82dee31ae9b60))

### Fix

- Bump clap from 3.0.13 to 3.0.14 ([`3455d94`](https://github.com/PurpleBooth/fast-conventional/commit/3455d949af056d816f2b9aba914d548346048db8))
- Bump clap_complete from 3.0.5 to 3.0.6 ([`4bfaf5e`](https://github.com/PurpleBooth/fast-conventional/commit/4bfaf5edcd29ca932b35452a94689783a32655c5))

