### PR TITLE
fix: Update git-moves-together to v2.5.22

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.21.tar.gz"
-  sha256 "a26ea86dcc5a7997cae245a154bd8886d63085f5e4013533c2307dbbf7be091b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.21"
-    sha256 cellar: :any,                 big_sur:      "e544bdbbb0b29e03a3e6347120dcdc1943c59424b6ce0442c911a83bff68e801"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "da491509d62ed84e7674dfaca38fff837ba3a4ce075d62050faf038ac9bbd969"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.22.tar.gz"
+  sha256 "a5258e33bd70117fb21f55fd9a36248a0c7c028081ecacb83a6e76790332f162"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.22](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.22) (2022-02-18)

### Build

- Versio update versions ([`bf5e500`](https://github.com/PurpleBooth/git-moves-together/commit/bf5e500189539106460dfe690f39dbf51d12babd))

### Ci

- Configuration update ([`d58e356`](https://github.com/PurpleBooth/git-moves-together/commit/d58e356a92386e16957bb723113c595fe2edca95))

### Fix

- Bump clap from 3.0.13 to 3.0.14 ([`bba5eb6`](https://github.com/PurpleBooth/git-moves-together/commit/bba5eb67d70531b1f61bcbc6a0914742e470dba2))
- Bump futures from 0.3.19 to 0.3.21 ([`8c37a8c`](https://github.com/PurpleBooth/git-moves-together/commit/8c37a8c1be1ae72508c4be4a033d7330a2f182ce))
- Bump rand from 0.8.4 to 0.8.5 ([`9333cc3`](https://github.com/PurpleBooth/git-moves-together/commit/9333cc3a2e1aaca96a2cc97fa04a1f1a3f318115))
- Bump tokio from 1.16.1 to 1.17.0 ([`00f9cb5`](https://github.com/PurpleBooth/git-moves-together/commit/00f9cb59d57ab1ecb6a824a0ae3af39878ab372c))
- Bump clap version ([`9d159a3`](https://github.com/PurpleBooth/git-moves-together/commit/9d159a32a7ec42f2edd9dae9d15991cbc49a6138))

