### PR TITLE
fix: Update git-mit to v5.12.32

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.31.tar.gz"
-  sha256 "a93892b36c4262394a7810f604b8de00fe67129fd86653876b1148d6f07e1bab"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.31"
-    sha256 cellar: :any,                 big_sur:      "1af5c0bb817a60506a2127aaae723aedc56e994b099e836c9605badb44d851cf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f4bd022e669318a85e9a443c5a5ee6a780c93f3ac1370afb7f951a259c6a88c3"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.32.tar.gz"
+  sha256 "57e2aa29774b606507acbe2631f02118df7c614c769ea04513703eec778609d8"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.32](https://github.com/PurpleBooth/git-mit/compare/...v5.12.32) (2022-02-18)

### Build

- Versio update versions ([`0be86ef`](https://github.com/PurpleBooth/git-mit/commit/0be86efb261014a5016d7ffd4eb43e1fd72cc634))

### Fix

- Bump tokio from 1.16.1 to 1.17.0 ([`47d5a3d`](https://github.com/PurpleBooth/git-mit/commit/47d5a3dd289ec102b322374a9150cce6270f7a18))
- Bump indoc from 1.0.3 to 1.0.4 ([`0f555c3`](https://github.com/PurpleBooth/git-mit/commit/0f555c34a8d6efcbff08996111ed2803a5d86440))

