### PR TITLE
fix: Update fast-conventional to v1.0.12

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.11.tar.gz"
-  sha256 "7f05fbc208cde57ae78c6877be37ec3bc876f0875ba3ef83782be0ae23360acf"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.11"
-    sha256 cellar: :any_skip_relocation, big_sur:      "d105fbea5e804b72005f4f22ce9ae32343a4bdeaf47611e226ee3ca5663c9b14"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "613b0ff0ebdbcdc74dc34d288fea5c465b7f673059ef61b90de3d512a0b27ee4"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.12.tar.gz"
+  sha256 "52d7885a424b5e09399ee0b36868a41fbfbef10242c9baa9fa7dde0209ef1b49"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.12](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.12) (2022-02-18)

### Build

- Versio update versions ([`1ceb0e2`](https://github.com/PurpleBooth/fast-conventional/commit/1ceb0e24dd40930a65a4a1f23ae3b71b29f57db2))

### Fix

- Bump clap version ([`f9a97a1`](https://github.com/PurpleBooth/fast-conventional/commit/f9a97a1268e3618dc947378f88aa87bf0c3aa635))
- Correct commit message keyword ([`7dfb72e`](https://github.com/PurpleBooth/fast-conventional/commit/7dfb72efe48fd39643b4c3c322b4ee4ca80cb83b))
- Bump mit-commit from 3.0.0 to 3.0.1 ([`b8fe28b`](https://github.com/PurpleBooth/fast-conventional/commit/b8fe28bf99a86fbf4255f0ece11c1c5a7ba77cb0))

