### PR TITLE
fix: Update git-mit to v5.12.33

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.31.tar.gz"
-  sha256 "a93892b36c4262394a7810f604b8de00fe67129fd86653876b1148d6f07e1bab"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.31"
-    sha256 cellar: :any,                 big_sur:      "1af5c0bb817a60506a2127aaae723aedc56e994b099e836c9605badb44d851cf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f4bd022e669318a85e9a443c5a5ee6a780c93f3ac1370afb7f951a259c6a88c3"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.33.tar.gz"
+  sha256 "420bc5d9c368799a5c7e53d02a0d0dcd8ba019bca1a188bf38ada86fb49a67c9"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.33](https://github.com/PurpleBooth/git-mit/compare/...v5.12.33) (2022-02-18)

### Build

- Versio update versions ([`4877d1e`](https://github.com/PurpleBooth/git-mit/commit/4877d1e2fcd70b8cd13a3699c13a49976ae9b32a))

### Fix

- Bump clap ([`4189338`](https://github.com/PurpleBooth/git-mit/commit/418933896de3d9955b330a3a2144117fe2717a8d))
- Remove unused versions ([`3525595`](https://github.com/PurpleBooth/git-mit/commit/3525595a37e62947e81f5fabe9cd775bbe3a6285))

