### PR TITLE
fix: Update ed-system-search to v1.1.27

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.26.tar.gz"
-  sha256 "9019b2845d46e9887c3daa109d1dafc4693012ce8d17131a26945279caefd61b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.26"
-    sha256 cellar: :any_skip_relocation, big_sur:      "514ce3f950401cc9a06b6460fd3d575ae595954d7f88b5c320612b54ac8d6b45"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8181ee0c84b92e88e367878862a5bf52d8c4682cac5c9b2d981c991d738c23ff"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.27.tar.gz"
+  sha256 "3b7c394b3c5540e1a679e627d17bec67474156fd5c1708fb731e5cee09307f1b"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.27](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.27) (2022-02-18)

### Build

- Versio update versions ([`46ddfe5`](https://github.com/PurpleBooth/ed-system-search/commit/46ddfe51840a3ded97314437e17bb4b0e12ec063))

### Fix

- Bump clap ([`277c0be`](https://github.com/PurpleBooth/ed-system-search/commit/277c0beabb24db25c675c780b7f24f3663ca2fb8))

