### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.40

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.39.tar.gz"
-  sha256 "bd519ddb1484269c8bbca5352c857efb174e4a766fdb33aea8135781df1ebfe4"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.40.tar.gz"
+  sha256 "850ff4a75cea05c99a382b931688e42a5cc0fa5996e5fc607e7826fbedbb8a4f"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.39"
-    sha256 cellar: :any_skip_relocation, big_sur:      "13b6a9afc44745e6f7340881944bedcdf22144da23075f69d352cb8053ac5757"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "bbde73b09fa25435dbb8e5fb038d2ede982146590930a5ec58fd50d092703808"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.40](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.40) (2022-02-19)

### Build

- Versio update versions ([`5438463`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/543846324218642c73e4654de761c1f6d530f3e2))

### Fix

- Bump clap ([`eedbc08`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/eedbc0887c4d71edc18c1cf0287829de3a36192f))

