### PR TITLE
fix: Update game-of-life to v1.53.54

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.53.tar.gz"
-  sha256 "1d4f11e1d0af385865a4d597ddb7a6e7a86bf3229f85af4fb9439d336db05516"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.53"
-    sha256 cellar: :any_skip_relocation, big_sur:      "2534705b68aac0f6fcfc1cccf72b6e8b4158337e7132b392758edced792c1108"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "94cbbdd3837dcbe99d8007fecb231dfbbad08b92069cba9639913d3960af97d4"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.54.tar.gz"
+  sha256 "e45a3d71aedbbe4e20bf9befeedbb1bb82108951e0b0b553eacfbefabdf4c9a1"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.54](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.54) (2022-02-19)

### Build

- Versio update versions ([`a0fb890`](https://github.com/PurpleBooth/game-of-life/commit/a0fb89037ac26f247d2a2669637242c626bd80fc))

### Fix

- Bump crossterm from 0.22.1 to 0.23.0 ([`b6741bf`](https://github.com/PurpleBooth/game-of-life/commit/b6741bfeaaaa56c6d3c1b1f95f32a757f3057318))
- Bump rand from 0.8.4 to 0.8.5 ([`c716ff8`](https://github.com/PurpleBooth/game-of-life/commit/c716ff8fb6441bde904d8538b476a84c8cd78ba0))
- Bump clap from 3.0.14 to 3.1.0 ([`e6a2ef1`](https://github.com/PurpleBooth/game-of-life/commit/e6a2ef1f946af1f0bc5bc4f1ba0701615096c168))
- Update clap ([`8a2237b`](https://github.com/PurpleBooth/game-of-life/commit/8a2237bb6fbfccd7261245aa885ec170c23820a8))

