### PR TITLE
fix: Update readable-name-generator to v2.100.9

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,23 +1,19 @@
 class ReadableNameGenerator < Formula
-  desc "Generate a readable name using Dockers formula"
+  desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.5.tar.gz"
-  sha256 "9b20d2e51bc7060a6ecec775e3fac0da3774648f1b5c1b40b390574cbe5adddd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.5"
-    sha256 cellar: :any_skip_relocation, catalina:     "8cfff858d358810150f09f51699430d1f020cdb6b337bac6cbe2722fdedcc7b1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6876b54ef39554fe8696d874103a733330c65c18fad923a93b8d0854f0c3f2bb"
-  end
-
-  depends_on "go" => :build
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.9.tar.gz"
+  sha256 "782a1f8c485e9f89677fb81bd2b73f274ffa3cd1e19fe0fa34de87b6114f702c"
+  depends_on "rust" => :build
+  depends_on "help2man" => :build
+  depends_on "specdown/repo/specdown" => :test
 
   def install
-    system "go", "build", *std_go_args
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
   end
 
   test do
-    system "#{bin}/readable-name-generator"
-    refute_equal "", shell_output("#{bin}/readable-name-generator").strip
+    system "#{bin}/readable-name-generator", "-h"
+    system "#{bin}/readable-name-generator", "-V"
+    system "specdown run --temporary-workspace-dir --add-path \"#{bin}\" \"#{prefix}\/README.md\""
   end
 end


### PR DESCRIPTION
## Changelog
### [v2.100.9](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.9) (2022-02-19)

### Build

- Versio update versions ([`7965653`](https://github.com/PurpleBooth/readable-name-generator/commit/79656535c4babe720d892ac400585b7056abec12))

### Fix

- Organise the examples a little better ([`6e58f09`](https://github.com/PurpleBooth/readable-name-generator/commit/6e58f09a293f7680343d1c1b60a4eea42e1a13ad))

