### PR TITLE
fix: Update readable-name-generator to v2.100.10

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,23 +1,19 @@
 class ReadableNameGenerator < Formula
-  desc "Generate a readable name using Dockers formula"
+  desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.5.tar.gz"
-  sha256 "9b20d2e51bc7060a6ecec775e3fac0da3774648f1b5c1b40b390574cbe5adddd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.5"
-    sha256 cellar: :any_skip_relocation, catalina:     "8cfff858d358810150f09f51699430d1f020cdb6b337bac6cbe2722fdedcc7b1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6876b54ef39554fe8696d874103a733330c65c18fad923a93b8d0854f0c3f2bb"
-  end
-
-  depends_on "go" => :build
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.10.tar.gz"
+  sha256 "20de72ae94f8a5b409e29109309393f65db3895e3c1da983edadd54634ace68c"
+  depends_on "help2man" => :build
+  depends_on "rust" => :build
+  depends_on "specdown/repo/specdown" => :test
 
   def install
-    system "go", "build", *std_go_args
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
   end
 
   test do
-    system "#{bin}/readable-name-generator"
-    refute_equal "", shell_output("#{bin}/readable-name-generator").strip
+    system "#{bin}/readable-name-generator", "-h"
+    system "#{bin}/readable-name-generator", "-V"
+    system "specdown run --temporary-workspace-dir --add-path \"#{bin}\" \"#{prefix}\/README.md\""
   end
 end


### PR DESCRIPTION
## Changelog
### [v2.100.10](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.10) (2022-02-19)

### Build

- Versio update versions ([`05e69b3`](https://github.com/PurpleBooth/readable-name-generator/commit/05e69b352a71ae1b5cf8dabc0f47985ad2e3de13))

### Fix

- Correct order of formula ([`36d53c2`](https://github.com/PurpleBooth/readable-name-generator/commit/36d53c210a05e45c65f6d187a8b5e7b91bbd8330))
- Add docker usage notes ([`c0a6418`](https://github.com/PurpleBooth/readable-name-generator/commit/c0a6418fe015c71b412e10462bd4fb11cb02abbf))
- Group build and run ([`24451ca`](https://github.com/PurpleBooth/readable-name-generator/commit/24451cad4c3f4247a8dde9e507721bcfa421ff1c))

