### PR TITLE
fix: Update readable-name-generator to v2.100.11

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,20 +1,27 @@
 class ReadableNameGenerator < Formula
-  desc "Make conventional commits, faster, and consistently name scopes"
+  desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.10.tar.gz"
-  sha256 "20de72ae94f8a5b409e29109309393f65db3895e3c1da983edadd54634ace68c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.10"
-    sha256 cellar: :any_skip_relocation, big_sur:      "bc96ba6b57d1a7f14f36fd4420d3c08fdb70d99bace4ec874d57e14d6bd10d88"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "269aaadc9ae3ef2d9087f407f6cb0f24d7cfceadf2afd69edbd034be4d3905f1"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.11.tar.gz"
+  sha256 "f10a48816945bd0b7f5b41fe865290b236e4b85ff2a03e3502e3e39f0e06eaa2"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test
 
   def install
+    # Build binary
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+
+    # Completions
+    output = Utils.safe_popen_read("#{bin}/readable-name-generator", "--completion", "bash")
+    (bash_completion/binary.to_s).write output
+    output = Utils.safe_popen_read("#{bin}/readable-name-generator", "--completion", "zsh")
+    (zsh_completion/binary.to_s).write output
+    output = Utils.safe_popen_read("#{bin}/readable-name-generator", "--completion", "fish")
+    (fish_completion/binary.to_s).write output
+
+    # Man pages
+    output = Utils.safe_popen_read("help2man", "#{bin}/readable-name-generator")
+    (man1/"readable-name-generator.1").write output
   end
 
   test do


### PR DESCRIPTION
## Changelog
### [v2.100.11](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.11) (2022-02-20)

### Build

- Versio update versions ([`e15b57f`](https://github.com/PurpleBooth/readable-name-generator/commit/e15b57f515e506b10d674a22a249b7795b7bd57d))

### Docs

- Update license ([`f93f7d0`](https://github.com/PurpleBooth/readable-name-generator/commit/f93f7d051aba2ec0b299dd2af3d62e07584d4d7b))

### Fix

- Update the ci versioning ([`89df7ea`](https://github.com/PurpleBooth/readable-name-generator/commit/89df7ea01560f812445705af2a2e7ef182644502))
- Improve name of homebrew repo ([`41226bb`](https://github.com/PurpleBooth/readable-name-generator/commit/41226bb7e2f4b0308da7c1ce64d5cf3495522167))
- Add completion to homebrew formula ([`54bc04a`](https://github.com/PurpleBooth/readable-name-generator/commit/54bc04a56d9a89b3edd4813fc35daccfffd2cfdc))

