### PR TITLE
fix: Update readable-name-generator to v2.100.12

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,20 +1,27 @@
 class ReadableNameGenerator < Formula
-  desc "Make conventional commits, faster, and consistently name scopes"
+  desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.10.tar.gz"
-  sha256 "20de72ae94f8a5b409e29109309393f65db3895e3c1da983edadd54634ace68c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.10"
-    sha256 cellar: :any_skip_relocation, big_sur:      "bc96ba6b57d1a7f14f36fd4420d3c08fdb70d99bace4ec874d57e14d6bd10d88"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "269aaadc9ae3ef2d9087f407f6cb0f24d7cfceadf2afd69edbd034be4d3905f1"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.12.tar.gz"
+  sha256 "92b122fcb06c927ac9d3f174e499fc7d55c8c179f5362002a6c665aed43385ed"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test
 
   def install
+    # Build binary
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+
+    # Completions
+    output = Utils.safe_popen_read("#{bin}/readable-name-generator", "--completion", "bash")
+    (bash_completion/"readable-name-generator").write output
+    output = Utils.safe_popen_read("#{bin}/readable-name-generator", "--completion", "zsh")
+    (zsh_completion/"_readable-name-generator").write output
+    output = Utils.safe_popen_read("#{bin}/readable-name-generator", "--completion", "fish")
+    (fish_completion/"readable-name-generator.fish").write output
+
+    # Man pages
+    output = Utils.safe_popen_read("help2man", "#{bin}/readable-name-generator")
+    (man1/"readable-name-generator.1").write output
   end
 
   test do


### PR DESCRIPTION
## Changelog
### [v2.100.12](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.12) (2022-02-20)

### Build

- Versio update versions ([`090468d`](https://github.com/PurpleBooth/readable-name-generator/commit/090468df86f994e093330135dd57020d60874d62))

### Fix

- Correct the completion in the formula ([`3a4c710`](https://github.com/PurpleBooth/readable-name-generator/commit/3a4c710a710f3990673e6fa5bfdbd858f234f767))
- Ci is already in the list, remove it ([`5bf8c40`](https://github.com/PurpleBooth/readable-name-generator/commit/5bf8c40dd514f694c6ae24d20094fc3759edd5e4))

