### PR TITLE
fix: Update ed-system-search to v1.1.28

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.27.tar.gz"
-  sha256 "3b7c394b3c5540e1a679e627d17bec67474156fd5c1708fb731e5cee09307f1b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.27"
-    sha256 cellar: :any_skip_relocation, big_sur:      "730c324f081846397c15b66e93ef5c9f0f07f54618c034f678b8de718d336bae"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a7665c0ace9d71209bf928ec5710e8ffec273d79b80a7cb25b7723159efa6fe4"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.28.tar.gz"
+  sha256 "86d9e02977ed9c92aa7b0c60a66484337fc38948a0ee559b3cc7ef8116f9df39"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.28](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.28) (2022-02-21)

### Build

- Versio update versions ([`06577ee`](https://github.com/PurpleBooth/ed-system-search/commit/06577eeb564080c4487378fd49030212f7be82ec))

### Fix

- Bump miette from 4.0.1 to 4.1.0 ([`949d6e4`](https://github.com/PurpleBooth/ed-system-search/commit/949d6e4ac50a2372822a83ecb0234224c28accd2))

