### PR TITLE
fix: Update git-moves-together to v2.5.23

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.22.tar.gz"
-  sha256 "a5258e33bd70117fb21f55fd9a36248a0c7c028081ecacb83a6e76790332f162"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.22"
-    sha256 cellar: :any,                 big_sur:      "965e4025c6df3dc03cc6d7fd710580145ba51ceda59811daffd50ffb77a06f3d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c79653f1c39258f38135a704f9c5edd1c4d50b0308f78a577b0e08496613e52a"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.23.tar.gz"
+  sha256 "c50406af77ed12367d44991436e146e3c175e904e95c4e03893c8e8677a91c44"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.23](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.23) (2022-02-21)

### Build

- Versio update versions ([`0a6a45e`](https://github.com/PurpleBooth/git-moves-together/commit/0a6a45e2ed854a6f42739034bca84937c71c0a54))

### Fix

- Bump comfy-table from 5.0.0 to 5.0.1 ([`980f799`](https://github.com/PurpleBooth/git-moves-together/commit/980f799fcf58efff104da4f150f667d77ca1d7cf))
- Bump miette from 4.0.1 to 4.1.0 ([`c58af17`](https://github.com/PurpleBooth/git-moves-together/commit/c58af17b3da0fbda74304c13c0ae5dc52ad01440))

