### PR TITLE
fix: Update fast-conventional to v1.0.13

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.12.tar.gz"
-  sha256 "52d7885a424b5e09399ee0b36868a41fbfbef10242c9baa9fa7dde0209ef1b49"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.12"
-    sha256 cellar: :any_skip_relocation, big_sur:      "4ff5a06f67b3d74e1af2996ed5fd1d54a3bc6623faddcd0eee9ae387f7489ab7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7e0054c9c7fbdf0851549c8a704b6d782197e22aa6f66236fa6662aa6f9ffbf8"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.13.tar.gz"
+  sha256 "34a0ce135d3edd5e2b20ffc734767793ae944ac4f00ec5711f22d21d39f2549f"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.13](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.13) (2022-02-21)

### Build

- Versio update versions ([`5c7c6a9`](https://github.com/PurpleBooth/fast-conventional/commit/5c7c6a967031a77cb99d1d7f52cb9a7eb1636891))

### Ci

- Add new scope for general code tasks ([`41eca8e`](https://github.com/PurpleBooth/fast-conventional/commit/41eca8ec9020504059bd47759172b7d61b93bc13))

### Fix

- Bump clap from 3.1.0 to 3.1.1 ([`88b25e3`](https://github.com/PurpleBooth/fast-conventional/commit/88b25e37409c7afcb388fc53803696da7ad53a84))
- Bump miette from 4.0.1 to 4.1.0 ([`fe47bcd`](https://github.com/PurpleBooth/fast-conventional/commit/fe47bcdd8ebe6b645cdad3ab9fccd3e67932c21c))

### Refactor

- Extract the config into its own model ([`663539a`](https://github.com/PurpleBooth/fast-conventional/commit/663539a3467fa66b773aff1c485308bcb8e35c14))
- Add a message to a state that should be impossible ([`927c9db`](https://github.com/PurpleBooth/fast-conventional/commit/927c9dbdb4ddf196c60b1e61665a096a85a61d57))
- Update the code for the yaml parse error ([`8ba8d43`](https://github.com/PurpleBooth/fast-conventional/commit/8ba8d43ec0baf330b038c59e6ce861c45a230a6f))
- Reduce visibility of config ([`84693cd`](https://github.com/PurpleBooth/fast-conventional/commit/84693cd8b6254725ed9a174dd0927f7e4a7c7edb))
- Remove unused unstable feature ([`d2bb402`](https://github.com/PurpleBooth/fast-conventional/commit/d2bb402c1bbdd6fa8a271da3cc1aec65690d2862))

