### PR TITLE
fix: Update whatismyip to v0.9.37

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.36.tar.gz"
-  sha256 "4552951c1a3109b7d3ec7a7724a3611df1a99ff99d342631b8860e08b2e75c46"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.36"
-    sha256 cellar: :any_skip_relocation, big_sur:      "5160869adb76003971c35e7811d87394d8ac4d418a586252ec025303f970ecde"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ba789e28bc765ac6751aed426fb712cf8064b720d59fae51efcc7db30d56e329"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.37.tar.gz"
+  sha256 "63760585cbe56d847fcd9a76c5d46dccd7fdac9de7208ad9bc237ba5315c6137"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.37](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.37) (2022-02-21)

### Build

- Versio update versions ([`e582583`](https://github.com/PurpleBooth/whatismyip/commit/e582583d56b4a95598872ab1d713364291c496fd))

### Ci

- Add fast conventional to make commits a bit easier ([`7287e32`](https://github.com/PurpleBooth/whatismyip/commit/7287e32a958736e01fa87fe39f9259008af10425))

### Fix

- Bump futures from 0.3.19 to 0.3.21 ([`9e4be6b`](https://github.com/PurpleBooth/whatismyip/commit/9e4be6b1e70bd0eb1f2a187add1266fade847323))
- Clean up unused dependencies ([`4ee88f6`](https://github.com/PurpleBooth/whatismyip/commit/4ee88f6b3238ff94ceefc51061a8c0137f9a1419))
- Bump clap from 3.1.0 to 3.1.1 ([`fced21b`](https://github.com/PurpleBooth/whatismyip/commit/fced21b0d8f04329421d9ea97c2dac12d3008238))
- Bump anyhow from 1.0.53 to 1.0.54 ([`28c73f0`](https://github.com/PurpleBooth/whatismyip/commit/28c73f05acdcbb1a0b484cbeb2ea1433fcae3fa8))

