### PR TITLE
fix: Update ellipsis to v0.6.33

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.32.tar.gz"
-  sha256 "1732a9778df3c95f94440b625903161b17f2d9b0dc4beb06e374b77a4a829398"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.32"
-    sha256 cellar: :any_skip_relocation, big_sur:      "313280f0f8f35b6bc67ebb0367eac2a6d911060962680ff93e51d02445a56436"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7ed6040e2dd30531f07cfb70ce785391d956a281494474dd3007ba7e5819a6f3"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.33.tar.gz"
+  sha256 "9c2c35c0a5cb67fe28926087b81c8eaaa472f8efead8045bd472abf4a4f54035"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.33](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.33) (2022-02-21)

### Build

- Versio update versions ([`591ff28`](https://github.com/PurpleBooth/ellipsis/commit/591ff287a54f789955d582d9366878be6e630db3))

### Fix

- Bump indoc from 1.0.3 to 1.0.4 ([`56721b7`](https://github.com/PurpleBooth/ellipsis/commit/56721b76b4e1724772e20728455870874e280455))
- Bump clap ([`2d5ebc7`](https://github.com/PurpleBooth/ellipsis/commit/2d5ebc7a79046790e47e20727e07a780748a6f58))
- Bump anyhow from 1.0.53 to 1.0.54 ([`5887174`](https://github.com/PurpleBooth/ellipsis/commit/58871742b2d8123b022d0b6094c454a0667768c5))

