### PR TITLE
fix: Update ed-system-search to v1.1.29

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.28.tar.gz"
-  sha256 "86d9e02977ed9c92aa7b0c60a66484337fc38948a0ee559b3cc7ef8116f9df39"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.28"
-    sha256 cellar: :any_skip_relocation, big_sur:      "b2bf4d1a5ed9a5e27619371e032546d55349d5e2590c2a650627e25df297cab7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "322ffbb4cb7e4e2244bfa3f40b9ff85e88d7c3e449bc38c22d135aabc2039821"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.29.tar.gz"
+  sha256 "13b61f119944b45b8d5f956eb43755866ad6e8c26bb7b1fbe626dc669caa2725"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.29](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.29) (2022-02-22)

### Build

- Versio update versions ([`23c4ce4`](https://github.com/PurpleBooth/ed-system-search/commit/23c4ce4f25c78faa1eab696236c002402d3b3517))

### Fix

- Bump clap from 3.1.0 to 3.1.1 ([`a0c7c43`](https://github.com/PurpleBooth/ed-system-search/commit/a0c7c438e0e1b5dfe51d94f349fd61a67c2a0aa2))

