### PR TITLE
fix: Update fix-compaudit to v0.46.74

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.73.tar.gz"
-  sha256 "d50a539a3d73b92ba093adfeb337c72cadd2774133078ef25b62be5f04d869ac"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.73"
-    sha256 cellar: :any_skip_relocation, big_sur:      "d53b56dc336147fa7fbd247883c1337bcfd90a1e964eeb0e491d2c0c5d944405"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2662b839f4ace2d64f38f17cb58cc59ff513cdcf2b291cb46ff9558c09717935"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.74.tar.gz"
+  sha256 "f7af64aa5b5c3da4dd9cab258e435273876171b06e6ab5f767230748825cf8dd"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.74](https://github.com/PurpleBooth/fix-compaudit/compare/v0.46.73...v0.46.74) (2022-02-22)

### Build

- Versio update versions ([`f63df2a`](https://github.com/PurpleBooth/fix-compaudit/commit/f63df2a647e5318b74d117ac438d530922f44114))

### Fix

- Bump clap from 3.0.13 to 3.0.14 ([`a6af477`](https://github.com/PurpleBooth/fix-compaudit/commit/a6af47778f1beb944165fb27ab50c47d55f6c5ff))
- Upgrade clap ([`9e9c093`](https://github.com/PurpleBooth/fix-compaudit/commit/9e9c093c1f3ffa1865eba6a3e45af517300bc32a))
- Bump clap from 3.1.0 to 3.1.1 ([`e0f50f5`](https://github.com/PurpleBooth/fix-compaudit/commit/e0f50f5ecf6cac97673eb49c0966333b98b4b9b5))

### [v0.46.73](https://github.com/PurpleBooth/fix-compaudit/compare/v0.46.72...v0.46.73) (2022-01-27)

### Build

- Versio update versions ([`796b0d6`](https://github.com/PurpleBooth/fix-compaudit/commit/796b0d6006a38f788644d77a8ad586b3e2091d3c))

### Ci

- Improve mergify config ([`466b117`](https://github.com/PurpleBooth/fix-compaudit/commit/466b117ef0f54652125bf23bcc6f4a02d384f92e))

### Fix

- Bump clap from 3.0.7 to 3.0.10 ([`a9d2ccc`](https://github.com/PurpleBooth/fix-compaudit/commit/a9d2ccc4cb6ffca7a32ddfcd82219b5c3c28a6b0))
- Bump clap from 3.0.10 to 3.0.12 ([`8c14fe5`](https://github.com/PurpleBooth/fix-compaudit/commit/8c14fe5d71a1dc1785a5cc9f3303872f9bcd5432))
- Bump clap from 3.0.12 to 3.0.13 ([`b88b671`](https://github.com/PurpleBooth/fix-compaudit/commit/b88b67139df43091c5b88cc1da1d5b82b6f885c5))

### [v0.46.72](https://github.com/PurpleBooth/fix-compaudit/compare/v0.46.71...v0.46.72) (2022-01-16)

### Build

- Versio update versions ([`dfbdd58`](https://github.com/PurpleBooth/fix-compaudit/commit/dfbdd583919c2ce0413937c04a8cc9e8c368a68b))

### Fix

- Bump clap from 3.0.6 to 3.0.7 ([`a080bd8`](https://github.com/PurpleBooth/fix-compaudit/commit/a080bd83f428af3cbc40d7f2b14c54644c21ef5f))

### [v0.46.71](https://github.com/PurpleBooth/fix-compaudit/compare/v0.46.70...v0.46.71) (2022-01-11)

### Build

- Versio update versions ([`6cd12a3`](https://github.com/PurpleBooth/fix-compaudit/commit/6cd12a355d84db0a5a36e1ececfc6d725145ac9b))

### Fix

- Bump clap from 3.0.5 to 3.0.6 ([`e3760c1`](https://github.com/PurpleBooth/fix-compaudit/commit/e3760c1451f6acede384f5db61e2b4bf81baf1b2))

### [v0.46.70](https://github.com/PurpleBooth/fix-compaudit/compare/v0.46.69...v0.46.70) (2022-01-10)

### Build

- Versio update versions ([`ed53164`](https://github.com/PurpleBooth/fix-compaudit/commit/ed531642e005a2a9acc212aa8be16da57726ed11))

### Fix

- Bump tempfile from 3.2.0 to 3.3.0 ([`9a0840d`](https://github.com/PurpleBooth/fix-compaudit/commit/9a0840da86656c3b544006dc31f5e9bf23f92e1a))

### [v0.46.69](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.69) (2022-01-08)

### Build

- Versio update versions ([`1509ac5`](https://github.com/PurpleBooth/fix-compaudit/commit/1509ac566cd43917a12a6c30189bd3a53a8e9481))

### Ci

- Fix the merge automation ([`100a581`](https://github.com/PurpleBooth/fix-compaudit/commit/100a5810af39d47602874da6be24a30733133fa8))

### Fix

- Bump clap from 3.0.0 to 3.0.5 ([`567f499`](https://github.com/PurpleBooth/fix-compaudit/commit/567f499a953408660cb533e0aa10b2b21a47cabe))

