### PR TITLE
fix: Update readable-name-generator to v2.100.13

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.12.tar.gz"
-  sha256 "92b122fcb06c927ac9d3f174e499fc7d55c8c179f5362002a6c665aed43385ed"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.12"
-    sha256 cellar: :any_skip_relocation, big_sur:      "e94ee15ec21ec9dfee985585fc21e1994e4bd6af75218eb5fc4a277a364a253e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "fd9e48772fdffb4d39dc9b50e053fff01864a464a98f56158c1f97d7f8d3d789"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.13.tar.gz"
+  sha256 "9267668f7da99fcd532c191770db7630c7782715524f0c68619ffcfef33cb452"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.13](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.13) (2022-02-22)

### Build

- Add scope for dependencies ([`0434177`](https://github.com/PurpleBooth/readable-name-generator/commit/0434177001d691d6d7ca223bda9ffb11354f474d))
- Versio update versions ([`e4e08bf`](https://github.com/PurpleBooth/readable-name-generator/commit/e4e08bf0b34fabb7052a1ffdad0d4db095cd8bfc))

### Ci

- Configuration update ([`d33ff80`](https://github.com/PurpleBooth/readable-name-generator/commit/d33ff80235e5303c88e5949f3f5489b78b72531f))

### Fix

- Bump clap from 3.1.0 to 3.1.1 ([`e359e47`](https://github.com/PurpleBooth/readable-name-generator/commit/e359e474879581903baa505d280668901da6415e))

