### PR TITLE
fix: Update readable-name-generator to v2.100.14

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.13.tar.gz"
-  sha256 "9267668f7da99fcd532c191770db7630c7782715524f0c68619ffcfef33cb452"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.13"
-    sha256 cellar: :any_skip_relocation, big_sur:      "9c4229e747ac2c5a19bb9f2ab52892f66dfe27fc952b02831c72e3c3280c959b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f679f9a18f136ae653a83822b2c41189f7bd2b406d6a9f89173c6e39b8ece03f"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.14.tar.gz"
+  sha256 "6adc5e5598fe358666c782673859a6cce2c1942736ba8f9fb750b7560e72220f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.14](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.14) (2022-02-22)

### Build

- Versio update versions ([`700003e`](https://github.com/PurpleBooth/readable-name-generator/commit/700003ed0eb026c4a4658302f8da2e64d6be0925))

### Fix

- Bump miette from 4.0.1 to 4.2.0 ([`24e9795`](https://github.com/PurpleBooth/readable-name-generator/commit/24e979573d5f43c5126d21b566820e80a09c2626))

