### PR TITLE
fix: Update git-moves-together to v2.5.24

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.23.tar.gz"
-  sha256 "c50406af77ed12367d44991436e146e3c175e904e95c4e03893c8e8677a91c44"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.23"
-    sha256 cellar: :any,                 big_sur:      "75da4f9c66abc75b5b4156e61922242f4da5b79c838facc1e1d2ba7c6a05d9e2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "50bbcc520c940b6a12ee1d792dd4fa4f358fbbbc54727783b072c9411f2b4730"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.24.tar.gz"
+  sha256 "e0ea224f9a7f884b197656e3965d4348d62e027a2cbcd73a52d813ef178b6637"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.24](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.24) (2022-02-22)

### Build

- Versio update versions ([`a4eddc2`](https://github.com/PurpleBooth/git-moves-together/commit/a4eddc278f05d76640040d28a7b4a4e2960008da))

### Fix

- Bump miette from 4.1.0 to 4.2.0 ([`f29e57e`](https://github.com/PurpleBooth/git-moves-together/commit/f29e57e6ae774d9ca645e74e43398679a1422f39))
- Bump clap from 3.1.0 to 3.1.1 ([`a1f1269`](https://github.com/PurpleBooth/git-moves-together/commit/a1f1269fe661cb7944eeb81b6ba917672cabd40f))

