### PR TITLE
fix: Update fast-conventional to v1.0.14

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.13.tar.gz"
-  sha256 "34a0ce135d3edd5e2b20ffc734767793ae944ac4f00ec5711f22d21d39f2549f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.13"
-    sha256 cellar: :any_skip_relocation, big_sur:      "731b2a36a6f1c9f5b6759e8dc321218c410d6381eb613c20dbb40aa84f335f70"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b36db21d5ecd770400002b9d374ddc5090cb636cdccbe56ceec6cd3d7d08779d"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.14.tar.gz"
+  sha256 "57f87e53c8a154afbd92a045e01d2cc727ba92c5bd457cbb7189e2c2b637c7d4"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.14](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.14) (2022-02-22)

### Build

- Add scopes ([`beb420c`](https://github.com/PurpleBooth/fast-conventional/commit/beb420c6da8bb7cca9b07fd167e8a1a04e7aae67))
- Versio update versions ([`f8972da`](https://github.com/PurpleBooth/fast-conventional/commit/f8972da70672ac7d73f04fa0dd4a648fd371ba73))

### Fix

- Bump miette from 4.1.0 to 4.2.0 ([`d2c5857`](https://github.com/PurpleBooth/fast-conventional/commit/d2c58577f25df39b15dc0afbd12eab9a11120a9e))

