### PR TITLE
fix: Update git-mit to v5.12.34

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.33.tar.gz"
-  sha256 "420bc5d9c368799a5c7e53d02a0d0dcd8ba019bca1a188bf38ada86fb49a67c9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.33"
-    sha256 cellar: :any,                 big_sur:      "43f91b8f414a1c8a39005506f0e2718b2b0ea8b85dd31a91a1f21a83b30ca44c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "fe8a1574e29dfb564363eff47325899e6c362cc8087a6622536beff35edbe526"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.34.tar.gz"
+  sha256 "f39c9fbc2089fdfc7ac994db4f3246620204bb3fba22b0934f2244e8520c21cc"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.34](https://github.com/PurpleBooth/git-mit/compare/...v5.12.34) (2022-02-22)

### Build

- Versio update versions ([`b5fd5f2`](https://github.com/PurpleBooth/git-mit/commit/b5fd5f2abd41f0ecb37a8245a796a5cf46ef11a1))

### Fix

- Bump miette from 4.0.1 to 4.1.0 ([`cd11e2b`](https://github.com/PurpleBooth/git-mit/commit/cd11e2bb7e2514cd0a8299284c5102a5c2144ec5))
- Bump clap from 3.1.0 to 3.1.1 ([`7f509b4`](https://github.com/PurpleBooth/git-mit/commit/7f509b4498a198bd4da9f9755a9d9994cdfc938a))
- Bump miette from 4.1.0 to 4.2.0 ([`421ab32`](https://github.com/PurpleBooth/git-mit/commit/421ab3228208e44f65352166c1bec768c4d29b5f))

