### PR TITLE
fix: Update ellipsis to v0.6.34

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.33.tar.gz"
-  sha256 "9c2c35c0a5cb67fe28926087b81c8eaaa472f8efead8045bd472abf4a4f54035"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.33"
-    sha256 cellar: :any_skip_relocation, big_sur:      "5dbae980b6e2c383c7a3c8b7b1e09901c242ede3e21ca1604ef2d1d1b16cef23"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "861060ea6a7661f15d8ebe587296a3885626304d2b041d9527b8ed8e8b675ca2"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.34.tar.gz"
+  sha256 "490d01f55f770f52e9e7bf0146396c2c5e4ff5e02c4b34bc38343f2f3219875f"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.34](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.34) (2022-02-22)

### Build

- Versio update versions ([`9e33e45`](https://github.com/PurpleBooth/ellipsis/commit/9e33e4510d40a3e53eaab20d21b21c9790bc7b7d))

### Fix

- Bump clap from 3.1.0 to 3.1.1 ([`2e410d4`](https://github.com/PurpleBooth/ellipsis/commit/2e410d4980a165dd706a87e9ea89595ea81e4787))
- Bump anyhow from 1.0.54 to 1.0.55 ([`e29a1c9`](https://github.com/PurpleBooth/ellipsis/commit/e29a1c9ea8f7457e95a3006013e195da06d44902))

