### PR TITLE
fix: Update ed-system-search to v1.1.30

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.29.tar.gz"
-  sha256 "13b61f119944b45b8d5f956eb43755866ad6e8c26bb7b1fbe626dc669caa2725"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.29"
-    sha256 cellar: :any_skip_relocation, big_sur:      "dfaa7eb1d2cf69bc647672e3efa8a4adbb5ac09c757a5054c5c411ecf7708b37"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c2aecfef5c6d8937233a954612ba0d9ef220ea7414d3d9731e68a2c2e00ad084"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.30.tar.gz"
+  sha256 "0518dd6fa9a1d77a3849a833140d9ec3466787a3e841ba940672ddda856ba397"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.30](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.30) (2022-02-23)

### Build

- Versio update versions ([`823b7e8`](https://github.com/PurpleBooth/ed-system-search/commit/823b7e806f294873a318624096ac18e91dc7c67f))

### Fix

- Bump miette from 4.1.0 to 4.2.0 ([`b8c0266`](https://github.com/PurpleBooth/ed-system-search/commit/b8c02664d08019d5c4da73c72fc4d9f98c5e4834))

