### PR TITLE
fix: Update whatismyip to v0.9.38

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.37.tar.gz"
-  sha256 "63760585cbe56d847fcd9a76c5d46dccd7fdac9de7208ad9bc237ba5315c6137"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.37"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6344625d907ff83eba8903550830df403ad07c5a8df8f156d0fd4e040ca06644"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3e5cc3f10077ada531ce997cb0ca8ae560150c3131d02eea32dc5d17a6488ca0"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.38.tar.gz"
+  sha256 "54b50dfdb85b80596ef3c71d0ac3b3db9a3849762ab533f70c786c052a9fc57e"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.38](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.38) (2022-02-23)

### Build

- Versio update versions ([`4d68859`](https://github.com/PurpleBooth/whatismyip/commit/4d688595cc34b0a5c9cc7b0f119d138543f0aee9))

### Fix

- Bump anyhow from 1.0.54 to 1.0.55 ([`e1fe61a`](https://github.com/PurpleBooth/whatismyip/commit/e1fe61ab24c217b89d0b92d0d2f6bc48802967ed))
- Bump clap from 3.1.1 to 3.1.2 ([`6e04f2a`](https://github.com/PurpleBooth/whatismyip/commit/6e04f2a9f2d985f2276eb33ce057eb50def0605e))

