### PR TITLE
fix: Update readable-name-generator to v2.100.15

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.14.tar.gz"
-  sha256 "6adc5e5598fe358666c782673859a6cce2c1942736ba8f9fb750b7560e72220f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.14"
-    sha256 cellar: :any_skip_relocation, big_sur:      "1e48da84421714dab540e6603c267c31fdcb429ff8dbc02fb01ba1d01fdf1fcd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6480effa95e31d7245a0235f5915b42198dc3771b129066fbbc1b3d00c0afa05"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.15.tar.gz"
+  sha256 "d7d478b7c8ebf3036ad35f05f0165dce1b534e383d335e9030ce5b22a71eb6e5"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.15](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.15) (2022-02-23)

### Build

- Versio update versions ([`a840ece`](https://github.com/PurpleBooth/readable-name-generator/commit/a840ece223e275fb944c2b4dc5786e737a2a085b))

### Fix

- Bump clap from 3.1.1 to 3.1.2 ([`ad3c69c`](https://github.com/PurpleBooth/readable-name-generator/commit/ad3c69c1bb6abb8a8ed188f299967debdd927f05))

