### PR TITLE
fix: Update game-of-life to v1.53.55

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.54.tar.gz"
-  sha256 "e45a3d71aedbbe4e20bf9befeedbb1bb82108951e0b0b553eacfbefabdf4c9a1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.54"
-    sha256 cellar: :any_skip_relocation, big_sur:      "3bafa78da90c7cd95f256154678f82f5a199ea01914f6b8d3a3bbf2060d4ecdc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e2940aa09f0016379f02ca1ddbd3d8a47631819d81ff6af97c38fcbcc643b1c5"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.55.tar.gz"
+  sha256 "1fbaa93ddb72ab6ccf16c639f4f7fd2a327cbab5a5580fc08edcf4b71be79c90"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.55](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.55) (2022-02-24)

### Build

- Versio update versions ([`2e9d0e3`](https://github.com/PurpleBooth/game-of-life/commit/2e9d0e37a61c6b77bcf632d1bd3a60be68395047))

### Fix

- Bump clap from 3.1.0 to 3.1.1 ([`c797806`](https://github.com/PurpleBooth/game-of-life/commit/c79780627c2cb02a5fcecef04f77924a78c6ad3b))
- Bump clap from 3.1.1 to 3.1.2 ([`79e4f1f`](https://github.com/PurpleBooth/game-of-life/commit/79e4f1f592d2b75cc8134aa2a72ec3f333d20821))

