### PR TITLE
fix: Update ed-system-search to v1.1.31

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.30.tar.gz"
-  sha256 "0518dd6fa9a1d77a3849a833140d9ec3466787a3e841ba940672ddda856ba397"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.30"
-    sha256 cellar: :any_skip_relocation, big_sur:      "f86c80f66d948506b7d8b66d3709380c4d3a2f1bb80689d9ede4f4eef56bc7c8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d0bd4768d7f07736fd46d268a70505ec443720fad32f5f2c7da8b1faf1662ed5"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.31.tar.gz"
+  sha256 "081e6877be97b2f4f1b559414a28a7c91f66441260a9f00dae25e813c9cb7ee3"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.31](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.31) (2022-02-24)

### Build

- Versio update versions ([`1d51ebc`](https://github.com/PurpleBooth/ed-system-search/commit/1d51ebc01cb0147385b608a7e351e252eea5aeb8))

### Fix

- Bump clap from 3.1.1 to 3.1.2 ([`8466e21`](https://github.com/PurpleBooth/ed-system-search/commit/8466e2189e9dbc595fab0e61f8c088533c06dce3))

