### PR TITLE
fix: Update fix-compaudit to v0.46.75

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.74.tar.gz"
-  sha256 "f7af64aa5b5c3da4dd9cab258e435273876171b06e6ab5f767230748825cf8dd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.74"
-    sha256 cellar: :any_skip_relocation, big_sur:      "ec19b4edece58961fb124b9e84de34dea4ee23d12999b7e2ebb0de0c03c2a4f4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6d3f6b8336852e2a930f07e8486d5aa7c63e4f4f0277686d21cc4b0fc0427960"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.75.tar.gz"
+  sha256 "8d4dda20a39b97eac0e7a8a8ecc3a93f2bcceced98b58d64bf3d0470fe31c94b"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.75](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.75) (2022-02-24)

### Build

- Versio update versions ([`b472543`](https://github.com/PurpleBooth/fix-compaudit/commit/b472543bd00be9e97a86bc27816e83c3731e4414))

### Fix

- Bump clap from 3.1.1 to 3.1.2 ([`80159e3`](https://github.com/PurpleBooth/fix-compaudit/commit/80159e3a0462cebbfc1455ebf43b2da8221efdf0))

