### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.41

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.40.tar.gz"
-  sha256 "850ff4a75cea05c99a382b931688e42a5cc0fa5996e5fc607e7826fbedbb8a4f"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.41.tar.gz"
+  sha256 "4e8e9a9ae450773dff7a683f32262f3e02fcc34c91b0dea19bff919cbeb2bc6c"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.40"
-    sha256 cellar: :any_skip_relocation, big_sur:      "220a9e89bb8e690bfaac3be29c587ef9ffde7ce0c1c0cfd7f9d8a20734f541b0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "617b44b7c233ae8096960db46578b988b2eee2d55adb3d73163fde0dd8ac744d"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.41](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.41) (2022-02-24)

### Build

- Versio update versions ([`f8b1ac5`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/f8b1ac54eddbb00e1cb41b8d67e0cf6e080d1705))

### Fix

- Bump clap from 3.1.0 to 3.1.1 ([`f59e4e8`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/f59e4e8d344c10727da6deb3e1997efb244bd3f2))
- Bump clap from 3.1.1 to 3.1.2 ([`80e0849`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/80e0849122a51dae166f56ea9dfdaa0b61c5ac04))

