### PR TITLE
fix: Update git-mit to v5.12.35

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.34.tar.gz"
-  sha256 "f39c9fbc2089fdfc7ac994db4f3246620204bb3fba22b0934f2244e8520c21cc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.34"
-    sha256 cellar: :any,                 big_sur:      "5f218afeffa9e39f38c058882aefc2863e7dba12d81b9e783db8933216f2513e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "604b800db5472b59d839d3510f2c43ede9621c4f896b249ac0c532252d24a46f"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.35.tar.gz"
+  sha256 "7bacaac74956783f20cf6688cd1c85551f49540f1b688140c95ffd6c21f371b8"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.35](https://github.com/PurpleBooth/git-mit/compare/...v5.12.35) (2022-02-24)

### Build

- Versio update versions ([`3a9eeea`](https://github.com/PurpleBooth/git-mit/commit/3a9eeeaecd2da4175853e26ec65d867c37fbf26f))

### Fix

- Bump mit-lint from 3.0.4 to 3.0.6 ([`20176ab`](https://github.com/PurpleBooth/git-mit/commit/20176ab5ca63f5ea09e02ba396cc282d9407bd54))
- Bump clap from 3.1.1 to 3.1.2 ([`9be8cc3`](https://github.com/PurpleBooth/git-mit/commit/9be8cc36014d5ee321700364a06e021622d51388))

