### PR TITLE
fix: Update hungry-distance to v0.1.24

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.23.tar.gz"
-  sha256 "2f030acd61a598d6e5e0253519629cb0045f8746c64661e529a41807dd0f9057"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.23"
-    sha256 cellar: :any_skip_relocation, big_sur:      "c6d0cb27a710bca77f5587c1762bb36d63603142af9e0708e4bb03b567948693"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a279bf09ba1dec5ebc557193e081336f238023733757c50f6dc702f2f6258dc3"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.24.tar.gz"
+  sha256 "569988786a985acac53bd45d3495dd6c07e46d641d8840bc5bc5c16331b6a5eb"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.24](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.24) (2022-02-24)

### Build

- Versio update versions ([`e753594`](https://github.com/PurpleBooth/hungry-distance/commit/e7535949f4b29c08358b8ce6c7d47d196abe17b9))

### Fix

- Bump clap from 3.1.0 to 3.1.1 ([`bfc21dd`](https://github.com/PurpleBooth/hungry-distance/commit/bfc21dd3e01cfa143d3bad7649bccbc917530aff))
- Bump clap from 3.1.1 to 3.1.2 ([`2b1c1b4`](https://github.com/PurpleBooth/hungry-distance/commit/2b1c1b4ecea6f15a35311c5169d06e2fe2647970))

