### PR TITLE
fix: Update git-moves-together to v2.5.25

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.24.tar.gz"
-  sha256 "e0ea224f9a7f884b197656e3965d4348d62e027a2cbcd73a52d813ef178b6637"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.24"
-    sha256 cellar: :any,                 big_sur:      "638bd1d02384d135d590b294e80fccb6317a3c1243485654ab2a36af9e891c77"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "01590c97638179a647c2a542a5d2aa70253cd0d8171ad421587c7707d61d94bd"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.25.tar.gz"
+  sha256 "6ffe26980228e792b1caac97d74b9d4ea2b3745fb3a430ae02f631bd0167dd80"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.25](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.25) (2022-02-25)

### Build

- Versio update versions ([`270fcac`](https://github.com/PurpleBooth/git-moves-together/commit/270fcac63c7766cafac6aefc00edf3bb741200c6))

### Fix

- Bump clap from 3.1.1 to 3.1.2 ([`d374cd0`](https://github.com/PurpleBooth/git-moves-together/commit/d374cd097529a569aaa5a4d8166940a17eba6629))
- Bump git2 from 0.13.25 to 0.14.0 ([`cbe9e0b`](https://github.com/PurpleBooth/git-moves-together/commit/cbe9e0b272d7cf12815fd80e42053874e114f306))

