### PR TITLE
fix: Update git-mit to v5.12.36

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.35.tar.gz"
-  sha256 "7bacaac74956783f20cf6688cd1c85551f49540f1b688140c95ffd6c21f371b8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.35"
-    sha256 cellar: :any,                 big_sur:      "fd8b051ebc84d23d1fe7e6b7333afb9ea6573b632bc981fc02f61ebc27d4738f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8380ceac3925371f59e2a457229833c26823e0e037f3251eeac98f9e717701d7"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.36.tar.gz"
+  sha256 "c0fc093b380bdc95900f4644158480149881b9c97912419533dca4b6eacf82e8"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.36](https://github.com/PurpleBooth/git-mit/compare/...v5.12.36) (2022-02-25)

### Build

- Versio update versions ([`2ff5e3c`](https://github.com/PurpleBooth/git-mit/commit/2ff5e3c54b46e55eff4216948cb2d2d17b911a92))

### Fix

- Bump git2 from 0.13.25 to 0.14.0 ([`34e106c`](https://github.com/PurpleBooth/git-mit/commit/34e106c4323d4dfc1c3cfca586259ae71bf79148))
- Bump rust from 1.58.1 to 1.59.0 ([`1fe3e3a`](https://github.com/PurpleBooth/git-mit/commit/1fe3e3a76571331346f4bfc34a1af8dda4185e51))

