### PR TITLE
fix: Update fast-conventional to v1.0.15

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.14.tar.gz"
-  sha256 "57f87e53c8a154afbd92a045e01d2cc727ba92c5bd457cbb7189e2c2b637c7d4"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.14"
-    sha256 cellar: :any_skip_relocation, big_sur:      "af0e4a791e67b4bac86b81bc941eca516786c9738b0f0406c9e005cd88d64374"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0fad7c7f01616034d6be65e8735698a1d9e05ea7c3be50ee6ebdaba51a891936"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.15.tar.gz"
+  sha256 "7b4d489b350586e188d643c211a5f189b3873ebc40f859f7d162d303e94df830"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.15](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.15) (2022-02-25)

### Build

- Versio update versions ([`7f3ae9a`](https://github.com/PurpleBooth/fast-conventional/commit/7f3ae9a00d36baccaba22eff30ba4158f777cf44))

### Fix

- Bump clap from 3.1.1 to 3.1.2 ([`4a5e5b3`](https://github.com/PurpleBooth/fast-conventional/commit/4a5e5b3dcbac14692d1d66eba257c5cb1ed3a78f))
- Bump miette from 4.2.0 to 4.2.1 ([`381e715`](https://github.com/PurpleBooth/fast-conventional/commit/381e715dc316e1debdc3b111c4ca0fdc3a50fee4))

