### PR TITLE
fix: Update readable-name-generator to v2.100.16

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.15.tar.gz"
-  sha256 "d7d478b7c8ebf3036ad35f05f0165dce1b534e383d335e9030ce5b22a71eb6e5"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.15"
-    sha256 cellar: :any_skip_relocation, big_sur:      "f328710ede663666f360105225a832c2a17ba24506f1913507f65bb0e67900a6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e06d07cd199a24f1e9f3a2d6b41c03d8084e167c0445c0301be4639afff1c516"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.16.tar.gz"
+  sha256 "dd00a00494f6de1801868a172b5aebd77b4de7cbe5aef93b77adc3b79b707538"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.16](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.16) (2022-02-25)

### Build

- Versio update versions ([`f00f9d8`](https://github.com/PurpleBooth/readable-name-generator/commit/f00f9d8a3ceb369939ecd81a1f49d40b6e7575bb))

### Fix

- Bump rust from 1.58.1 to 1.59.0 ([`0649221`](https://github.com/PurpleBooth/readable-name-generator/commit/064922131f81fe6273a46f79de4b8d96da436707))

