### PR TITLE
fix: Update ed-system-search to v1.1.32

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.31.tar.gz"
-  sha256 "081e6877be97b2f4f1b559414a28a7c91f66441260a9f00dae25e813c9cb7ee3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.31"
-    sha256 cellar: :any_skip_relocation, big_sur:      "700123c6eec07826209b244326d04de3bb5fbe6d8842d009322d257267d43307"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0cf63359efa7a9e5dd31efd755adefa52bd06907c8e108945ac497360a332e3c"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.32.tar.gz"
+  sha256 "a3b83ad682f5bfbebf955fc20f78a9d357ec7691085ef6c6506ac47fecf289e1"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.32](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.32) (2022-02-28)

### Build

- Versio update versions ([`764defa`](https://github.com/PurpleBooth/ed-system-search/commit/764defa1da8ac73623e74438fdbe1b56c5063426))

### Fix

- Bump miette from 4.2.0 to 4.2.1 ([`adab9d6`](https://github.com/PurpleBooth/ed-system-search/commit/adab9d6a53cf444678a4e6206d3a66535bf1a03f))

