### PR TITLE
fix: Update whatismyip to v0.9.39

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.38.tar.gz"
-  sha256 "54b50dfdb85b80596ef3c71d0ac3b3db9a3849762ab533f70c786c052a9fc57e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.38"
-    sha256 cellar: :any_skip_relocation, big_sur:      "2cc78cb97e9d1e02d24d1c393ff065ae38357642e3819e35a87966d8fc9cafa4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "508b2ebdbe045ba098b87177882985b6ff015bfb555ba3e93f3e6bc7a7d2fcb8"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.39.tar.gz"
+  sha256 "bf91a3703b3e86685ecdfd2842fdd0a0aa2b3b04013bd19835744bc521e0834b"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.39](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.39) (2022-02-28)

### Build

- Versio update versions ([`df231cb`](https://github.com/PurpleBooth/whatismyip/commit/df231cbe0850be72c6182471841db0973b573591))

### Fix

- Bump clap from 3.1.2 to 3.1.3 ([`993f8f3`](https://github.com/PurpleBooth/whatismyip/commit/993f8f33fa9282f094ec28fe6e51e21eae4d5b2c))

