### PR TITLE
fix: Update readable-name-generator to v2.100.17

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.16.tar.gz"
-  sha256 "dd00a00494f6de1801868a172b5aebd77b4de7cbe5aef93b77adc3b79b707538"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.16"
-    sha256 cellar: :any_skip_relocation, big_sur:      "ddc258e3e97d38fe65f301a6292ad1e8656ab64a3882edea21b4d26f74e1be2d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "df326d6382730fa470332ccdb6f3d10e0b1de48217f1a69a610e1bb4bedeaf3c"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.17.tar.gz"
+  sha256 "e0376ac98b50c66d39093bf9871dc35dc72e910b7b68dfb65af5c304a5b87fd6"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.17](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.17) (2022-02-28)

### Build

- Versio update versions ([`650ab7a`](https://github.com/PurpleBooth/readable-name-generator/commit/650ab7a8466e2a73466063b1bba1e06f22a3d8ce))

### Fix

- Bump miette from 4.2.0 to 4.2.1 ([`694919b`](https://github.com/PurpleBooth/readable-name-generator/commit/694919b91b2eca57effab5318eecc75f49fd27f6))
- Bump clap from 3.1.2 to 3.1.3 ([`dbca133`](https://github.com/PurpleBooth/readable-name-generator/commit/dbca133f9acd1df09f2d8b2889d6311dedc550d0))

