### PR TITLE
fix: Update fast-conventional to v1.0.16

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.15.tar.gz"
-  sha256 "7b4d489b350586e188d643c211a5f189b3873ebc40f859f7d162d303e94df830"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.15"
-    sha256 cellar: :any_skip_relocation, big_sur:      "d8bf3950c4f1a0932a01a4774ca82fa38334022eea44071c65606cec75bb8382"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "321d781b74221b78bf503d7a4b476fdb7dc1de52313f820df981687c30014a1b"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.16.tar.gz"
+  sha256 "8c8fe2883bb5a297c3950646a28f59ffa846489ac60c8cd7912773fd7384ffa7"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.16](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.16) (2022-02-28)

### Build

- Versio update versions ([`fc29c04`](https://github.com/PurpleBooth/fast-conventional/commit/fc29c04181a1aff3493038e9dc219af774aa8747))

### Fix

- Bump clap from 3.1.2 to 3.1.3 ([`97d3079`](https://github.com/PurpleBooth/fast-conventional/commit/97d30792c59806ef2e11b88e59f42a2a7b4f6a51))

### Refactor

- Mark structs as non-exhausted ([`a0a069a`](https://github.com/PurpleBooth/fast-conventional/commit/a0a069af0daf54c1bb1cbcedaff38f03b0f3227f))

