### PR TITLE
fix: Update git-moves-together to v2.5.27

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.26.tar.gz"
-  sha256 "78fa89d0875811685bbe479e4407745d828dad03b92b8cfee0f4f7588cfb7c95"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.26"
-    sha256 cellar: :any,                 big_sur:      "f9e173d9923708370c80c29d8f9488c4f00fdb264ca39dae514ecd12471bef9a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "cc9cde2e1ed3f377c24d535f4165294fc5d2eb81b825ab3cad3dc1b8e6407ddb"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.27.tar.gz"
+  sha256 "ba5d22f1bea792df6603738970c1dc268d8fab740e84e751b894ae650f454d97"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.27](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.27) (2022-02-28)

### Build

- Versio update versions ([`fac932f`](https://github.com/PurpleBooth/git-moves-together/commit/fac932f0dd31daa51debc76e934552c9dd485bd1))

### Fix

- Bring cargo.toml up to date ([`5bce501`](https://github.com/PurpleBooth/git-moves-together/commit/5bce50165cc71f34fc757ec50ca3db52d73fe567))

### Refactor

- Move to using parse syntax from clap ([`b589288`](https://github.com/PurpleBooth/git-moves-together/commit/b58928805d73a9a38d497796e20f6f837342fecd))

