### PR TITLE
fix: Update ellipsis to v0.6.35

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.34.tar.gz"
-  sha256 "490d01f55f770f52e9e7bf0146396c2c5e4ff5e02c4b34bc38343f2f3219875f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.34"
-    sha256 cellar: :any_skip_relocation, big_sur:      "3ae44bc3ffe9e8e169e43dc774ff77fa8d83f34a6b207b1ca4db68747dcd694b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "95e8708c97972c329f84fb93cde3b4d4eb861c9b18690fd1b03c89298a7462f4"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.35.tar.gz"
+  sha256 "3e97fe724ff4a1379807fb00fb2bd3184e23dcad1a4f69adeedd7cbd984947e9"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.35](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.35) (2022-02-28)

### Build

- Versio update versions ([`09303c4`](https://github.com/PurpleBooth/ellipsis/commit/09303c4f7651e09ac501dead0eee0030d04fe0d9))

### Fix

- Bump clap from 3.1.1 to 3.1.2 ([`638366d`](https://github.com/PurpleBooth/ellipsis/commit/638366df1139428df5b69bd23064b5b6667283da))
- Bump clap from 3.1.2 to 3.1.3 ([`b43f014`](https://github.com/PurpleBooth/ellipsis/commit/b43f0148faea053a68ae8be20fb5f26ac0e28e92))

