### PR TITLE
fix: Update ed-system-search to v1.1.33

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.32.tar.gz"
-  sha256 "a3b83ad682f5bfbebf955fc20f78a9d357ec7691085ef6c6506ac47fecf289e1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.32"
-    sha256 cellar: :any_skip_relocation, big_sur:      "377e76f970752844890fc4ba09f43a1552b86b2064a371fb119421c22d1ee736"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "146a85a8a0dd287c6e6d3ae68c06ce0a0f107459ce3ca3200f774421cec66b1b"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.33.tar.gz"
+  sha256 "0c008304c43c5fc1c7cddf692d5a05502901fc4b18319f06241268aa06fe5982"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.33](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.33) (2022-03-01)

### Build

- Versio update versions ([`864b66f`](https://github.com/PurpleBooth/ed-system-search/commit/864b66fd3c99d7dacaa1c10e84008d20bf03571a))

### Fix

- Bump clap from 3.1.2 to 3.1.3 ([`03cf255`](https://github.com/PurpleBooth/ed-system-search/commit/03cf255d93acf3ef3d8b5270c25a1351d0cb4c21))

