### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.42

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.41.tar.gz"
-  sha256 "4e8e9a9ae450773dff7a683f32262f3e02fcc34c91b0dea19bff919cbeb2bc6c"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.42.tar.gz"
+  sha256 "945b3a40c683ec6bf639ed4bf53a238112d4dfb61b6587066cdf412ed793e281"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.41"
-    sha256 cellar: :any_skip_relocation, big_sur:      "a1709426027072fe7952cbe8a10d994acad28ebd49f82021920a04c7c3350aff"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b94d378df429e092a9443636cfeb922c56d4e6307d17ff096194e42c7b87999f"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.42](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.42) (2022-03-01)

### Build

- Versio update versions ([`07ce4d4`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/07ce4d4c8407d07fb0483d9fafe1d366ced2fecd))

### Fix

- Bump clap from 3.1.2 to 3.1.3 ([`36ceab2`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/36ceab231e8c35a663ddda219617ffb27b8b7769))

