### PR TITLE
fix: Update git-mit to v5.12.38

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.37.tar.gz"
-  sha256 "7972f73ad95d344c7e43c90d09d7c90b51bc0ddc888b8782e33f63098423061b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.37"
-    sha256 cellar: :any,                 big_sur:      "598d487a359e1a7b67a01b1a6e1ca51037c5589750d5bb8b7841667462b9a0d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6af99806920d43fab56c6d38467b759dd978910006ec74d6550bd75dc6d34f4e"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.38.tar.gz"
+  sha256 "bf422baa305541785f9f3db9685b7ee1ae8357651b9db4bbb3afee9d156db9c8"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.38](https://github.com/PurpleBooth/git-mit/compare/...v5.12.38) (2022-03-01)

### Build

- Versio update versions ([`eb4d5db`](https://github.com/PurpleBooth/git-mit/commit/eb4d5dba53206f1c319076845b88eeb389321697))

### Fix

- Bump git2 from 0.14.0 to 0.14.1 ([`effcb1e`](https://github.com/PurpleBooth/git-mit/commit/effcb1eff07f5b5032bd25a51821904e6eca34d6))
- Bump clap from 3.1.2 to 3.1.3 ([`8fa1464`](https://github.com/PurpleBooth/git-mit/commit/8fa146487426020d300427508032eac000cfda16))

