### PR TITLE
fix: Update fast-conventional to v1.0.17

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.16.tar.gz"
-  sha256 "8c8fe2883bb5a297c3950646a28f59ffa846489ac60c8cd7912773fd7384ffa7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.16"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0e1ea74318b3f2fcd1979009a8ffdba98fd6e7ae427772cc11dff7f23e2d175b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3107a8a3697d845404e472290ba210a476712471963ef02b2aa699cf1265d11a"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.17.tar.gz"
+  sha256 "d61895405484678efacbfebd9819cea35944b83ca4930bde0a7ca4c1aebdd1c0"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.17](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.17) (2022-03-02)

### Build

- Versio update versions ([`f0fe23f`](https://github.com/PurpleBooth/fast-conventional/commit/f0fe23fe1a1a1451bd8a30af7563853afb148ed4))

### Ci

- Let mergify do the rebasing ([`7fcc3d7`](https://github.com/PurpleBooth/fast-conventional/commit/7fcc3d727f8e7e959a14bf7291b336c184c83be7))
- Configuration update ([`38acec2`](https://github.com/PurpleBooth/fast-conventional/commit/38acec29876d0b65ad8c348772e3a884b6c3ebea))
- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`1f7fd36`](https://github.com/PurpleBooth/fast-conventional/commit/1f7fd36ba3fc8e874d1f64876b0d67ddd729af35))

### Fix

- Bump clap_complete from 3.1.0 to 3.1.1 ([`9138d3b`](https://github.com/PurpleBooth/fast-conventional/commit/9138d3bca7465bf7a49125268971bd63fbe80722))

### Refactor

- Use the cute little derive method for clap ([`d978c73`](https://github.com/PurpleBooth/fast-conventional/commit/d978c735b1e34c9c72034dd504a40787ad305ea6))

