### PR TITLE
fix: Update whatismyip to v0.9.40

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.39.tar.gz"
-  sha256 "bf91a3703b3e86685ecdfd2842fdd0a0aa2b3b04013bd19835744bc521e0834b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.39"
-    sha256 cellar: :any_skip_relocation, big_sur:      "01a2cd7fa38e501234f9ae27eea684d5646f2a334f50a05f01ecade22a5c2415"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d98ed1c3ebd90c6acccb43658435366dcbdf75cccaecd2e271f0c54937b59ca0"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.40.tar.gz"
+  sha256 "852de9d19d99c41eff444195b1d4cb50a687ce89601d06026afec07f446ea3e2"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.9.40](https://github.com/PurpleBooth/whatismyip/compare/...v0.9.40) (2022-03-02)

### Build

- Add more scopes ([`858a9b5`](https://github.com/PurpleBooth/whatismyip/commit/858a9b54d39775d0a4ce23ab0fe7a663bf13c9ac))
- Versio update versions ([`5a3037c`](https://github.com/PurpleBooth/whatismyip/commit/5a3037c596fb2b55c6cc84521649ca1c53990f0a))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`315065f`](https://github.com/PurpleBooth/whatismyip/commit/315065f12c9fbbc33528c46b70af9fdf73c25513))

### Fix

- Bump trust-dns-resolver from 0.20.4 to 0.21.1 ([`f63a073`](https://github.com/PurpleBooth/whatismyip/commit/f63a073e3c5051e7c6ccffdca0490307f5003b2d))

### Refactor

- Switch to derive syntax ([`68e02b9`](https://github.com/PurpleBooth/whatismyip/commit/68e02b9ae3113461c23a2746cc83bd0470a8ea7b))
- Change how we create resolver_opts ([`a3b3af2`](https://github.com/PurpleBooth/whatismyip/commit/a3b3af2ca22153b2509c9b506cf52bf03ae745b5))
- Use specdown features ([`c6ac604`](https://github.com/PurpleBooth/whatismyip/commit/c6ac604d138cd9ea3476a91e5f8a1ea5dfdcfc21))

### Test

- Remove exe from help ([`fdfa08c`](https://github.com/PurpleBooth/whatismyip/commit/fdfa08c75fcc87804bd471b6b3ecb4c04ced71d6))

