### PR TITLE
fix: Update readable-name-generator to v2.100.19

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.17.tar.gz"
-  sha256 "e0376ac98b50c66d39093bf9871dc35dc72e910b7b68dfb65af5c304a5b87fd6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.17"
-    sha256 cellar: :any_skip_relocation, big_sur:      "387a0d3a6f0c9d2a99e9dcf4f084f5c6eeba7b5e8f3e598a49e53adc2855869a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3058bf5b4f219a9af588e713ebc493f430918e31ca461ea782b4854852464453"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.19.tar.gz"
+  sha256 "3311eb6721831e7a5da8c508a00f4760e744fba55168533792853056b043957b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.19](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.19) (2022-03-02)

### Build

- Versio update versions ([`b19d72c`](https://github.com/PurpleBooth/readable-name-generator/commit/b19d72caadbe66b7c0e46cd16553ea2785540a5e))

### Fix

- Bump clap_complete from 3.1.0 to 3.1.1 ([`08167f9`](https://github.com/PurpleBooth/readable-name-generator/commit/08167f9f081c2afffc40d3ae20727e851a3def2e))

