### PR TITLE
fix: Update ellipsis to v0.6.36

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.35.tar.gz"
-  sha256 "3e97fe724ff4a1379807fb00fb2bd3184e23dcad1a4f69adeedd7cbd984947e9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.35"
-    sha256 cellar: :any_skip_relocation, big_sur:      "b8e75e12b1e4f064f7f39f001aac140c04f7de4865d4a36d7f4cd04e0cfe99be"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "48c7e7b2113815ee9193d030dbd8362a2f5c9baedbcabe8ca0adb2cfadfed9f5"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.36.tar.gz"
+  sha256 "3c4685e31658c350658f7530428fe7037d9e2debf76dccdaaf0621326bb4325f"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.36](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.36) (2022-03-02)

### Build

- Versio update versions ([`4426e5c`](https://github.com/PurpleBooth/ellipsis/commit/4426e5c8c1e30d3eb0d5a2b1f5e7a3aa4f8a3daf))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`c9d285d`](https://github.com/PurpleBooth/ellipsis/commit/c9d285d9d0adf06d3e97291f21ef51d5f8dad2dd))

### Fix

- Bump clap from 3.1.3 to 3.1.5 ([`f42c074`](https://github.com/PurpleBooth/ellipsis/commit/f42c074bb4f5e5c1c6b6037fa9183ca0c49ff5ca))

