### PR TITLE
fix: Update game-of-life to v1.53.56

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.55.tar.gz"
-  sha256 "1fbaa93ddb72ab6ccf16c639f4f7fd2a327cbab5a5580fc08edcf4b71be79c90"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.55"
-    sha256 cellar: :any_skip_relocation, big_sur:      "63e9fbf30c1c33bc6b76c70e5f5a816ed1621bac2fd7d099ac25eb6b5e6a09de"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b6a20b83c4a9eb7146af96fd0afbf20d98992f4f42b16c2e793f8249ca8377d0"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.56.tar.gz"
+  sha256 "4974ce061431b369b4a02c9b502e3a2de5560cb57dcb712954a4217d6135a114"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.56](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.56) (2022-03-03)

### Build

- Versio update versions ([`1ff1b38`](https://github.com/PurpleBooth/game-of-life/commit/1ff1b38449a7b065ae3a0ce3660bd36de479f671))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`7f078af`](https://github.com/PurpleBooth/game-of-life/commit/7f078af0a72c54043e1e5ef9572971a36380f0f9))

### Fix

- Bump clap from 3.1.2 to 3.1.3 ([`be8a0fa`](https://github.com/PurpleBooth/game-of-life/commit/be8a0fa784eba50c72e95be302a769461406fcc0))
- Bump clap from 3.1.3 to 3.1.5 ([`5d7d70e`](https://github.com/PurpleBooth/game-of-life/commit/5d7d70ee1ceac6f2cd343d6a800f98877050aff1))

