### PR TITLE
fix: Update fix-compaudit to v0.46.76

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.75.tar.gz"
-  sha256 "8d4dda20a39b97eac0e7a8a8ecc3a93f2bcceced98b58d64bf3d0470fe31c94b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.75"
-    sha256 cellar: :any_skip_relocation, big_sur:      "ae117dfeacc3762d70c2a90746fa222791b25ea235391a401fba67a17faf587e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1868f48d47bc6c6e9d641d7be90e3e9afa2cda2b35a1bfd3253937afbbfaac89"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.76.tar.gz"
+  sha256 "465fecdd599accf3771cb7bffe0b988162c508ecdbbdf6b40f85cd2d57f2348b"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.76](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.76) (2022-03-03)

### Build

- Versio update versions ([`1630f5d`](https://github.com/PurpleBooth/fix-compaudit/commit/1630f5d5a24692a409af52ab343c0ac8277a8e24))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`bf07e69`](https://github.com/PurpleBooth/fix-compaudit/commit/bf07e693c3daa494077047fee647405bc1fa958e))

### Fix

- Bump clap from 3.1.2 to 3.1.3 ([`6fab66f`](https://github.com/PurpleBooth/fix-compaudit/commit/6fab66fdd382ac5cf3bd41c4f4d39569913e4bdf))
- Bump clap from 3.1.3 to 3.1.5 ([`b6d16e9`](https://github.com/PurpleBooth/fix-compaudit/commit/b6d16e9bdfb941937801625b46d54821ba66c16a))

