### PR TITLE
fix: Update ed-system-search to v1.1.34

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.33.tar.gz"
-  sha256 "0c008304c43c5fc1c7cddf692d5a05502901fc4b18319f06241268aa06fe5982"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.33"
-    sha256 cellar: :any_skip_relocation, big_sur:      "17d1d6b6f044dd2d89f045b09c602b3541aca12af35456ced8c54e798c2b6655"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "81815e523b5a246e39c99bf86c1283d848eb1323c0c738b29fe8e48f0aecfb7c"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.34.tar.gz"
+  sha256 "f4f26533fea7323ddfeb06fc3aef3d5015af0379607f34576229aaf00d18d662"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.34](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.34) (2022-03-03)

### Build

- Versio update versions ([`3dbdf0d`](https://github.com/PurpleBooth/ed-system-search/commit/3dbdf0d14a973c0953a0b379941e76daea2a1a4c))

### Ci

- Bump actions/checkout from 2.4.0 to 3 ([`db925c0`](https://github.com/PurpleBooth/ed-system-search/commit/db925c0c3842caebce1835ce39059c152d164a9a))
- Bump PurpleBooth/generate-formula-action from 0.1.5 to 0.1.6 ([`96d28fd`](https://github.com/PurpleBooth/ed-system-search/commit/96d28fd05184f947a5be4f30489b8c784be3fb0a))

### Fix

- Bump clap from 3.1.3 to 3.1.5 ([`d863331`](https://github.com/PurpleBooth/ed-system-search/commit/d8633319656275fd071c8e8a9d5332e7309a6cff))

