### PR TITLE
fix: Update git-moves-together to v2.5.28

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.27.tar.gz"
-  sha256 "ba5d22f1bea792df6603738970c1dc268d8fab740e84e751b894ae650f454d97"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.27"
-    sha256 cellar: :any,                 big_sur:      "7fb0ca789b1b7f7f829504faf32268db1cca12c62f499574542141d49f7ca5d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "639087771e10d5ea5011d96440a4056e7ba6c72324126dbf60ab4b108d72c905"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.28.tar.gz"
+  sha256 "006611d733ef444879804398a6a533683d8272ce025ca3178fd76eb4f671b305"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.28](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.28) (2022-03-03)

### Build

- Versio update versions ([`e2fde2b`](https://github.com/PurpleBooth/git-moves-together/commit/e2fde2b33af24675aa0b418f9cf71be09111f7d1))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`2085181`](https://github.com/PurpleBooth/git-moves-together/commit/20851819fe4e95bb41e5c7d34fa2c7e4e47794db))

### Fix

- Bump clap from 3.1.3 to 3.1.5 ([`a83e129`](https://github.com/PurpleBooth/git-moves-together/commit/a83e1295a17da29675745a510b39b1f339065b37))

