### PR TITLE
fix: Update git-mit to v5.12.39

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.38.tar.gz"
-  sha256 "bf422baa305541785f9f3db9685b7ee1ae8357651b9db4bbb3afee9d156db9c8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.38"
-    sha256 cellar: :any,                 big_sur:      "11ecf48d1bffaf254fcab26a5b9284f3cca2ae3c89653c4715f909a6c32f111a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "782fe012fa18a66f29ecd1796ae53f0cb36b4a7795002e95033ab556eac4e1b3"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.39.tar.gz"
+  sha256 "4118d8734ee9b17c9d69483b0f7a0cf071c0a5100f238c761c6b1863a883d53e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.39](https://github.com/PurpleBooth/git-mit/compare/...v5.12.39) (2022-03-03)

### Build

- Versio update versions ([`bd68039`](https://github.com/PurpleBooth/git-mit/commit/bd6803941d850e348679823dabf7249697873a48))

### Ci

- Bump PurpleBooth/generate-formula-action from 0.1.5 to 0.1.6 ([`ad8662f`](https://github.com/PurpleBooth/git-mit/commit/ad8662f46dfe4ec20929cb4882f38a8fc1c0ae31))
- Bump actions/checkout from 2.4.0 to 3 ([`4c6b424`](https://github.com/PurpleBooth/git-mit/commit/4c6b424b96662f8d32635f396dabfd20a162386c))
- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`31b1512`](https://github.com/PurpleBooth/git-mit/commit/31b1512b2dc9096e2770b3cd3ace0345457daf29))
- Bump PurpleBooth/generate-formula-action from 0.1.6 to 0.1.7 ([`b3f1937`](https://github.com/PurpleBooth/git-mit/commit/b3f1937cf1df555f010b70cb1fe017298608a577))
- Bump PurpleBooth/changelog-action from 0.3.1 to 0.3.2 ([`9f9582b`](https://github.com/PurpleBooth/git-mit/commit/9f9582b6e43bec49e5cb844c97d2b66ec66f7f98))

### Fix

- Bump clap_complete from 3.1.0 to 3.1.1 ([`682a8ca`](https://github.com/PurpleBooth/git-mit/commit/682a8ca5d3a0c4236464bbfcf8986887dd4937f9))

