### PR TITLE
fix: Update hungry-distance to v0.1.25

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.24.tar.gz"
-  sha256 "569988786a985acac53bd45d3495dd6c07e46d641d8840bc5bc5c16331b6a5eb"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.24"
-    sha256 cellar: :any_skip_relocation, big_sur:      "919f2381e67a3d9c2c0f0da6909c905401c0a1d084198d4934c70830167caba7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "92703dce97d7333ffd85555241bdc4ee29d439bdbc3d297138960217867429e2"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.25.tar.gz"
+  sha256 "b45a2389477af18067705ce8e0aa5901d364713e5a80f1906db8e6ab1f22d804"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.25](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.25) (2022-03-03)

### Build

- Versio update versions ([`75a12ff`](https://github.com/PurpleBooth/hungry-distance/commit/75a12ffb469eca74c4f91d3a273fd570289df210))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`652070a`](https://github.com/PurpleBooth/hungry-distance/commit/652070aecd7f2dac5ad6098175fa1c1f933feca7))

### Fix

- Bump clap from 3.1.2 to 3.1.3 ([`af80cfc`](https://github.com/PurpleBooth/hungry-distance/commit/af80cfca0567af803baa25f035db8e542cb1ccc6))
- Bump clap from 3.1.3 to 3.1.5 ([`d60739e`](https://github.com/PurpleBooth/hungry-distance/commit/d60739ed3da46e8c2b06b451c1437381310fb1e9))

