### PR TITLE
fix: Update whatismyip to v0.10.0

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.9.40.tar.gz"
-  sha256 "852de9d19d99c41eff444195b1d4cb50a687ce89601d06026afec07f446ea3e2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.9.40"
-    sha256 cellar: :any_skip_relocation, big_sur:      "d323c734bf96b6492dcb248b1d1552df9b025d0274645c11f91f4f72622b8b87"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a7b82691d4eabbd56855df5f31a7c66f4458e665cb838f659a492fff5c5fe561"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.10.0.tar.gz"
+  sha256 "82269264ed4fef53f4d3d4f683b0c74c922732ccf54b6cc8ed934544f6fa8899"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.10.0](https://github.com/PurpleBooth/whatismyip/compare/...v0.10.0) (2022-03-04)

### Build

- Switch to just ([`3395216`](https://github.com/PurpleBooth/whatismyip/commit/3395216fda5e2d6ff0b76c5a70f2d25f21190a23))
- Correct how we get the directory of the justfile ([`6959827`](https://github.com/PurpleBooth/whatismyip/commit/69598278997ca2eb13ba1f9a2948db3055739041))
- Versio update versions ([`696e970`](https://github.com/PurpleBooth/whatismyip/commit/696e970d85a56800a6abd4eb6626d0bb87e06332))

### Feat

- Add fancy errors ([`b720d30`](https://github.com/PurpleBooth/whatismyip/commit/b720d30529fadbf68c8d2886391cbd4005b98766))

### Fix

- Bump clap from 3.1.3 to 3.1.5 ([`6b811f6`](https://github.com/PurpleBooth/whatismyip/commit/6b811f680f1b40e9dc9902f5fb970c0194d2ba0d))

### Refactor

- Swap out a string in an interface for a proper type ([`eb86aeb`](https://github.com/PurpleBooth/whatismyip/commit/eb86aebd59dfc0bd2fe905558bc8a3befbb60fac))
- Clean up the tests with into ([`3edcbd3`](https://github.com/PurpleBooth/whatismyip/commit/3edcbd3695e75d6ed97d67628ad56d3b06bb6c00))

