### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.43

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.42.tar.gz"
-  sha256 "945b3a40c683ec6bf639ed4bf53a238112d4dfb61b6587066cdf412ed793e281"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.43.tar.gz"
+  sha256 "1f13a7a3fcfe5fc77b23344b60a3bdb0634c52714947faafbf56ecd83d3904fb"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.42"
-    sha256 cellar: :any_skip_relocation, big_sur:      "4d6c85ba47c2cd2beffc9962a4adab36ba34989813e9f42f9663a03646a6d029"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "29afc3c634a87b50210f64cf8147fde9882fbea92626925311db3a543f29ab3d"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.43](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.43) (2022-03-04)

### Build

- Versio update versions ([`7b5c2bb`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/7b5c2bb74224a5f8421d5c5ba1dbac6711be417b))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`f34018e`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/f34018e657a4dcde48586273457c22e631d5919e))
- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`2418a2c`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/2418a2c09d1adb12052f5f45a9929d63e728e1f0))

### Fix

- Bump clap from 3.1.3 to 3.1.5 ([`1b0845c`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/1b0845ca2b49152d6effc47df085d0078f597b67))

