### PR TITLE
fix: Update fast-conventional to v1.0.18

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.17.tar.gz"
-  sha256 "d61895405484678efacbfebd9819cea35944b83ca4930bde0a7ca4c1aebdd1c0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.17"
-    sha256 cellar: :any_skip_relocation, big_sur:      "145095b14b867beaa7e4718f4e3ca67f9646e202b0ed99d02d0d7de39da8dff4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8a8801994164bfeab93bf81ceede7083c9bdf0e796cbf26f2ea4d68d7b7f14c8"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.18.tar.gz"
+  sha256 "b37ef19d0538c1736e4d51aa39950e2ff00987baa950b904e920df3d382b8e61"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.0.18](https://github.com/PurpleBooth/fast-conventional/compare/...v1.0.18) (2022-03-04)

### Build

- Versio update versions ([`6713614`](https://github.com/PurpleBooth/fast-conventional/commit/67136140307dd8c9683419a8a5b0c9102b42a04d))

### Ci

- Remove rebase-strategy ([`deacc72`](https://github.com/PurpleBooth/fast-conventional/commit/deacc7215075b788b3474fb1407153a2c604404e))
- Remove recreate prompt ([`2220648`](https://github.com/PurpleBooth/fast-conventional/commit/2220648765ada75d579fffaf5e4bfcb1fbea9b4c))
- Only tag me in when dependabot fails ([`5469a1a`](https://github.com/PurpleBooth/fast-conventional/commit/5469a1a5b8d9c7d4ec4795cc2e1a003663340b9c))
- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`b1255cb`](https://github.com/PurpleBooth/fast-conventional/commit/b1255cb6da7505a43234fe57136caf8f649f99a3))

### Fix

- Bump clap from 3.1.3 to 3.1.5 ([`f7c0fa9`](https://github.com/PurpleBooth/fast-conventional/commit/f7c0fa9b2bdb23362a0893751d1d70f5ee21a8d1))

