### PR TITLE
fix: Update fast-conventional to v1.1.0

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.0.18.tar.gz"
-  sha256 "b37ef19d0538c1736e4d51aa39950e2ff00987baa950b904e920df3d382b8e61"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.0.18"
-    sha256 cellar: :any_skip_relocation, big_sur:      "8e213bcccbce720b2caf5a615ec0ce56dccbe0fb61f4963cb2225851dcb91c62"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8c928cec3ed1c0042df2209ea440fa658f41421c60c1ae9b5fcb24e605534a57"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.1.0.tar.gz"
+  sha256 "764b30c14047094970d0bd9bb87d8eeb588efe2e8dac81d3eec33fa69d0ff199"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.1.0](https://github.com/PurpleBooth/fast-conventional/compare/...v1.1.0) (2022-03-06)

### Build

- Versio update versions ([`e0a682e`](https://github.com/PurpleBooth/fast-conventional/commit/e0a682ec849721ec5e5110286681791fafa39d9f))

### Feat

- Add ability to edit ([`f63aa6e`](https://github.com/PurpleBooth/fast-conventional/commit/f63aa6e3e0e439b3fdc85d80c0568067a0c2d318))

### Refactor

- Split questions and commit making into two functions ([`4351d8d`](https://github.com/PurpleBooth/fast-conventional/commit/4351d8db03d8469f79ebd5d2488c108a8332983c))

