### PR TITLE
fix: Update fast-conventional to v1.1.1

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.1.0.tar.gz"
-  sha256 "764b30c14047094970d0bd9bb87d8eeb588efe2e8dac81d3eec33fa69d0ff199"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.1.0"
-    sha256 cellar: :any_skip_relocation, big_sur:      "24af0f3eb0e035dc3dfa7a652cbf6d6c190918aeec34e62f249e28651d072e46"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5514ddf303e46afde7d1ac5d3445c1feed7330ced16113f6e0ff5710193a970e"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.1.1.tar.gz"
+  sha256 "b3573253383051ad64ad23a1c332e53de13944791301862bd1f0d945f26b5772"
 
   depends_on "rust" => :build
   depends_on "socat" => :test


### PR DESCRIPTION
## Changelog
### [v1.1.1](https://github.com/PurpleBooth/fast-conventional/compare/...v1.1.1) (2022-03-06)

### Build

- Versio update versions ([`b75d2c2`](https://github.com/PurpleBooth/fast-conventional/commit/b75d2c2a340ce4d5011ae8ab392bb1469682f27b))

### Fix

- Prompts only have defaults if there's a previous commit ([`88f07dc`](https://github.com/PurpleBooth/fast-conventional/commit/88f07dcfbdcbbd0240c006ee9b7ab9189e18d7f4))

### Refactor

- Extract more logic into models ([`d7f1a2b`](https://github.com/PurpleBooth/fast-conventional/commit/d7f1a2b1d73001120617028eed47b26cd4724a02))
- Move UI stuff into it's own module ([`a2679a9`](https://github.com/PurpleBooth/fast-conventional/commit/a2679a9ea8f07f86180a87affa48a1b78c6b5e8b))

