### PR TITLE
fix: Update fast-conventional to v2.0.0

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,21 +1,32 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v1.1.0.tar.gz"
-  sha256 "764b30c14047094970d0bd9bb87d8eeb588efe2e8dac81d3eec33fa69d0ff199"
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.0.0.tar.gz"
+  sha256 "1965e89012bf86698932769cc7690bba42bd424fa7af099c1dde21f7b46c16be"
 
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-1.1.0"
-    sha256 cellar: :any_skip_relocation, big_sur:      "24af0f3eb0e035dc3dfa7a652cbf6d6c190918aeec34e62f249e28651d072e46"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5514ddf303e46afde7d1ac5d3445c1feed7330ced16113f6e0ff5710193a970e"
-  end
-
+  depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "socat" => :test
   depends_on "specdown/repo/specdown" => :test
 
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+
+    # Install bash completion
+    output = Utils.safe_popen_read("#{bin}/fast-conventional", "completion", "bash")
+    (bash_completion/"fast-conventional").write output
+
+    # Install zsh completion
+    output = Utils.safe_popen_read("#{bin}/fast-conventional", "completion", "zsh")
+    (zsh_completion/"_fast-conventional").write output
+
+    # Install fish completion
+    output = Utils.safe_popen_read("#{bin}/fast-conventional", "completion", "fish")
+    (fish_completion/"fast-conventional.fish").write output
+
+    # Man pages
+    output = Utils.safe_popen_read("help2man", "#{bin}/fast-conventional")
+    (man1/"fast-conventional.1").write output
   end
 
   test do


### PR DESCRIPTION
## Changelog
### [v2.0.0](https://github.com/PurpleBooth/fast-conventional/compare/...v2.0.0) (2022-03-06)

### Build

- Versio update versions ([`c72df54`](https://github.com/PurpleBooth/fast-conventional/commit/c72df5481c740a21459519820963b308a13eef9f))

### Ci

- Disable formatting markdown ([`063882c`](https://github.com/PurpleBooth/fast-conventional/commit/063882c9a12114c7be6cce6c7a3cea969d89badd))

### Feat

- Add completions ([`32ebd11`](https://github.com/PurpleBooth/fast-conventional/commit/32ebd1135c6bbc23235647f63c6b128968bd49d1))
- **Breaking Change:** Switch to command based structure ([`2ba6849`](https://github.com/PurpleBooth/fast-conventional/commit/2ba68495f3622386456f9d10651b4a273da067c8))

