### PR TITLE
fix: Update fast-conventional to v2.1.0

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.0.0.tar.gz"
-  sha256 "1965e89012bf86698932769cc7690bba42bd424fa7af099c1dde21f7b46c16be"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.0.0"
-    sha256 cellar: :any_skip_relocation, big_sur:      "72af61df1adb1d4c41ed0554e119408ec549108d70a4cdbf4e28bbeada32872b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2154e3ec69c3b6bf45404de26f504e2834aa23a6a65ca57579e96d5694c548fa"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.1.0.tar.gz"
+  sha256 "8d90b7698a8f59563c6fecaea00a919ba0f7776962d091d82ac40283bcedaf4d"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build
@@ -33,6 +27,16 @@ class FastConventional < Formula
     # Man pages
     output = Utils.safe_popen_read("help2man", "#{bin}/fast-conventional")
     (man1/"fast-conventional.1").write output
+  end
+
+  def caveats
+    <<~EOS
+      Update your git config to finish installation:
+        $ git config --global alias.fci '-c "core.editor=fast-conventional editor" commit'
+      To use it run
+        $ git fci
+      You may add any of the usual commit arguments
+    EOS
   end
 
   test do


### PR DESCRIPTION
## Changelog
### [v2.1.0](https://github.com/PurpleBooth/fast-conventional/compare/...v2.1.0) (2022-03-06)

### Build

- Versio update versions ([`c048c20`](https://github.com/PurpleBooth/fast-conventional/commit/c048c20c56fb4f37c6d5bde23ca8495edca87941))

### Docs

- Add correct install info ([`27ed432`](https://github.com/PurpleBooth/fast-conventional/commit/27ed4322bdff731a6c122e7f5cb9a552950dceb0))
- Correct documentation ([`ff61bf2`](https://github.com/PurpleBooth/fast-conventional/commit/ff61bf2524293a3981b0dcb0c7a8bdc74c58e276))
- Split the docs into multiple pages ([`94c3fb7`](https://github.com/PurpleBooth/fast-conventional/commit/94c3fb749c61dc0c6cb76ebb6270318b33cffaba))
- Add a logo ([`af6029a`](https://github.com/PurpleBooth/fast-conventional/commit/af6029a9ab9c1bcf9501b32d30545a19884ed14b))
- Correct image links ([`8c05ba7`](https://github.com/PurpleBooth/fast-conventional/commit/8c05ba708f6027ca54222f56bc309a03c271d5e1))
- Add a general cli usage doc ([`a6a1557`](https://github.com/PurpleBooth/fast-conventional/commit/a6a1557f1b35263080f43e17bdc031ff60f3a479))
- Standarise formatting ([`612c166`](https://github.com/PurpleBooth/fast-conventional/commit/612c166584b5ee8d97eb14fa5f2907b848f03587))

### Feat

- Add fallback for editing non-conventional commits ([`c5b0ec4`](https://github.com/PurpleBooth/fast-conventional/commit/c5b0ec4343720df5c3bb019230d1604907d01d8d))
- Add example config generator ([`c4df35a`](https://github.com/PurpleBooth/fast-conventional/commit/c4df35a6a7d5f1132d8bf5644424abbd6832e032))

