### PR TITLE
fix: Update git-mit to v5.12.41

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.40.tar.gz"
-  sha256 "fe2b900ddf472436ebb3bed008a97a0c1770687b8ef2d15f74512211d7465921"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.40"
-    sha256 cellar: :any,                 big_sur:      "fa9b80e750cb2625b6e2c69c5784278dcaa019253adcbc4240c6c1e5b908b2e1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "06540ad5ee9e6983593571f03d0c423068fd07a1ed2b42e115c4ffd5b01df31d"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.41.tar.gz"
+  sha256 "44ba3436bfb89e040f40b4c8d305e0362ebdbe74103664b55fddd7209c5f1444"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.41](https://github.com/PurpleBooth/git-mit/compare/...v5.12.41) (2022-03-07)

### Build

- Versio update versions ([`d796c00`](https://github.com/PurpleBooth/git-mit/commit/d796c00687cc8aae7ca60ac098f6d9022fb69f2a))

### Ci

- Bump PurpleBooth/generate-formula-action from 0.1.7 to 0.1.8 ([`6d5c3f5`](https://github.com/PurpleBooth/git-mit/commit/6d5c3f5d2634c9424ed18fbe0cae20dcabcc079d))
- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`0aa22b8`](https://github.com/PurpleBooth/git-mit/commit/0aa22b8e2baafc392c9b6d7a01cc1806f09e2194))

### Fix

- Bump mit-lint from 3.0.6 to 3.0.7 ([`c37ae56`](https://github.com/PurpleBooth/git-mit/commit/c37ae560fe42978456b7b6739b07b4ffa5fb11e6))

