### PR TITLE
fix: Update ellipsis to v0.6.37

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.36.tar.gz"
-  sha256 "3c4685e31658c350658f7530428fe7037d9e2debf76dccdaaf0621326bb4325f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.36"
-    sha256 cellar: :any_skip_relocation, big_sur:      "1b6062ec493f28af8aee2f3e5e6b7315de79fd0cb6a5d7c79ef9b09ea09d7ae1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3695bb658c279fd5b4b94b0e623584e9fb9e2e1d444d3e86e294e73b6276ef72"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.37.tar.gz"
+  sha256 "61eb448e32d55a4fffed677fcd2db87ed9ec2aa64b584bb6f3f92e9e8e76774e"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.37](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.37) (2022-03-07)

### Build

- Versio update versions ([`9bbfc6f`](https://github.com/PurpleBooth/ellipsis/commit/9bbfc6f1e321b523645cab4733f0f157d3f2fabe))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`c15164b`](https://github.com/PurpleBooth/ellipsis/commit/c15164bc897e0e0d7bdb4fd6961e2cf9abf60d66))

### Fix

- Bump clap from 3.1.5 to 3.1.6 ([`3195a2f`](https://github.com/PurpleBooth/ellipsis/commit/3195a2f2790aa0cee0053786612585ce24eaa70d))
- Bump anyhow from 1.0.55 to 1.0.56 ([`c476bd5`](https://github.com/PurpleBooth/ellipsis/commit/c476bd5a9ed1634156521b5e44dc332ee278c2aa))

