### PR TITLE
fix: Update game-of-life to v1.53.57

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.56.tar.gz"
-  sha256 "4974ce061431b369b4a02c9b502e3a2de5560cb57dcb712954a4217d6135a114"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.56"
-    sha256 cellar: :any_skip_relocation, big_sur:      "99b66ac34377af0cce0a578b1e753ac6af056c3d368fb94f69f139cdc3f4c445"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3064321344bac5dab17bb588ffcce4fd940dc1bc9e1da1810f0c87262c639bd6"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.57.tar.gz"
+  sha256 "e3be4ae0d7deaf36f5b3230a8fbbd2acf662d5700f2cb0e23e6981a1d0b3c718"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.57](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.57) (2022-03-08)

### Build

- Versio update versions ([`31ef89b`](https://github.com/PurpleBooth/game-of-life/commit/31ef89b6bb7c9df3754fdb2692904d94860e44e0))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`f1ad237`](https://github.com/PurpleBooth/game-of-life/commit/f1ad23734efb12842d3beb6b84f2255c8b765b1e))

### Fix

- Bump clap from 3.1.5 to 3.1.6 ([`3b12550`](https://github.com/PurpleBooth/game-of-life/commit/3b12550ae39d88fbf9d554a4216dc045758a2ead))

