### PR TITLE
fix: Update ed-system-search to v1.1.35

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.34.tar.gz"
-  sha256 "f4f26533fea7323ddfeb06fc3aef3d5015af0379607f34576229aaf00d18d662"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.34"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6a9b237751126d196d87ec29bb18566f86acf4f6be67782a0f6c1b63af3cf2f7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "258b7bb75777d0bb2b0c70eaf55125b7ec3a17a405d381abb0e51e78c1ec1cd4"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.35.tar.gz"
+  sha256 "2498b03b76160b216577035a397653e39d3b8632eff60cd50ebd1231fd805800"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.35](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.35) (2022-03-08)

### Build

- Versio update versions ([`26c9e85`](https://github.com/PurpleBooth/ed-system-search/commit/26c9e8558fccac3164c56dfdf070d85ccbe7c176))

### Ci

- Bump PurpleBooth/changelog-action from 0.3.1 to 0.3.2 ([`9b12ce0`](https://github.com/PurpleBooth/ed-system-search/commit/9b12ce088776f0900ef472d47a1e0be4a763b0e3))
- Bump PurpleBooth/generate-formula-action from 0.1.6 to 0.1.7 ([`b41fe5b`](https://github.com/PurpleBooth/ed-system-search/commit/b41fe5bde5aba27e99731a5de629c82cb0191aec))
- Disable markdown check ([`a3b37c3`](https://github.com/PurpleBooth/ed-system-search/commit/a3b37c31a7162b45e38dcf0c9effc8dcd272c02c))
- Bump PurpleBooth/generate-formula-action from 0.1.7 to 0.1.8 ([`b293601`](https://github.com/PurpleBooth/ed-system-search/commit/b293601cfddba89cc51a6506d5e84e7a5225d3c9))

### Fix

- Bump clap from 3.1.5 to 3.1.6 ([`43df3fa`](https://github.com/PurpleBooth/ed-system-search/commit/43df3fa1b4a5dc29c67736fa1d29912fa104afbf))

### Refactor

- Switch to derive api ([`19cf277`](https://github.com/PurpleBooth/ed-system-search/commit/19cf27767141c7ed4a9124eb93d1cca60879396f))
- Add async loop ([`b7e6912`](https://github.com/PurpleBooth/ed-system-search/commit/b7e691226271bd18647b1c094cee1f04826720be))

