### PR TITLE
fix: Update git-moves-together to v2.5.29

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.28.tar.gz"
-  sha256 "006611d733ef444879804398a6a533683d8272ce025ca3178fd76eb4f671b305"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.28"
-    sha256 cellar: :any,                 big_sur:      "9181d2313a7f32ada9ffefe7c6c0bbb0f8db96c2abcda04d64cd3876ce51e3fe"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "78ccb2dff2f2503b21585cc409e759c6ffeb52d14b31e1c7f3b60d67da9e21d2"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.29.tar.gz"
+  sha256 "5ee9687027eb1a0c3fd35bbc250fd234fadde5bb65ddfe74409ad39a73bc10ba"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.29](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.29) (2022-03-08)

### Build

- Versio update versions ([`44ec24f`](https://github.com/PurpleBooth/git-moves-together/commit/44ec24f6cecf392c18f2915cbc83dc648b21aca9))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`973521d`](https://github.com/PurpleBooth/git-moves-together/commit/973521dad8556d90caa6b31427b4acdddb7d6769))

### Fix

- Bump clap from 3.1.5 to 3.1.6 ([`06e2ba8`](https://github.com/PurpleBooth/git-moves-together/commit/06e2ba878a6fbb42f32a36a0125ea337a699aa50))

