### PR TITLE
fix: Update hungry-distance to v0.1.26

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.25.tar.gz"
-  sha256 "b45a2389477af18067705ce8e0aa5901d364713e5a80f1906db8e6ab1f22d804"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.25"
-    sha256 cellar: :any_skip_relocation, big_sur:      "76261e285452415c0c74dc61a2da25137725b1a8dd441abac7ce1d7b4faf5822"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1d70939ec6d33564db1f948ce1d3cbf844a5de481f3d1e2f82f7d5c6f56412fb"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.26.tar.gz"
+  sha256 "b1d480e3258a61b1cd7c80e260b19019c1277d39fd910ece8442a4a7ed808bb0"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.26](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.26) (2022-03-08)

### Build

- Versio update versions ([`0cc9cf2`](https://github.com/PurpleBooth/hungry-distance/commit/0cc9cf2f0bf7fa4d80d05053c55a772f0b98ddea))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`751a053`](https://github.com/PurpleBooth/hungry-distance/commit/751a0531ab5e5cda02ac60ff756547d3ec2a75ad))

### Fix

- Bump clap from 3.1.5 to 3.1.6 ([`5533435`](https://github.com/PurpleBooth/hungry-distance/commit/5533435474ec9fa4f770763b00b542d1fe5b8590))

