### PR TITLE
fix: Update whatismyip to v0.10.1

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/v0.10.0.tar.gz"
-  sha256 "82269264ed4fef53f4d3d4f683b0c74c922732ccf54b6cc8ed934544f6fa8899"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.10.0"
-    sha256 cellar: :any_skip_relocation, big_sur:      "f96997c344d3e3a67e9b2cd56a39e9638b23ec317a95e7e4b2debec100e1152f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0b6ca99c741d4c1d2a459189cc3f7ed09f45ee9c8e9a09793999539e7631a0fa"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/v0.10.1.tar.gz"
+  sha256 "4dde6a1642a8b50d6431c0b9f10fd35ea5a486532a5359e2478f4bf5b9bbf1c2"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.10.1](https://github.com/PurpleBooth/whatismyip/compare/...v0.10.1) (2022-03-08)

### Build

- Versio update versions ([`e8b4975`](https://github.com/PurpleBooth/whatismyip/commit/e8b4975f89271e46d3feaa27a2b2657c55fc9dd1))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`b5559bb`](https://github.com/PurpleBooth/whatismyip/commit/b5559bb91e86d92b6ca7dae4a05a0cb235c8adbc))

### Fix

- Bump clap from 3.1.5 to 3.1.6 ([`666699a`](https://github.com/PurpleBooth/whatismyip/commit/666699a36a0432219ef8650357ec01e03882279a))

### Refactor

- Introduce constants for hard coded strings ([`db8cfa7`](https://github.com/PurpleBooth/whatismyip/commit/db8cfa78deb287638629db07f6c82950f586014c))

