### PR TITLE
fix: Update git-mit to v5.12.43

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.42.tar.gz"
-  sha256 "9669c67dc346d2726390c9ccf0c71fd2289ed1be31f06e855df9ac43e97111b7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.42"
-    sha256 cellar: :any,                 big_sur:      "e4c8a83f2cd33d2d35525b8ffac3861c6d4dd22cf1537f294438aae07c77b8dc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6a2d2de15faaf17858a9b15bef6090510a03b9ac0be2432dc69aae5cc486704f"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.43.tar.gz"
+  sha256 "97e069dacf30004a339734b59d36cc9542d074e5c5812585529d009180ccdb68"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.43](https://github.com/PurpleBooth/git-mit/compare/...v5.12.43) (2022-03-09)

### Build

- Versio update versions ([`80d6630`](https://github.com/PurpleBooth/git-mit/commit/80d6630c5ae1417e0820d1e40c9c14375725965c))

### Fix

- Bump regex from 1.5.4 to 1.5.5 ([`057bfe6`](https://github.com/PurpleBooth/git-mit/commit/057bfe664ff46452010ee7839dbd0aaa14eec6cf))

