### PR TITLE
fix: Update git-mit to v5.12.44

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.43.tar.gz"
-  sha256 "97e069dacf30004a339734b59d36cc9542d074e5c5812585529d009180ccdb68"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.43"
-    sha256 cellar: :any,                 big_sur:      "1e45f7705959be17a45318c75d663bfe5cecdc299ae812de26bac87b4451b35c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b47b73a7fdf913e923794a57b450d49cbf7bb5ae5b037b1b31ee8ed3de80806a"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.44.tar.gz"
+  sha256 "89247e5c219826cdeab0d02406aade9f73f88e87792f94df462d81c35cd054e5"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.44](https://github.com/PurpleBooth/git-mit/compare/...v5.12.44) (2022-03-11)

### Build

- Versio update versions ([`685f686`](https://github.com/PurpleBooth/git-mit/commit/685f68618f335f5e848bd7a61c07813cd6bfc874))

### Fix

- Bump arboard from 2.0.1 to 2.1.0 ([`ef52ecd`](https://github.com/PurpleBooth/git-mit/commit/ef52ecda8466ba2095e39a4556c066f9c0d18eb0))
- Bump git2 from 0.14.1 to 0.14.2 ([`6ffabd1`](https://github.com/PurpleBooth/git-mit/commit/6ffabd19c811ac9602822b39322d748b9622a9f9))

