### PR TITLE
fix: Update git-mit to v5.12.45

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.44.tar.gz"
-  sha256 "89247e5c219826cdeab0d02406aade9f73f88e87792f94df462d81c35cd054e5"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.44"
-    sha256 cellar: :any,                 big_sur:      "c65f5141b4c8a339836f81112e5d849f1d4da1c79ff70f6c324e55660f2b1ec1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d3cb6f3dd5f6cb9ac75b1fa468cd1b428fd863bd81c694c9b75a33ee5b61f9e6"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.45.tar.gz"
+  sha256 "eba08f323c48d8c92741ddf44e6675949a8a4d707c74cbada0e34dd17cae6d85"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.45](https://github.com/PurpleBooth/git-mit/compare/...v5.12.45) (2022-03-14)

### Build

- Versio update versions ([`ff883f2`](https://github.com/PurpleBooth/git-mit/commit/ff883f2e0604c2a3cc41243394ee3257e3ae90ef))

### Fix

- Bump mit-commit from 3.1.0 to 3.1.1 ([`8f1a26b`](https://github.com/PurpleBooth/git-mit/commit/8f1a26b6c5bf9fb70c17281220cc4fd51f57783c))

