### PR TITLE
fix: Update fast-conventional to v2.2.0

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.1.0.tar.gz"
-  sha256 "8d90b7698a8f59563c6fecaea00a919ba0f7776962d091d82ac40283bcedaf4d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.1.0"
-    sha256 cellar: :any_skip_relocation, big_sur:      "93677661177dc831109bc660ff653b42d546225876c6e4312a43f86f8b0bd07d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "da134e96969891f686f391ec14e034801dc7ba937ae485cad6ed7291a05880aa"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.0.tar.gz"
+  sha256 "700a0e055a036be4fa5fbd36f997956e42b6426f88fab903a928c346f717953d"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.2.0](https://github.com/PurpleBooth/fast-conventional/compare/...v2.2.0) (2022-03-15)

### Build

- Add new scope for logo ([`8a816a9`](https://github.com/PurpleBooth/fast-conventional/commit/8a816a9d808412c58e80fcc4a43792cccbcc7742))
- Versio update versions ([`f11cc1a`](https://github.com/PurpleBooth/fast-conventional/commit/f11cc1a477a7c3f3071874cd38d8ee7a0f3ac148))

### Docs

- Switch dark and light images ([`d367953`](https://github.com/PurpleBooth/fast-conventional/commit/d367953897b83d31a3497d2bbbca5f9e618fec11))
- Convert the svgs to paths for easier veiwing ([`346f99c`](https://github.com/PurpleBooth/fast-conventional/commit/346f99cd6315ec2fddec8c8796e51f096273cf77))
- Use svg for readme ([`32fc74c`](https://github.com/PurpleBooth/fast-conventional/commit/32fc74c4774b1694a911186539dc184c1de66d3e))

### Feat

- Use a known filename ([`a47e81e`](https://github.com/PurpleBooth/fast-conventional/commit/a47e81e78d4e66868486e5f80d7ee13f62ffecd1))

### Fix

- Bump clap from 3.1.5 to 3.1.6 ([`b7263b2`](https://github.com/PurpleBooth/fast-conventional/commit/b7263b27939383ee6c66517682e8638fc6581d80))
- Subject now is correctly parsed ([`aee0632`](https://github.com/PurpleBooth/fast-conventional/commit/aee06321c7838796b4afa0450e2cc163e67ae2f4))
- Bump nom from 7.1.0 to 7.1.1 ([`410c4fe`](https://github.com/PurpleBooth/fast-conventional/commit/410c4fea01ba5f0764cb39816669ca881e3005b3))

### Refactor

- Pull different commands into their own modules ([`71a4a21`](https://github.com/PurpleBooth/fast-conventional/commit/71a4a218c6f4995f6587f938a16e5376e7c871c4))
- Switch to single parser ([`1004276`](https://github.com/PurpleBooth/fast-conventional/commit/10042768c879f2a33aad73d14cd7368148b7a452))

