### PR TITLE
fix: Update git-moves-together to v2.5.30

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.29.tar.gz"
-  sha256 "5ee9687027eb1a0c3fd35bbc250fd234fadde5bb65ddfe74409ad39a73bc10ba"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.29"
-    sha256 cellar: :any,                 big_sur:      "167ee6c520bae62115c4e838a2d301e724daa4f08466be9cc3693234d7c22f9b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "419c53ee98a87e6b47aeaae708d1faca604a4086fc7a35cec674e67e75d73765"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.30.tar.gz"
+  sha256 "775e04e2ab1597f67dc7f19a2024f95197b5249a22570c661adec1fe33c2b309"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.30](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.30) (2022-03-23)

### Build

- Versio update versions ([`8983e5b`](https://github.com/PurpleBooth/git-moves-together/commit/8983e5b1ed929a266148d784058aff05efa9a080))

### Fix

- Bump git2 from 0.14.1 to 0.14.2 ([`cd07cab`](https://github.com/PurpleBooth/git-moves-together/commit/cd07cab9f153307319181ca7ccfdf98d3e6fa187))
- Bump time from 0.3.7 to 0.3.9 ([`5d4a367`](https://github.com/PurpleBooth/git-moves-together/commit/5d4a3677ba3ef5167d74b2268e708cb90a6df160))

