### PR TITLE
fix: Update git-mit to v5.12.46

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.45.tar.gz"
-  sha256 "eba08f323c48d8c92741ddf44e6675949a8a4d707c74cbada0e34dd17cae6d85"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.45"
-    sha256 cellar: :any,                 big_sur:      "6a903bd757d29bb6a9764cdc3914a81f6ba914ce61c98c22e6166478d924d3a3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4fe51ab7bf4ae825a842d649c06373e83865b5309471024d0b54da03d9e717c7"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.46.tar.gz"
+  sha256 "d7ec6d9ab5392904dfdd359868a1670ca62665decb173a2ae4fe8355c8c9f163"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.46](https://github.com/PurpleBooth/git-mit/compare/...v5.12.46) (2022-03-23)

### Build

- Versio update versions ([`b6d3ea2`](https://github.com/PurpleBooth/git-mit/commit/b6d3ea20bf9a6d36f93eeb0f4756d247759d1d4c))

### Fix

- Bump time from 0.3.7 to 0.3.9 ([`42e41a9`](https://github.com/PurpleBooth/git-mit/commit/42e41a9b970dc87d57cfe597cab7af6aab402569))

### Refactor

- Follow clippy advice ([`cc25cf5`](https://github.com/PurpleBooth/git-mit/commit/cc25cf5f75ac93c7fdaec21f5b40da401a46bc5f))

