### PR TITLE
fix: Update git-mit to v5.12.47

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.46.tar.gz"
-  sha256 "d7ec6d9ab5392904dfdd359868a1670ca62665decb173a2ae4fe8355c8c9f163"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.46"
-    sha256 cellar: :any,                 big_sur:      "d75f4000bfc1dd4965639f59d85c331d73e73a135f3c6e0fa0a9a75bbaef40e0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "be52a9e3a9815d6ddf95f74427f92cccc12bb6bb9816c9245000ced838eeef9f"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.47.tar.gz"
+  sha256 "cb0c916385e0ee07612cc469c84dff659ac402e67add12becc1ece0f7aaa57da"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.47](https://github.com/PurpleBooth/git-mit/compare/...v5.12.47) (2022-03-23)

### Build

- Versio update versions ([`47c26ce`](https://github.com/PurpleBooth/git-mit/commit/47c26ced76e539871028b3fed1bf5992c4f64e38))

### Ci

- Bump actions/cache from 2.1.7 to 3 ([`882552d`](https://github.com/PurpleBooth/git-mit/commit/882552db7d3150ed68e01380c4720642072865d8))

### Fix

- Bump which from 4.2.4 to 4.2.5 ([`988f006`](https://github.com/PurpleBooth/git-mit/commit/988f006f882db4cb1a5d7708746a97930d0a000e))

