### PR TITLE
fix: Update ellipsis to v0.6.38

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.37.tar.gz"
-  sha256 "61eb448e32d55a4fffed677fcd2db87ed9ec2aa64b584bb6f3f92e9e8e76774e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.37"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6cf66e0c720a25efe6b4611fdc0da497706592cda889ddb683355b77fdfdf070"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ca21aad4dee5557f96437757979157bc99867076dc85ec21e8783c6dd7b5692b"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.38.tar.gz"
+  sha256 "8f54194a1bab68f6479873b55833ef959443aa3e12ce8389ca947f2bbd4ef9b9"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.38](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.38) (2022-03-23)

### Build

- Versio update versions ([`fefcba9`](https://github.com/PurpleBooth/ellipsis/commit/fefcba97617edb3053c07401b7c7f03ca2c5c97e))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.9 to 0.1.10 ([`71c50b9`](https://github.com/PurpleBooth/ellipsis/commit/71c50b91ecefcab64c2c45e78a0996529c551941))

### Fix

- Bump regex from 1.5.4 to 1.5.5 ([`0041fa9`](https://github.com/PurpleBooth/ellipsis/commit/0041fa98e0ca3a1432734283732f1f785852caa5))

