### PR TITLE
fix: Update game-of-life to v1.53.58

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.57.tar.gz"
-  sha256 "e3be4ae0d7deaf36f5b3230a8fbbd2acf662d5700f2cb0e23e6981a1d0b3c718"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.57"
-    sha256 cellar: :any_skip_relocation, big_sur:      "2debebf8c5dbbd5c09251861a24d9682446e11ad6fb603c17e84d742cb313df1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c10926fb3ed6aea2cfeca9092158f5b3704f07796e207118b2fd51fadf0955fb"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.58.tar.gz"
+  sha256 "e1a42a714653072799a903d4a19e24d4e017e070df9eda3693f6abb489314dca"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.58](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.58) (2022-03-24)

### Build

- Versio update versions ([`6597c71`](https://github.com/PurpleBooth/game-of-life/commit/6597c71919ec8ad739cdb1c9aca8c5b57a555d92))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.9 to 0.1.10 ([`aa0812b`](https://github.com/PurpleBooth/game-of-life/commit/aa0812b012e824b5a32c085edbc9c2a8ad1192c4))

### Fix

- Bump crossterm from 0.23.0 to 0.23.1 ([`7306814`](https://github.com/PurpleBooth/game-of-life/commit/7306814b4c24a3264e2e7662af4a29007313590c))

