### PR TITLE
fix: Update fix-compaudit to v0.46.77

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.76.tar.gz"
-  sha256 "465fecdd599accf3771cb7bffe0b988162c508ecdbbdf6b40f85cd2d57f2348b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.76"
-    sha256 cellar: :any_skip_relocation, big_sur:      "abe0ac5bfad2912d9f709c2d0737ff83d79b495d4d4a088ccec674a60303ea7c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "95ecaf39514f14fbab259b102d7c95a1e981e2a2e5e9dc4ee9d70a3c766187f6"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.77.tar.gz"
+  sha256 "8f73b0230267b69f33449f90b77f94bec6a4391e1dd32251c160c4d385d74386"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.77](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.77) (2022-03-24)

### Build

- Versio update versions ([`2233fcf`](https://github.com/PurpleBooth/fix-compaudit/commit/2233fcff040f0575f1f94fa0947c0e2786048d2a))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`54b6225`](https://github.com/PurpleBooth/fix-compaudit/commit/54b62251dee774e4d07978a48af592a5a188dd47))
- Bump PurpleBooth/versio-release-action from 0.1.9 to 0.1.10 ([`4ccddcb`](https://github.com/PurpleBooth/fix-compaudit/commit/4ccddcb7dc3b95d22d187db18618f471f15533d8))

### Fix

- Bump clap from 3.1.5 to 3.1.6 ([`8d71133`](https://github.com/PurpleBooth/fix-compaudit/commit/8d7113301ea718a0edbb919a106d31b6e34edb1d))

