### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.44

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.43.tar.gz"
-  sha256 "1f13a7a3fcfe5fc77b23344b60a3bdb0634c52714947faafbf56ecd83d3904fb"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.44.tar.gz"
+  sha256 "2663a0a09c562a394442b2c0f2c1d0f0e266d61aba2d03961aed7d6ba8cecba0"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.43"
-    sha256 cellar: :any_skip_relocation, big_sur:      "8be2e2fd4967d4cfd4b32ae1b9e110faae5d42b13442aba0f4ccdae0b3c2cdfc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e6182f629709ea607b7cf1f436685656bb99438dc4c4a3f03a9cab97721f05ae"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.44](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.44) (2022-03-24)

### Build

- Versio update versions ([`db4596b`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/db4596b62a725a113739522151519b207efb3172))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.9 to 0.1.10 ([`71fcb0d`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/71fcb0d064dda514ee544488277a1221d5cfc35f))

### Fix

- Bump clap from 3.1.5 to 3.1.6 ([`e58484a`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/e58484a5b854c8dc4c5ba2bb517aae44ea2f4dc2))

