### PR TITLE
fix: Update fast-conventional to v2.2.1

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.0.tar.gz"
-  sha256 "700a0e055a036be4fa5fbd36f997956e42b6426f88fab903a928c346f717953d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.2.0"
-    sha256 cellar: :any_skip_relocation, big_sur:      "24468ead5787dcbc8f53cb9b9e818d94a9b03a1253f8746163a73d192cfb2416"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "95f5d789cd410a051758f308355c0ac642caa5d61d4a39213ebf94b13b6c1343"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.1.tar.gz"
+  sha256 "092b146b38428b4212cd74f2bdcdef6d403655aefe7cef95550b8d8f9fdcae5e"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.2.1](https://github.com/PurpleBooth/fast-conventional/compare/...v2.2.1) (2022-03-31)

### Build

- Versio update versions ([`4380a2b`](https://github.com/PurpleBooth/fast-conventional/commit/4380a2bb9d230f1d5616a3ebb5000e6d900f9c46))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.9 to 0.1.10 ([`22919a2`](https://github.com/PurpleBooth/fast-conventional/commit/22919a244fc71a4ce95fd2ea65b1c3e60d5286f0))

### Docs

- Formatting of help page has minorly changed ([`479b541`](https://github.com/PurpleBooth/fast-conventional/commit/479b5418f5c234b1e8b346ce86584feedbfd6777))

### Fix

- Bump miette from 4.2.1 to 4.3.0 ([`a61645d`](https://github.com/PurpleBooth/fast-conventional/commit/a61645d353648f5eebf6a1e07d7b54f840592b71))

