### PR TITLE
fix: Update readable-name-generator to v2.100.22

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.21.tar.gz"
-  sha256 "22f3a718fad068b7305926d7b6e1a7c23dd2159b5cfe2ffa00c69201b1caaf69"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.21"
-    sha256 cellar: :any_skip_relocation, big_sur:      "e16de3940a32459664a1bcef115af2b6b6b08f19fc22ed1296322b0c4d9281da"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7159d4f83dbd7133c6f5a536afc579a1445d415d4c8660c2c2e52baed7988ce8"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.22.tar.gz"
+  sha256 "e2d1530056fe0eab4d635c4071e9c1ec4e4d60ab9bdbb36656b5c8ac372d3c85"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.22](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.22) (2022-03-31)

### Build

- Versio update versions ([`651c612`](https://github.com/PurpleBooth/readable-name-generator/commit/651c61240cb274fb7d0afbb72a47b2ebccce4454))

### Fix

- Bump clap from 3.1.6 to 3.1.7 ([`3b8bd04`](https://github.com/PurpleBooth/readable-name-generator/commit/3b8bd0464536c467820ed18e6bf3acf88263e340))

