### PR TITLE
fix: Update fix-compaudit to v0.46.78

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.77.tar.gz"
-  sha256 "8f73b0230267b69f33449f90b77f94bec6a4391e1dd32251c160c4d385d74386"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.77"
-    sha256 cellar: :any_skip_relocation, big_sur:      "96c98064a88991bc26b3fb84fea409af1de9dfc497696c2c10b72fa73b4d6feb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a5b479bf0f5145654e6eb846575895c272cccfa40689b1e24278ecab56f4760c"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.78.tar.gz"
+  sha256 "a09cf3d4038b54cc5603aa3f5ea913609bc8d9c0fda1734d70f03b427d01e883"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.78](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.78) (2022-04-01)

### Build

- Versio update versions ([`0817487`](https://github.com/PurpleBooth/fix-compaudit/commit/0817487a7d551ada6de2fdfd718ae563a8b659fb))

### Fix

- Bump clap from 3.1.6 to 3.1.7 ([`ee83f26`](https://github.com/PurpleBooth/fix-compaudit/commit/ee83f2694fd210c80e7e5ad191650503419021a4))

