### PR TITLE
fix: Update git-moves-together to v2.5.31

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.30.tar.gz"
-  sha256 "775e04e2ab1597f67dc7f19a2024f95197b5249a22570c661adec1fe33c2b309"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.30"
-    sha256 cellar: :any,                 big_sur:      "ed1c1a1be7330119bb0769fdb8d6728f8e25f31ccdd2daf11cacf71661138cfe"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "31228025451b7a75eb445dc9bfbb25bd9ecf8099a685e0dd05ea94340f023ae2"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.31.tar.gz"
+  sha256 "aaec501d944ab5e115b02dbd89e0e6af280ccd49598c5ad0a8a2c9ecd38d09e6"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.31](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.31) (2022-04-01)

### Build

- Versio update versions ([`2017cc8`](https://github.com/PurpleBooth/git-moves-together/commit/2017cc836616704c8746e40a21d24f2d7f7772dd))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.9 to 0.1.10 ([`10c8abd`](https://github.com/PurpleBooth/git-moves-together/commit/10c8abd433e11ebe048066f50dd21edf24b6a967))

### Fix

- Bump miette from 4.2.1 to 4.3.0 ([`86c3a67`](https://github.com/PurpleBooth/git-moves-together/commit/86c3a671193ca4237655fd44a312cf0354266c4f))
- Bump clap from 3.1.6 to 3.1.7 ([`6c68d71`](https://github.com/PurpleBooth/git-moves-together/commit/6c68d713529c3501c842bafe1436f935a26ddf67))

