### PR TITLE
fix: Update git-mit to v5.12.48

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.47.tar.gz"
-  sha256 "cb0c916385e0ee07612cc469c84dff659ac402e67add12becc1ece0f7aaa57da"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.47"
-    sha256 cellar: :any,                 big_sur:      "de98f77cd8a2f72b67b006e0555663972ca4563b92e3e50e3fe965e5b7632f08"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9f38293dc840f4ad0347890cb7504952ae47ba26392321703d475314d45b0e5a"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.48.tar.gz"
+  sha256 "2869baff0f5696f8248a9a8dc643c28b5ff64b80dc742fc378e6be851f6becae"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.48](https://github.com/PurpleBooth/git-mit/compare/...v5.12.48) (2022-04-01)

### Build

- Versio update versions ([`1e72cc0`](https://github.com/PurpleBooth/git-mit/commit/1e72cc0b341a549d38a3b253c594da84563a6640))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.9 to 0.1.10 ([`2d52acc`](https://github.com/PurpleBooth/git-mit/commit/2d52acc528ce50cf2b944705b3f374ccf8e9dbbb))
- Bump ncipollo/release-action from 1.9.0 to 1.10.0 ([`983f958`](https://github.com/PurpleBooth/git-mit/commit/983f9589f4eca10902ccf1611549c4ac733e5ea3))

### Fix

- Bump clap from 3.1.6 to 3.1.7 ([`b9e2597`](https://github.com/PurpleBooth/git-mit/commit/b9e2597f399c8a3602ce5fc7e655a703d911f03c))

