### PR TITLE
fix: Update fast-conventional to v2.2.2

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.1.tar.gz"
-  sha256 "092b146b38428b4212cd74f2bdcdef6d403655aefe7cef95550b8d8f9fdcae5e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.2.1"
-    sha256 cellar: :any_skip_relocation, big_sur:      "c167b3a66b23cef8acb2f9bb4783155fcf0960899aa6b5d85d5f98e5abaeb8d8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "81e3fd0dd78138b1633bfa27a70caa1eec5d3e604b1b83932d2553cad881eda4"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.2.tar.gz"
+  sha256 "c367e2e69c4579a95d11805910c74240573e2de23e280f24f611f0e98ce31ce1"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.2.2](https://github.com/PurpleBooth/fast-conventional/compare/...v2.2.2) (2022-04-01)

### Build

- Versio update versions ([`25c714d`](https://github.com/PurpleBooth/fast-conventional/commit/25c714d708e86590f458c9b3fd70df8cfef1f7cb))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.10 to 0.1.11 ([`ac4af84`](https://github.com/PurpleBooth/fast-conventional/commit/ac4af8437163b93db2a124a8ba501960f9772a85))

### Fix

- Bump clap from 3.1.6 to 3.1.7 ([`2b009b9`](https://github.com/PurpleBooth/fast-conventional/commit/2b009b94d60e9231705f3513511f4dd7c24e2b61))

