### PR TITLE
fix: Update readable-name-generator to v2.100.23

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.22.tar.gz"
-  sha256 "e2d1530056fe0eab4d635c4071e9c1ec4e4d60ab9bdbb36656b5c8ac372d3c85"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.22"
-    sha256 cellar: :any_skip_relocation, big_sur:      "b66759e84fdc3f645bf3016c07174d7962330b266d04b537bd8a9c532a0a98f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ddab626f46fdf68e3f266f0e06538089b7fed9e314564f47a7667195918a56c9"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.23.tar.gz"
+  sha256 "1c063ea8f5a62451eca1c6180e250faae47259e5a0f0487be3708983d892cf46"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.23](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.23) (2022-04-01)

### Build

- Versio update versions ([`b3ceef1`](https://github.com/PurpleBooth/readable-name-generator/commit/b3ceef11ee459489b1a7316f10908e52bdb9057b))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.10 to 0.1.11 ([`4fe0cab`](https://github.com/PurpleBooth/readable-name-generator/commit/4fe0cab64ff1db150e5e47b5ab9220dc164365b6))

### Fix

- Bump clap from 3.1.7 to 3.1.8 ([`aa98d53`](https://github.com/PurpleBooth/readable-name-generator/commit/aa98d53cd99370e0d4cb56a9e226bc047711afb1))

