### PR TITLE
fix: Update ellipsis to v0.6.39

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.38.tar.gz"
-  sha256 "8f54194a1bab68f6479873b55833ef959443aa3e12ce8389ca947f2bbd4ef9b9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.38"
-    sha256 cellar: :any_skip_relocation, big_sur:      "737ba8f63e50ce578e76cd9f72d621adb0573b73dbdc69afe0ccad34c3fa9ab8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "02582968666fbd8ebc7cbae8be5a83586a123cf2a1dfbf0682732479dbd7894f"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.39.tar.gz"
+  sha256 "400b5dba36779a64c99b2592463222c9ee3953eb0f92a29382999c7e3f150bfc"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.39](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.39) (2022-04-01)

### Build

- Versio update versions ([`3de80ff`](https://github.com/PurpleBooth/ellipsis/commit/3de80ffddff3d3eb657cba778987301d9870df6c))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.10 to 0.1.11 ([`00741e5`](https://github.com/PurpleBooth/ellipsis/commit/00741e531c7cbd0e8eea72281097cad5bd087e65))

### Fix

- Bump clap from 3.1.6 to 3.1.7 ([`2afac9a`](https://github.com/PurpleBooth/ellipsis/commit/2afac9a773917f1bd9dbea1f9f195dfc473604e7))

