### PR TITLE
fix: Update game-of-life to v1.53.59

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.58.tar.gz"
-  sha256 "e1a42a714653072799a903d4a19e24d4e017e070df9eda3693f6abb489314dca"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.58"
-    sha256 cellar: :any_skip_relocation, big_sur:      "8552cdec652eb4b35fccf80590c63e4b742c1cdaa4e7df817416a18321aa1379"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2471403337b5ff0acce97e0bd6ae20d6e7f4e624bd34811e29c2c762e85c9416"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.59.tar.gz"
+  sha256 "4c0ade885553c36c1393ba527f1f3b8b84756506218ea70add3e53f6ca40abfc"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.59](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.59) (2022-04-04)

### Build

- Versio update versions ([`aabbfaf`](https://github.com/PurpleBooth/game-of-life/commit/aabbfaf5a2ccb95b277ee87f40ddc74d71c29948))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.10 to 0.1.11 ([`e989d17`](https://github.com/PurpleBooth/game-of-life/commit/e989d17f53495ef3b869483dd2973179b48a6712))

### Fix

- Bump clap from 3.1.6 to 3.1.7 ([`fb2a309`](https://github.com/PurpleBooth/game-of-life/commit/fb2a30939c80de3dc9c3cf74a88f608dc451393d))
- Bump clap from 3.1.7 to 3.1.8 ([`09f5519`](https://github.com/PurpleBooth/game-of-life/commit/09f55190f60d18d79dc97c9d3a2f2ef6142eb83a))

