### PR TITLE
fix: Update fix-compaudit to v0.46.79

### DIFF
--- a/Formula/fix-compaudit.rb
+++ b/Formula/fix-compaudit.rb
@@ -1,14 +1,8 @@
 class FixCompaudit < Formula
   desc "Fixes problems reported by compuaudit"
   homepage "https://github.com/PurpleBooth/fix-compaudit"
-  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.78.tar.gz"
-  sha256 "a09cf3d4038b54cc5603aa3f5ea913609bc8d9c0fda1734d70f03b427d01e883"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-compaudit-0.46.78"
-    sha256 cellar: :any_skip_relocation, big_sur:      "a1b919adff3bca05893193dd2b9253dd9862f0a9215dd02d7a24e0500ad16098"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6fd5b8c0a59ec2c8ad311433d0f9915e660ede14ba4161d12dca255f6f4dedeb"
-  end
+  url "https://github.com/PurpleBooth/fix-compaudit/archive/v0.46.79.tar.gz"
+  sha256 "8952a2abd41f5a2e24cdc0f8ffaaa752c070013be1becaba43c86e72131cd19b"
 
   depends_on "rust" => :build
   depends_on "zsh"


### PR DESCRIPTION
## Changelog
### [v0.46.79](https://github.com/PurpleBooth/fix-compaudit/compare/...v0.46.79) (2022-04-04)

### Build

- Versio update versions ([`2feb3dd`](https://github.com/PurpleBooth/fix-compaudit/commit/2feb3dd9262c7d59eb2dc0471482f83d66263aa5))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.10 to 0.1.11 ([`23de42f`](https://github.com/PurpleBooth/fix-compaudit/commit/23de42ff42857a606e20dc46651916ee47cefc13))

### Fix

- Bump clap from 3.1.7 to 3.1.8 ([`27951e5`](https://github.com/PurpleBooth/fix-compaudit/commit/27951e5b542d623f982140156df3b91c456e750d))

