### PR TITLE
fix: Update fix-gnupg-permissions to v0.49.45

### DIFF
--- a/Formula/fix-gnupg-permissions.rb
+++ b/Formula/fix-gnupg-permissions.rb
@@ -1,15 +1,9 @@
 class FixGnupgPermissions < Formula
   desc "Fixes permissions problems on the gnupg directory"
   homepage "https://github.com/PurpleBooth/fix-gnupg-permissions"
-  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.44.tar.gz"
-  sha256 "2663a0a09c562a394442b2c0f2c1d0f0e266d61aba2d03961aed7d6ba8cecba0"
+  url "https://github.com/PurpleBooth/fix-gnupg-permissions/archive/v0.49.45.tar.gz"
+  sha256 "0e0573c24ff8151726d509d9e17db975ae4a7aa4fc977e2b1d77318f041c3d43"
   license "CC0-1.0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fix-gnupg-permissions-0.49.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "02a0d43cd74ab3a70216d2dd3ca3befeefc765c18af69fb61de5071df971ed3a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c867c79759d0bf2f3cdfaeada2fd67cd9ce278c62125e85bc16997f6efa64628"
-  end
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.49.45](https://github.com/PurpleBooth/fix-gnupg-permissions/compare/...v0.49.45) (2022-04-04)

### Build

- Versio update versions ([`4b560a3`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/4b560a35031fcc9382ca670f8371b1039d36905d))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.10 to 0.1.11 ([`38e3d02`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/38e3d02d5336d25f26a586c00accdc8d9ba44c89))

### Fix

- Bump clap from 3.1.6 to 3.1.7 ([`a3eab52`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/a3eab523dbfa1384294a1df752f72a61c285454c))
- Bump clap from 3.1.7 to 3.1.8 ([`9d05daf`](https://github.com/PurpleBooth/fix-gnupg-permissions/commit/9d05dafc5d3b097980c6f45b97235e62a8bcd753))

