### PR TITLE
fix: Update hungry-distance to v0.1.28

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.27.tar.gz"
-  sha256 "3544da904aac672dae0e11287d8eac83a80f4d92f8072cee62da81bd6afbe5a6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.27"
-    sha256 cellar: :any_skip_relocation, big_sur:      "5bf402c0d12a55b3cfe91dda9ece9c26699d9d151898f0f2c1801f70254708c3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "81611249377928b9b85eb8906491ba80f4e66782f704a1ac2a2fa106d8bf1118"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.28.tar.gz"
+  sha256 "82881a8fb7c11fcb02fbd005093c0f21cd76bcacca770d75024b3529f1700047"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.28](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.28) (2022-04-04)

### Build

- Versio update versions ([`dfea070`](https://github.com/PurpleBooth/hungry-distance/commit/dfea07080ea5cf1cb0b225071a7c9179dbeeb55b))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.10 to 0.1.11 ([`c427d6d`](https://github.com/PurpleBooth/hungry-distance/commit/c427d6d2503dae68bcc71c4cff3e9bed39d1d2fd))

### Fix

- Bump clap from 3.1.7 to 3.1.8 ([`c94d79f`](https://github.com/PurpleBooth/hungry-distance/commit/c94d79f58da00a7e7ec31852e0ea6f5287d32234))

