### PR TITLE
fix: Update ellipsis to v0.6.40

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.39.tar.gz"
-  sha256 "400b5dba36779a64c99b2592463222c9ee3953eb0f92a29382999c7e3f150bfc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.39"
-    sha256 cellar: :any_skip_relocation, big_sur:      "8759784d9dc196b5bea1eb0beaf4bd403d92ecb1f86e5d1c6cd79fa02bcd1ab1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "de4f8d8589b8fc324175a4b25617223008bffb2b8c9e2352d7fa4318ac002507"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.40.tar.gz"
+  sha256 "6f942101f616a1513bcc5ed8d0a58659ee34af9791d2d81f40a5dcf85aa5a28d"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.40](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.40) (2022-04-04)

### Build

- Versio update versions ([`88a67b6`](https://github.com/PurpleBooth/ellipsis/commit/88a67b6f96f864821c4d1b3e23ebf9998338bcc7))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.11 to 0.1.12 ([`6b62cbe`](https://github.com/PurpleBooth/ellipsis/commit/6b62cbeaa6495b5ce7a14abeef4f3fecc3650f0e))

### Fix

- Bump clap from 3.1.7 to 3.1.8 ([`0acc3a2`](https://github.com/PurpleBooth/ellipsis/commit/0acc3a2f79ed31e1e4bee5aa78e6f29f76caa668))

