### PR TITLE
fix: Update game-of-life to v1.53.60

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.59.tar.gz"
-  sha256 "4c0ade885553c36c1393ba527f1f3b8b84756506218ea70add3e53f6ca40abfc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.59"
-    sha256 cellar: :any_skip_relocation, big_sur:      "759c190657d8cccf5ece55947a7f2cb833b89c4257caec81ec4a76e9b74c4d1e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "aa5d05c8b74690652b36492815c60d38eec6c3dd33723e6b8c16fdd39760b28f"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.60.tar.gz"
+  sha256 "4ffae4cca9e3eaa43c405d062d56f8fd7fc8f156d067ffba2a4ed26d030ede5b"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.60](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.60) (2022-04-05)

### Build

- Versio update versions ([`5c90fb0`](https://github.com/PurpleBooth/game-of-life/commit/5c90fb0d99c28d985b4cf03a1ea4c1f0f9d71d7d))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.11 to 0.1.12 ([`fc3ed13`](https://github.com/PurpleBooth/game-of-life/commit/fc3ed13c523cc1d886bce3e30faf24288ecc81b4))

### Fix

- Bump crossterm from 0.23.1 to 0.23.2 ([`2cb2c7c`](https://github.com/PurpleBooth/game-of-life/commit/2cb2c7c61591ce9d1ab4d11d68b4d3fd782b8093))

