### PR TITLE
fix: Update readable-name-generator to v2.100.24

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.23.tar.gz"
-  sha256 "1c063ea8f5a62451eca1c6180e250faae47259e5a0f0487be3708983d892cf46"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.23"
-    sha256 cellar: :any_skip_relocation, big_sur:      "442f394724fec713234322d8edf412408960ff1aea7b9e4100013095530e2ec1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "fbe0a0ae217d86d08fe7c93371543818aef029b453bd312fc7c3b0054388fd4a"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.24.tar.gz"
+  sha256 "7e72ae6ae129775c7a4e5681c768b49670e7445f8c330499d556cc076e7242b3"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.24](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.24) (2022-04-08)

### Build

- Versio update versions ([`a2a13f0`](https://github.com/PurpleBooth/readable-name-generator/commit/a2a13f028616724f927928525aba422c1ed34d92))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.11 to 0.1.12 ([`3f1092e`](https://github.com/PurpleBooth/readable-name-generator/commit/3f1092e6226213405a99bea6bb4fd1c53c4ee514))

### Fix

- Bump rust from 1.59.0 to 1.60.0 ([`ee89007`](https://github.com/PurpleBooth/readable-name-generator/commit/ee890074c53ac768b527daa03c957805401d63c7))

