### PR TITLE
fix: Update ed-system-search to v1.1.36

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.35.tar.gz"
-  sha256 "2498b03b76160b216577035a397653e39d3b8632eff60cd50ebd1231fd805800"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.35"
-    sha256 cellar: :any_skip_relocation, big_sur:      "5923c416d2a9a6b57db00410b8d489086c6f3c2ce63b5890eb8a541bc3b26750"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b46e6a9b9a45348fa727ae0c891685978a86199315007d23f7435755138914a6"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.36.tar.gz"
+  sha256 "933c896cd27bbcc106cca43abdce0f104db2caebe8ce21bcf22b101d8cebaa46"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.36](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.36) (2022-04-13)

### Build

- Versio update versions ([`58f064a`](https://github.com/PurpleBooth/ed-system-search/commit/58f064a992c09fdf663a3fd38e28fd953aaf2423))

### Ci

- Bump actions/cache from 2.1.7 to 3 ([`c64f4bf`](https://github.com/PurpleBooth/ed-system-search/commit/c64f4bf0fe659dda717feec6d620ffee8d9dd265))
- Bump actions/download-artifact from 2 to 3 ([`b7d7f63`](https://github.com/PurpleBooth/ed-system-search/commit/b7d7f63fece19627802df8438103c7620789381a))
- Bump actions/upload-artifact from 2 to 3 ([`e8ea7c3`](https://github.com/PurpleBooth/ed-system-search/commit/e8ea7c3ed80580fcf1c23619c8ad787b8ae5ce18))
- Bump PurpleBooth/changelog-action from 0.3.2 to 0.3.3 ([`a575e38`](https://github.com/PurpleBooth/ed-system-search/commit/a575e38e39188832e09e294a1e22eb598735f47d))

### Fix

- Bump miette from 4.2.1 to 4.4.0 ([`34d385b`](https://github.com/PurpleBooth/ed-system-search/commit/34d385b5edd80040009699e182724904bc30b75e))

