### PR TITLE
fix: Update ed-system-search to v1.1.37

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.36.tar.gz"
-  sha256 "933c896cd27bbcc106cca43abdce0f104db2caebe8ce21bcf22b101d8cebaa46"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.36"
-    sha256 cellar: :any_skip_relocation, big_sur:      "bd7aac8b984be9025d5f337318c5da1d8fcb8c630a06b2e9562df84f39e8fda7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "dbc32586cafbdafa28568e1af914903781f37f4e68daf68b36934c18e642ec12"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.37.tar.gz"
+  sha256 "d97eaacec7472ef55a66ff3a8b101c25d022ca03489acfa6948e791b4ddd841f"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.37](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.37) (2022-04-13)

### Build

- Versio update versions ([`42f4b2f`](https://github.com/PurpleBooth/ed-system-search/commit/42f4b2f40ae37252167f9f5dfdd62e81aa2fea1d))

### Fix

- Bump clap from 3.1.6 to 3.1.8 ([`3d783bf`](https://github.com/PurpleBooth/ed-system-search/commit/3d783bf01647e5e1a47b7850a84fcc4d574cf588))

