### PR TITLE
fix: Update ed-system-search to v1.1.38

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.37.tar.gz"
-  sha256 "d97eaacec7472ef55a66ff3a8b101c25d022ca03489acfa6948e791b4ddd841f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.37"
-    sha256 cellar: :any_skip_relocation, big_sur:      "538f836699b0df9f74e84409fb58437ee00f899c8ce661b5576319ff9d84c511"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b200fd900849c8b6074c2cf2680584347264d001942540776a04746f65f6b056"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.38.tar.gz"
+  sha256 "f4c12c254f1613bada60787f1f0852e7e9912a1859c7895cec9ae6466268d3e8"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.38](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.38) (2022-04-18)

### Build

- Versio update versions ([`dab8b67`](https://github.com/PurpleBooth/ed-system-search/commit/dab8b67dc5afd2645259ae88a4c433f29d468608))

### Fix

- Bump clap from 3.1.8 to 3.1.9 ([`a4c22e0`](https://github.com/PurpleBooth/ed-system-search/commit/a4c22e05e087093fddca622835aef359674a8b11))

