### PR TITLE
fix: Update hungry-distance to v0.1.29

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.28.tar.gz"
-  sha256 "82881a8fb7c11fcb02fbd005093c0f21cd76bcacca770d75024b3529f1700047"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.28"
-    sha256 cellar: :any_skip_relocation, big_sur:      "d481d389eb312083a9a7405d6d4b8f6096c222f685ef8316e0fa57ec26106680"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "167f83fe95fe924de339af47548c11dda428ed46c34443e98294123b3d192881"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.29.tar.gz"
+  sha256 "2ae08046d83acdaa2d64fbd545f787928c77ddc2d4c5454321d7eaae2a328e97"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.29](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.29) (2022-04-18)

### Build

- Versio update versions ([`0ba8072`](https://github.com/PurpleBooth/hungry-distance/commit/0ba807247acdf12f9c9b6c2588a974fc0ecb096e))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.11 to 0.1.12 ([`0676a46`](https://github.com/PurpleBooth/hungry-distance/commit/0676a46270c14172da45000d433c7ee1155621db))

### Fix

- Bump clap from 3.1.8 to 3.1.9 ([`d1ce7c7`](https://github.com/PurpleBooth/hungry-distance/commit/d1ce7c7670072cd806b332660eed126348c278d4))

