### PR TITLE
fix: Update fast-conventional to v2.2.4

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.3.tar.gz"
-  sha256 "1ddf211729ba2d767cce18c22b7ced3faffbfb0ef37f185ccc84ffa9a84092fc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.2.3"
-    sha256 cellar: :any_skip_relocation, big_sur:      "efe0f7955ce8fe938d33d9cb6561741215bc33357b724ef7a1313c178309f836"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "62f00ceee15f81b566d22b311491f828d327ba3d947fd8fbe1a1c34bfe5a7dc3"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.4.tar.gz"
+  sha256 "3240b378d960c0b259626defea85a355002476b76d7e377d7073d2c9cd5d195c"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.2.4](https://github.com/PurpleBooth/fast-conventional/compare/...v2.2.4) (2022-04-18)

### Build

- Versio update versions ([`e172d7f`](https://github.com/PurpleBooth/fast-conventional/commit/e172d7ff0a1e4f0f3fa27af875d12e22bc35b3f4))

### Fix

- Bump miette from 4.3.0 to 4.4.0 ([`3a926f5`](https://github.com/PurpleBooth/fast-conventional/commit/3a926f5a455672eaf8e369c2ab2999563be69f2d))
- Bump miette from 4.4.0 to 4.5.0 ([`92c1456`](https://github.com/PurpleBooth/fast-conventional/commit/92c1456bfc9b3e1c6a829de797f40c4aa4ae0224))
- Bump clap from 3.1.8 to 3.1.9 ([`02be997`](https://github.com/PurpleBooth/fast-conventional/commit/02be9977de28852ca2037469605e298cfa1ed805))

