### PR TITLE
fix: Update readable-name-generator to v2.100.25

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.24.tar.gz"
-  sha256 "7e72ae6ae129775c7a4e5681c768b49670e7445f8c330499d556cc076e7242b3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.24"
-    sha256 cellar: :any_skip_relocation, big_sur:      "03a0f8e29bdb1885566f5c0916f192de9ad34b2fb93b6802dd9e2e9b5bf85674"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8677ac76382d4c63d8f34b2dda1e45ccd8db07b0be3afb99b25a5d75f47d1e54"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.25.tar.gz"
+  sha256 "a370554e9ac2c209aeedcf2f0d8820fe07674e3b11bbc31890e8c3631714d659"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.25](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.25) (2022-04-18)

### Build

- Versio update versions ([`92cf2ed`](https://github.com/PurpleBooth/readable-name-generator/commit/92cf2eda20546d75f68fbbdc51031d44e36fefaf))

### Fix

- Bump miette from 4.3.0 to 4.4.0 ([`0292d17`](https://github.com/PurpleBooth/readable-name-generator/commit/0292d1736351b2738c48350533c9dfdad06c20c1))
- Bump miette from 4.4.0 to 4.5.0 ([`a152ce3`](https://github.com/PurpleBooth/readable-name-generator/commit/a152ce38d0ab550431ea4420ff30ddb48790105d))

