### PR TITLE
fix: Update ed-system-search to v1.1.39

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.38.tar.gz"
-  sha256 "f4c12c254f1613bada60787f1f0852e7e9912a1859c7895cec9ae6466268d3e8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.38"
-    sha256 cellar: :any_skip_relocation, big_sur:      "b7bfbe3431d54dd4e21a55edc9650c747d10ba04fcc5aa45feb71ecc2a689861"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "fa458a9bc2ec567728b06dc6fa2be3b3f2bd2cd8e22ff72a8f539ccb4c6141ed"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.39.tar.gz"
+  sha256 "59f8d8c3264b48c8525767ac41765dcea27f75535bf4fc18c3a9d65c6fbe51e6"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.39](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.39) (2022-04-19)

### Build

- Versio update versions ([`54a45c1`](https://github.com/PurpleBooth/ed-system-search/commit/54a45c1c069fac24a57bed0767c350a83c10c776))

### Fix

- Bump miette from 4.4.0 to 4.5.0 ([`5af5553`](https://github.com/PurpleBooth/ed-system-search/commit/5af5553312e2b1637321975847e6a22ec95acba3))

