### PR TITLE
fix: Update ellipsis to v0.6.41

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.40.tar.gz"
-  sha256 "6f942101f616a1513bcc5ed8d0a58659ee34af9791d2d81f40a5dcf85aa5a28d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.40"
-    sha256 cellar: :any_skip_relocation, big_sur:      "5d1447fc72a95a8e2fc609d13b6a01053d9ebfe6a8eecdd1880ec6c44f7b9e37"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "44fcd435d378a4533e9be4b35528302c9fb50bc6d05b7849bb1ff363be6d3cb0"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.41.tar.gz"
+  sha256 "d2ab545a85504dd17b278059a02a9a334df448b9759df2229cfc250a32833271"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.41](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.41) (2022-04-19)

### Build

- Versio update versions ([`89576f5`](https://github.com/PurpleBooth/ellipsis/commit/89576f57ed9a40487cfe27a3b3652f6b5af04c6c))

### Fix

- Bump clap from 3.1.8 to 3.1.9 ([`7caed96`](https://github.com/PurpleBooth/ellipsis/commit/7caed96bd58f11f61c8fdc78f4267a76b951f25d))
- Bump clap from 3.1.9 to 3.1.10 ([`9690847`](https://github.com/PurpleBooth/ellipsis/commit/969084771c85cf0be2cf9cf30d8a355a7b20824a))

