### PR TITLE
fix: Update game-of-life to v1.53.61

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.60.tar.gz"
-  sha256 "4ffae4cca9e3eaa43c405d062d56f8fd7fc8f156d067ffba2a4ed26d030ede5b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.60"
-    sha256 cellar: :any_skip_relocation, big_sur:      "78af7df75b6a118405ce9c19df718fa121ab85dbdfe238f0b39934eccad9aaea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3f7ebfd50a86af745f5ea25c20beda1872b4f43a5b4664b3578b9859e3a3b9b5"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.61.tar.gz"
+  sha256 "b1a542ceaff5722891f02d1e6c4685b39ec8e6d79c036040b8557cfbdd175b7b"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.61](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.61) (2022-04-20)

### Build

- Versio update versions ([`f3967bb`](https://github.com/PurpleBooth/game-of-life/commit/f3967bbbf5885823285ac87adb87cfdc403c0c8f))

### Fix

- Bump clap from 3.1.8 to 3.1.9 ([`448ecbc`](https://github.com/PurpleBooth/game-of-life/commit/448ecbc49cec99f601a68555b61dd620f67042df))
- Bump clap from 3.1.9 to 3.1.10 ([`1d0e678`](https://github.com/PurpleBooth/game-of-life/commit/1d0e678a4d67aa716b1fd8d79c990a2c3adb88ad))

