### PR TITLE
fix: Update ed-system-search to v1.1.40

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.39.tar.gz"
-  sha256 "59f8d8c3264b48c8525767ac41765dcea27f75535bf4fc18c3a9d65c6fbe51e6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.39"
-    sha256 cellar: :any_skip_relocation, big_sur:      "e87ef932370dfd7034d250e669cd643a6fdda17fab250682391ab1ac581776b8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a150625ab20044bd08dcf15656dee4cc06747aeb478b155f4f35b4e72b0d1c5b"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.40.tar.gz"
+  sha256 "cd357a6e544a06a7ffcb0719d7de91609fd07b3d9178e017c60f8a05c884eeca"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.40](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.40) (2022-04-20)

### Build

- Versio update versions ([`662da51`](https://github.com/PurpleBooth/ed-system-search/commit/662da51507cf8687f3edf2b8fe3f67bd8d249c25))

### Fix

- Bump clap from 3.1.9 to 3.1.10 ([`a1dfc29`](https://github.com/PurpleBooth/ed-system-search/commit/a1dfc299034edb1e540e4a632868afa9fcf19ec4))

