### PR TITLE
fix: Update readable-name-generator to v2.100.26

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.25.tar.gz"
-  sha256 "a370554e9ac2c209aeedcf2f0d8820fe07674e3b11bbc31890e8c3631714d659"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.25"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0d9a5281377f5f739884f197bc9142eb9d0ed5b1c21018a742c8ad4f234233fb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "42101eba4bc716069b724d0508ee5cfc2c080a621d02f3bc06208a7a7ab3e3e1"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.26.tar.gz"
+  sha256 "e4e952727c5d05e051e873621c2e92677a555ad5dda9c44bd7b20c56cf586b5d"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.26](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.26) (2022-04-20)

### Build

- Versio update versions ([`482e0e8`](https://github.com/PurpleBooth/readable-name-generator/commit/482e0e8d78857d067d0e9f781b83b62b236f227d))

### Fix

- Bump clap from 3.1.8 to 3.1.9 ([`8d51da8`](https://github.com/PurpleBooth/readable-name-generator/commit/8d51da888ae9bc8cd2c04fb423e851ff1a996d62))
- Bump clap from 3.1.9 to 3.1.10 ([`0577a32`](https://github.com/PurpleBooth/readable-name-generator/commit/0577a32c3e96dd509bf91882ba75879272dffc1a))
- Bump clap_complete from 3.1.1 to 3.1.2 ([`17ee7dc`](https://github.com/PurpleBooth/readable-name-generator/commit/17ee7dccb0233ee68a16aa8148edc8744dbe5112))

