### PR TITLE
fix: Update hungry-distance to v0.1.30

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.29.tar.gz"
-  sha256 "2ae08046d83acdaa2d64fbd545f787928c77ddc2d4c5454321d7eaae2a328e97"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.29"
-    sha256 cellar: :any_skip_relocation, big_sur:      "b45eb941958f4efea164ea029b730164d6a599ac6a6d9104cb299f87cb586b6c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ac8b6dbd651581a9a1032718769456590a143cac063efac6aad4cbfd2b7bbbdc"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.30.tar.gz"
+  sha256 "601d32acc845b9418561292987e1ba61717252d4a7255f2930981b7e8baa95ce"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.30](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.30) (2022-04-22)

### Build

- Versio update versions ([`b665754`](https://github.com/PurpleBooth/hungry-distance/commit/b665754904542c532c8be5a73bbfbbffa3776b45))

### Fix

- Bump clap from 3.1.9 to 3.1.10 ([`2674e4d`](https://github.com/PurpleBooth/hungry-distance/commit/2674e4d1b637c4548e3825c3d8fd78659a9bac47))
- Bump clap from 3.1.10 to 3.1.12 ([`cdb6dbf`](https://github.com/PurpleBooth/hungry-distance/commit/cdb6dbfe00382e5848cf4fa827f77fa7f01bb0a1))

