### PR TITLE
fix: Update ellipsis to v0.6.42

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.41.tar.gz"
-  sha256 "d2ab545a85504dd17b278059a02a9a334df448b9759df2229cfc250a32833271"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.41"
-    sha256 cellar: :any_skip_relocation, big_sur:      "1eb793bcf0fa15e881397bf684636bc4a31c98bc6f77b171eecac90047ec7d67"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5141b67f7b0e82ddee396c2415b7bd14839af408b72ee775f848f0e99a59efe0"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.42.tar.gz"
+  sha256 "3029f1ed08ed6ca4a5cf2a81125d05ef35cb9c16d54e51350eccd0cbebe5f6b9"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.42](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.42) (2022-04-22)

### Build

- Versio update versions ([`565f097`](https://github.com/PurpleBooth/ellipsis/commit/565f09703eeee259b906e5d5c2d7ec74ddf9e01b))

### Fix

- Bump anyhow from 1.0.56 to 1.0.57 ([`b2c8429`](https://github.com/PurpleBooth/ellipsis/commit/b2c842901ebfa1a429b79d65df26d3aaf7ed1580))
- Bump clap from 3.1.10 to 3.1.12 ([`06b9d8d`](https://github.com/PurpleBooth/ellipsis/commit/06b9d8d2300f69e12662ba75b5f852f8ffe1b6ef))

