### PR TITLE
fix: Update game-of-life to v1.53.62

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.61.tar.gz"
-  sha256 "b1a542ceaff5722891f02d1e6c4685b39ec8e6d79c036040b8557cfbdd175b7b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.61"
-    sha256 cellar: :any_skip_relocation, big_sur:      "a55264fa0ebd2a74cd1aacc419f9de91007dbac66c6be58c89b9a4aece3bc2c8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d1c4c400a649b1bb326067460f73327d7de64b095429c07a5b1a11cce6a2285c"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.62.tar.gz"
+  sha256 "54bfa13ef25c95e05d491933a895a0c9f824df409c13b877063253e8da7d3671"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.62](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.62) (2022-04-25)

### Build

- Versio update versions ([`60f5d78`](https://github.com/PurpleBooth/game-of-life/commit/60f5d78c6509c01224636c462976e0e3323295a4))

### Fix

- Bump clap from 3.1.10 to 3.1.12 ([`f61ec02`](https://github.com/PurpleBooth/game-of-life/commit/f61ec026702b3e9c07c84aa923bde81408410819))

