### PR TITLE
fix: Update ed-system-search to v1.1.41

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.40.tar.gz"
-  sha256 "cd357a6e544a06a7ffcb0719d7de91609fd07b3d9178e017c60f8a05c884eeca"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.40"
-    sha256 cellar: :any_skip_relocation, big_sur:      "daeb7de20bde5ace7b3dab5ea3aa54f30cd58f6a213d868facc6304091bdaf0b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "cd3711f773003f6d94657e75340956b58e2634b64a5b08e6b9fd83eb44fe1365"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.41.tar.gz"
+  sha256 "28ba3b16f3b18a1965cc6c6aded38601498f489e041cdf150e9881a39b864dc8"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.41](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.41) (2022-04-25)

### Build

- Versio update versions ([`0757737`](https://github.com/PurpleBooth/ed-system-search/commit/0757737cc7c50f2d41be711d4c844de39425a099))

### Fix

- Bump miette from 4.5.0 to 4.6.0 ([`a30fbca`](https://github.com/PurpleBooth/ed-system-search/commit/a30fbcafac3f080d505ee9b0e212870ec574cc9f))
- Bump clap from 3.1.10 to 3.1.12 ([`97556e9`](https://github.com/PurpleBooth/ed-system-search/commit/97556e9052ff034f848625c41cbd97531c2a6768))

