### PR TITLE
fix: Update fast-conventional to v2.2.5

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.4.tar.gz"
-  sha256 "3240b378d960c0b259626defea85a355002476b76d7e377d7073d2c9cd5d195c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.2.4"
-    sha256 cellar: :any_skip_relocation, big_sur:      "cc3f6af50e3cd03d15f821054c9d85b748710c4ea01fc2446c3c15916a9e0542"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "478d0c0ff3e0afca8e2344349be0f393d19cac122c3e8f714c2cd6b632120956"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.5.tar.gz"
+  sha256 "d65a0532ff0c254728d4c4857ba7b6ba4972ffce8b05e99338e6313c72dc5777"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.2.5](https://github.com/PurpleBooth/fast-conventional/compare/...v2.2.5) (2022-04-26)

### Build

- Versio update versions ([`32bd96e`](https://github.com/PurpleBooth/fast-conventional/commit/32bd96e0493d5ae664861f638fdd8feb083d46ef))

### Fix

- Bump clap from 3.1.9 to 3.1.10 ([`ff034cb`](https://github.com/PurpleBooth/fast-conventional/commit/ff034cb8255bfa15a9d893a3937790f71d48a868))
- Bump clap_complete from 3.1.1 to 3.1.2 ([`8895303`](https://github.com/PurpleBooth/fast-conventional/commit/889530368266f9ca9c340237e1018d305a52e24f))
- Bump clap from 3.1.10 to 3.1.12 ([`8730656`](https://github.com/PurpleBooth/fast-conventional/commit/87306568b57e1a86d7c75ce56a2004b1b3ff65db))
- Bump miette from 4.5.0 to 4.6.0 ([`33b4628`](https://github.com/PurpleBooth/fast-conventional/commit/33b4628e48e2f3b1126d366d2e92808cfd2578a4))

