### PR TITLE
fix: Update ed-system-search to v1.1.42

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.41.tar.gz"
-  sha256 "28ba3b16f3b18a1965cc6c6aded38601498f489e041cdf150e9881a39b864dc8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.41"
-    sha256 cellar: :any_skip_relocation, big_sur:      "00daa54d32c5335d4c79697e1aa96e5d3aee344384176f03d1c6d00938dad9f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a1523e221eeade37f5c6fc0670da1238c6a00fdf5a41b626da302080d14b9ecc"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.42.tar.gz"
+  sha256 "f1e2be35946adccf11622e914791d2d14e4e6f38f5574be9296186acea102f3d"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.42](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.42) (2022-04-28)

### Build

- Versio update versions ([`4d26c7e`](https://github.com/PurpleBooth/ed-system-search/commit/4d26c7e3bad5eb60016d6d7bbb57ba271118af15))

### Fix

- Bump tokio from 1.17.0 to 1.18.0 ([`20ec224`](https://github.com/PurpleBooth/ed-system-search/commit/20ec22439d33e16ab2bdd9c7f9b181326ddad889))

