### PR TITLE
fix: Update ed-system-search to v1.1.43

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.42.tar.gz"
-  sha256 "f1e2be35946adccf11622e914791d2d14e4e6f38f5574be9296186acea102f3d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.42"
-    sha256 cellar: :any_skip_relocation, big_sur:      "798b66a972334521199c1118b368b8219c1a3526514a8a50597484c3e3aaed95"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a7d161773c18ef7e6dbea8687aa0a900d201cd1a880a75e1a66e16138b06d40a"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.43.tar.gz"
+  sha256 "be04d107f8e59bef5fb10ab905e399171c45cca1a7ad45068985021564d5b7a3"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.43](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.43) (2022-05-02)

### Build

- Versio update versions ([`3498183`](https://github.com/PurpleBooth/ed-system-search/commit/3498183b224dd13de297f9788a146b7997110ea9))

### Fix

- Bump clap from 3.1.12 to 3.1.14 ([`b94281e`](https://github.com/PurpleBooth/ed-system-search/commit/b94281e363e56cc726396727c0d327f0d0feebf7))
- Bump thiserror from 1.0.30 to 1.0.31 ([`42fe56e`](https://github.com/PurpleBooth/ed-system-search/commit/42fe56e5d46cf7d640f599a3d1ef894e12cc048b))
- Bump serde_json from 1.0.79 to 1.0.80 ([`3482bc9`](https://github.com/PurpleBooth/ed-system-search/commit/3482bc9c79a18218d1f11e51b71471c234737f81))

