### PR TITLE
fix: Update ed-system-search to v1.1.44

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.43.tar.gz"
-  sha256 "be04d107f8e59bef5fb10ab905e399171c45cca1a7ad45068985021564d5b7a3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.43"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0f09a665bd2f4556ab9f0fc3a696bcdb26241f4dfef8d14badb5ad758e8432b3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ff7b3d9d44b9f785e04811a9cbd8e625e351ce7413ec8e5a3b76049d79488d14"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.44.tar.gz"
+  sha256 "0af3840a82c8000f6dffb3b9ad46831ae3699d920444ebd2cedfb4899e2a1d46"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.44](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.44) (2022-05-02)

### Build

- Versio update versions ([`d6ac254`](https://github.com/PurpleBooth/ed-system-search/commit/d6ac2544854ad3d9a6d68c86702d2c918002d97f))

### Fix

- Bump serde from 1.0.136 to 1.0.137 ([`8b88f9b`](https://github.com/PurpleBooth/ed-system-search/commit/8b88f9bc3df5aced2e6a2341db5190e2462d6319))

