### PR TITLE
fix: Update fast-conventional to v2.2.6

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.5.tar.gz"
-  sha256 "d65a0532ff0c254728d4c4857ba7b6ba4972ffce8b05e99338e6313c72dc5777"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.2.5"
-    sha256 cellar: :any_skip_relocation, big_sur:      "f5a9291ecc2a29371ae19ec98b3ecd8a5335786a30bf55e2b20dac8ba5792804"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2fbb82189a2f25c27ed9553309690c62fb65315448537bc1edf9c205c1545351"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.6.tar.gz"
+  sha256 "b224a28a831c33463343d8b5e25b681f97aaede6142918b7786117247245a317"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.2.6](https://github.com/PurpleBooth/fast-conventional/compare/...v2.2.6) (2022-05-02)

### Build

- Versio update versions ([`ac4e340`](https://github.com/PurpleBooth/fast-conventional/commit/ac4e340824095a475d3665f794e3633ec8682835))

### Fix

- Bump clap from 3.1.12 to 3.1.14 ([`f0385a0`](https://github.com/PurpleBooth/fast-conventional/commit/f0385a0cb7209f9ba7dd409378645ad7fc557736))
- Bump serde from 1.0.136 to 1.0.137 ([`161d2c3`](https://github.com/PurpleBooth/fast-conventional/commit/161d2c365f3f1fc3fc54cd39022012567933f3e1))

