### PR TITLE
fix: Update fast-conventional to v2.2.7

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.6.tar.gz"
-  sha256 "b224a28a831c33463343d8b5e25b681f97aaede6142918b7786117247245a317"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.2.6"
-    sha256 cellar: :any_skip_relocation, big_sur:      "3671765131d9ad4d2dc767d0afa7531caa0748a5bbc86c1b3cb935bde3cb4306"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "13527db7ea772a3f067fca63ca16ee3739c029d31be7e60b710054ae22e33ce8"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.7.tar.gz"
+  sha256 "02eb10576b263304d1e0c9eb05c753c83c6ef2788fe21f7df6aae1743efd33cb"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.2.7](https://github.com/PurpleBooth/fast-conventional/compare/...v2.2.7) (2022-05-02)

### Build

- Versio update versions ([`0327484`](https://github.com/PurpleBooth/fast-conventional/commit/0327484d895b80967dd084d689a046b37e37ba61))

### Fix

- Bump thiserror from 1.0.30 to 1.0.31 ([`f2e4cba`](https://github.com/PurpleBooth/fast-conventional/commit/f2e4cba15cba9756172055dd5a784e31282f7da7))

