### PR TITLE
fix: Update ellipsis to v0.6.43

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.42.tar.gz"
-  sha256 "3029f1ed08ed6ca4a5cf2a81125d05ef35cb9c16d54e51350eccd0cbebe5f6b9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.42"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0106beadd4abb7bbb1d16f6d19330826b6b78cb15475b12ea0713924bdb8ef2a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0de7e527b53273602cfd015bef0c1430ebd69c37ad632348dd09f6dd3fa54008"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.43.tar.gz"
+  sha256 "94c8cb5c9c033cc3680228144c9997b7965740b6819a5841bbbb2a9ce66fc3a8"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.43](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.43) (2022-05-02)

### Build

- Versio update versions ([`f4e4ef0`](https://github.com/PurpleBooth/ellipsis/commit/f4e4ef000f09e642beadda184bd80b9a5e03c6fe))

### Fix

- Bump serde from 1.0.136 to 1.0.137 ([`5a082c8`](https://github.com/PurpleBooth/ellipsis/commit/5a082c80e36ec8eaa4b5007b0fce523938bb6121))
- Bump thiserror from 1.0.30 to 1.0.31 ([`07c3f5b`](https://github.com/PurpleBooth/ellipsis/commit/07c3f5bb0103479c31a56bc19dbb96d36c0e8a67))

