### PR TITLE
fix: Update fast-conventional to v2.2.8

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.7.tar.gz"
-  sha256 "02eb10576b263304d1e0c9eb05c753c83c6ef2788fe21f7df6aae1743efd33cb"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.2.7"
-    sha256 cellar: :any_skip_relocation, big_sur:      "9f62c27b6009d63905959efa7b19a9493d3d7c2adb636d1b48b12a157e661a18"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "78929924aaaf8c0eb0eccfb9eac2aac30fed66afaa349bf7e514b31adc85fc62"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.8.tar.gz"
+  sha256 "11703e081ea0444c53ffb93a345d04a39479a7de3846fbab06fe4fc0789faa8b"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.2.8](https://github.com/PurpleBooth/fast-conventional/compare/...v2.2.8) (2022-05-09)

### Build

- Versio update versions ([`52dde02`](https://github.com/PurpleBooth/fast-conventional/commit/52dde02ffb9bd4a4b5b7664f15494ae68d3bdd04))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.12 to 0.1.13 ([`44be2d4`](https://github.com/PurpleBooth/fast-conventional/commit/44be2d476190147be32c5145c300e1e08179c3f7))

### Fix

- Bump clap_complete from 3.1.2 to 3.1.3 ([`eebe7a2`](https://github.com/PurpleBooth/fast-conventional/commit/eebe7a2d024f21a3ee72cd8fe03bb2d8d31b93e5))

