### PR TITLE
fix: Update fast-conventional to v2.2.10

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.9.tar.gz"
-  sha256 "6f2ea49511a30015388fdea2e93f64847b4443e77cc4bc94df97c44e089a865b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.2.9"
-    sha256 cellar: :any_skip_relocation, big_sur:      "8457c46c7e0a895c15e3ea76cdf645c2a2e3bf8b09362607b1c32b2137f21555"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0961c764f32bcf6f304998696a6b051de70eb460d09f06264b03d96fb3e336b7"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.10.tar.gz"
+  sha256 "d1d3696346012e03663613e03aa6ad99094e2ce74b305551c051d614c8de69ce"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.2.10](https://github.com/PurpleBooth/fast-conventional/compare/...v2.2.10) (2022-05-09)

### Build

- Versio update versions ([`6ac301f`](https://github.com/PurpleBooth/fast-conventional/commit/6ac301fd1e0a1b6f0d532fae8d6140a4d9af19e4))

### Fix

- Bump miette from 4.6.0 to 4.7.0 ([`d2feac4`](https://github.com/PurpleBooth/fast-conventional/commit/d2feac464cdd024afe55a4ebdb50cc890733bae5))
- Bump serde_yaml from 0.8.23 to 0.8.24 ([`894dceb`](https://github.com/PurpleBooth/fast-conventional/commit/894dceb6df3b8fda26bc1cfc7acf623b164ec99d))
- Bump clap_complete from 3.1.3 to 3.1.4 ([`2be7fbe`](https://github.com/PurpleBooth/fast-conventional/commit/2be7fbe73bff7f3954c3ad51ae6bd6aadd2f37c0))

