### PR TITLE
fix: Update readable-name-generator to v2.100.29

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.28.tar.gz"
-  sha256 "15e5edcaeee32550e3be6f8dd26e96ee33e3228b860bd9638e3a3b673a9158da"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.28"
-    sha256 cellar: :any_skip_relocation, big_sur:      "03fa26ebc828546a8e18bdbd320845cd3051b057c44e6cf5d2ee74dc41d7e75f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "310bfd7a6f613ecd8172c2bf9600c999034e6a372e1de8d0426479a503da3eeb"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.29.tar.gz"
+  sha256 "4de8feffd91b6051d094c01120b17b55abaac1ba648e8929c4e907248be9263a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.29](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.29) (2022-05-09)

### Build

- Versio update versions ([`a724364`](https://github.com/PurpleBooth/readable-name-generator/commit/a724364c5342057fe9053de4d1d9c9c0b9e9f7cb))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.12 to 0.1.13 ([`5f6df4b`](https://github.com/PurpleBooth/readable-name-generator/commit/5f6df4b645e8f9183d27f9af5cda6fb141bdffa4))

### Fix

- Bump clap_complete from 3.1.2 to 3.1.3 ([`6728deb`](https://github.com/PurpleBooth/readable-name-generator/commit/6728deb508ab5ca9fc80a9d03b1a18fc87b60ac8))

