### PR TITLE
fix: Update readable-name-generator to v2.100.30

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.29.tar.gz"
-  sha256 "4de8feffd91b6051d094c01120b17b55abaac1ba648e8929c4e907248be9263a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.29"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6620bc02924981a09a9d69ad23e3f891588a03d778af6b2a8bc4db09404f0789"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1df4ac49ab98e9c9602d08e5435f67f30eba7a0e6e1963d023d1ca8740fcc104"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.30.tar.gz"
+  sha256 "794b85a91c72559b3ed215f34ea20ae00b5cfa045b2913795c3660b5618cd22f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.30](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.30) (2022-05-09)

### Build

- Versio update versions ([`78246b1`](https://github.com/PurpleBooth/readable-name-generator/commit/78246b192bc41b75574d9962091e4003cc252252))

### Fix

- Bump clap from 3.1.15 to 3.1.17 ([`598c40b`](https://github.com/PurpleBooth/readable-name-generator/commit/598c40b486c3115c7a6aac666160df795ba2dad6))

