### PR TITLE
fix: Update readable-name-generator to v2.100.31

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.30.tar.gz"
-  sha256 "794b85a91c72559b3ed215f34ea20ae00b5cfa045b2913795c3660b5618cd22f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.30"
-    sha256 cellar: :any_skip_relocation, big_sur:      "426c441c279cdd7232b9376d034dc64c0f9f68c3c8621e371181758268f8069a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c52227ebf05fb88e2ce01b4165ebff15d3b454d9d729ace26d6d7de720f10c25"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.31.tar.gz"
+  sha256 "c35eca063827472acc1a5c54270c90cabcbf73e60b27ada8a26f4cb7fd6505c7"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.31](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.31) (2022-05-09)

### Build

- Versio update versions ([`e739c9b`](https://github.com/PurpleBooth/readable-name-generator/commit/e739c9b5a50da4c63e0cfe456937cbf0b48631d3))

### Fix

- Bump clap_complete from 3.1.3 to 3.1.4 ([`e4c4f8f`](https://github.com/PurpleBooth/readable-name-generator/commit/e4c4f8fe1bf1393c5744346c0b3c2869d5756fb2))
- Bump miette from 4.6.0 to 4.7.0 ([`6b43314`](https://github.com/PurpleBooth/readable-name-generator/commit/6b43314261115f6b6187e7976a9ed6906ab86e0b))

