### PR TITLE
fix: Update ellipsis to v0.6.44

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.43.tar.gz"
-  sha256 "94c8cb5c9c033cc3680228144c9997b7965740b6819a5841bbbb2a9ce66fc3a8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.43"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6fd5b46d76fff875ef865da6702a81010041416b75c21196ccf432d343c02259"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "59de05b15898581ab1663eae5141b9fe7750581857bf20da279b3456717fb18b"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.44.tar.gz"
+  sha256 "5d3a8dcee9c9c876e75c4d69ec9ab884acd3c00950e37bd4e5d269a283ed0017"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.44](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.44) (2022-05-09)

### Build

- Versio update versions ([`1ebf6c9`](https://github.com/PurpleBooth/ellipsis/commit/1ebf6c997a254586f3a142ac6f50cd231b269943))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.12 to 0.1.13 ([`346938f`](https://github.com/PurpleBooth/ellipsis/commit/346938f41fed1cbb90a022433af64e6f179e3f77))

### Fix

- Bump clap from 3.1.12 to 3.1.15 ([`1a163b6`](https://github.com/PurpleBooth/ellipsis/commit/1a163b6127214c43c163743ab063212dfa98bf9d))
- Bump indoc from 1.0.4 to 1.0.6 ([`6a4331b`](https://github.com/PurpleBooth/ellipsis/commit/6a4331bd6cc8e65d47b81743322386d99326cd01))

