### PR TITLE
fix: Update ed-system-search to v1.1.45

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.44.tar.gz"
-  sha256 "0af3840a82c8000f6dffb3b9ad46831ae3699d920444ebd2cedfb4899e2a1d46"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "a736a5a1917156d0f72cbe521770e40ff92cefb34b59361cb278dead041257d1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c427dd672b0e88b61dce6f7479f83f0a7fb8dd7d225f06c3364bdf2bf083746b"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.45.tar.gz"
+  sha256 "2e1e7a376af5d1a0fd7a8f9b46aa7eacbdbb3347f7597cf5b500711cdd456668"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.45](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.45) (2022-05-09)

### Build

- Versio update versions ([`4517f24`](https://github.com/PurpleBooth/ed-system-search/commit/4517f243da66ebe808423116cbf84811e72cc8a4))

### Ci

- Remove versio install step ([`2b5f97f`](https://github.com/PurpleBooth/ed-system-search/commit/2b5f97f8168bdc7204bdc69dde8c31e70015b013))

### Fix

- Fix clippy problems ([`febcfae`](https://github.com/PurpleBooth/ed-system-search/commit/febcfae7d0a1155b77c8bfa580d92beead823ec9))

