### PR TITLE
fix: Update game-of-life to v1.53.64

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.63.tar.gz"
-  sha256 "c6a704d9e1cb7597d8de47f405e02f825602fedd291b1c8b48d37136ddb3e18d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.63"
-    sha256 cellar: :any_skip_relocation, big_sur:      "ae7dd351770067d10693827dc23cbf9fd13169a092e1748e7671b314b7b8de2b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9fac71693887839bc34af18a81212f0eeb419898a833fe178cc1aa89b961d1b6"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.64.tar.gz"
+  sha256 "dda4ca1393d3caa41ce535ee7021e33e31ce02ef92f3709911bf7f3a233cc362"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.64](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.64) (2022-05-09)

### Build

- Versio update versions ([`666911c`](https://github.com/PurpleBooth/game-of-life/commit/666911cf620263691f0d3b89767cfa3c7122e291))

### Fix

- Bump clap from 3.1.14 to 3.1.17 ([`4a37182`](https://github.com/PurpleBooth/game-of-life/commit/4a37182c4259a6caf72df0ad6e9d7d612c8e7790))

