### PR TITLE
fix: Update git-moves-together to v2.5.38

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.31.tar.gz"
-  sha256 "aaec501d944ab5e115b02dbd89e0e6af280ccd49598c5ad0a8a2c9ecd38d09e6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.31"
-    sha256 cellar: :any,                 big_sur:      "6993ba88779e262787d4b74368c308224391820205d29a1cda6bc4c17f50644c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b39cb1768b26ad0ce6299d98202ba482c3113c9580368c2c358e66f9245fa581"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.38.tar.gz"
+  sha256 "1060b6094468104ed31884932d583597fedae6c23ec82bdd4f789adfdf6d7c8a"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.38](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.38) (2022-05-09)

### Build

- Versio update versions ([`6b4a053`](https://github.com/PurpleBooth/git-moves-together/commit/6b4a05379f98dd8ab96df7ec20f774a22816de7e))

### Fix

- Bump clap from 3.1.14 to 3.1.17 ([`e5a70d8`](https://github.com/PurpleBooth/git-moves-together/commit/e5a70d8bed1469431939cb5dc0c400a51951b6f7))
- Bump tokio from 1.18.0 to 1.18.2 ([`330540a`](https://github.com/PurpleBooth/git-moves-together/commit/330540af014402f7fe2003d00e764087628f3557))

