### PR TITLE
fix: Update ellipsis to v0.6.45

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.44.tar.gz"
-  sha256 "5d3a8dcee9c9c876e75c4d69ec9ab884acd3c00950e37bd4e5d269a283ed0017"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "4a0f167d866a06d0671aa6691e1e4b266d94bd23bd9b7436f40bf00f9f501348"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6fe9d9551d4c76ac32598089a5c04c5eaaca2dfa3a5d5e1d24e2721c4f1f3b3d"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.45.tar.gz"
+  sha256 "0a80ca1153439d83c695852a7f084392192d48ce07ab798d61c3217b5cd4a278"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.45](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.45) (2022-05-09)

### Build

- Versio update versions ([`910d368`](https://github.com/PurpleBooth/ellipsis/commit/910d3682fbe44126befa3781a3b69f5e3b99842a))

### Fix

- Bump serde_yaml from 0.8.23 to 0.8.24 ([`c9ea7c8`](https://github.com/PurpleBooth/ellipsis/commit/c9ea7c896ec534797863c4935d5402403c977350))
- Bump clap from 3.1.15 to 3.1.17 ([`9f5660f`](https://github.com/PurpleBooth/ellipsis/commit/9f5660feb26db76bf3253155e74e57298fd8fc17))

