### PR TITLE
fix: Update hungry-distance to v0.1.31

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.30.tar.gz"
-  sha256 "601d32acc845b9418561292987e1ba61717252d4a7255f2930981b7e8baa95ce"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.30"
-    sha256 cellar: :any_skip_relocation, big_sur:      "feaaa4f5861c3f1929029161ec4c4d66464afc1d3e0712e7dbbbd5da8db36ced"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ac2f04997d24794888b531993805aa039f0904b0815c5b4ec6c8623e00d20ab5"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.31.tar.gz"
+  sha256 "487e04f58163ff19ab4a0a4727f2cad3e331b98ce607aa171ee6b3695c9e12eb"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.31](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.31) (2022-05-10)

### Build

- Versio update versions ([`3bd4bce`](https://github.com/PurpleBooth/hungry-distance/commit/3bd4bce365e8fc98e347c3a2fe07ed1bd3e41db8))

### Ci

- Bump PurpleBooth/versio-release-action from 0.1.12 to 0.1.13 ([`dd7fefd`](https://github.com/PurpleBooth/hungry-distance/commit/dd7fefd0e50fafff750e9bdb5d2f058d12cffc3b))

### Fix

- Bump clap from 3.1.12 to 3.1.14 ([`a477bd0`](https://github.com/PurpleBooth/hungry-distance/commit/a477bd0c483e29dfb11e8853cbfd26c2f8eed046))
- Bump clap from 3.1.14 to 3.1.17 ([`656f55b`](https://github.com/PurpleBooth/hungry-distance/commit/656f55b4bc0836ac829b4d4e3aad19c541449b8a))

