### PR TITLE
fix: Update ed-system-search to v1.1.46

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.45.tar.gz"
-  sha256 "2e1e7a376af5d1a0fd7a8f9b46aa7eacbdbb3347f7597cf5b500711cdd456668"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.45"
-    sha256 cellar: :any_skip_relocation, big_sur:      "df76c829745aef74b933852712ddbb357dc013d2546ead11db2287c84977eb14"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "bef832d16d243266f28c5cd3f5cfcc661a6562ce62f9bce8d0856b940c273321"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.46.tar.gz"
+  sha256 "8c1ec6fbaa409de0deab0f570ff81ce5307ef4ecd6205f435f510749b8648f51"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.46](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.46) (2022-05-11)

### Deploy

#### Build

- Versio update versions ([`e958a51`](https://github.com/PurpleBooth/ed-system-search/commit/e958a514a4ab17ae856e7ea089c0466a41f3e567))


### Deps

#### Ci

- Bump PurpleBooth/generate-formula-action from 0.1.8 to 0.1.9 ([`68cd661`](https://github.com/PurpleBooth/ed-system-search/commit/68cd6612f119979d8298b25ff136cb9852d01c7d))
- Bump ncipollo/release-action from 1.9.0 to 1.10.0 ([`3f00567`](https://github.com/PurpleBooth/ed-system-search/commit/3f00567f6b0d1dd61a7de5c7f59a3788abb794b7))

#### Fix

- Bump clap from 3.1.17 to 3.1.18 ([`448f391`](https://github.com/PurpleBooth/ed-system-search/commit/448f39134faf3e32610e75d88fe541510d40dd61))


