### PR TITLE
fix: Update git-moves-together to v2.5.39

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.38.tar.gz"
-  sha256 "1060b6094468104ed31884932d583597fedae6c23ec82bdd4f789adfdf6d7c8a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.38"
-    sha256 cellar: :any,                 big_sur:      "fe87fee5b9938d256fc3da6cec465dc0d3edda6d03aa0d92ff7c3f4a979ebaf0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "549b79dc640b109d2a644194f1415711e3614f1daf0b6901cf733f0e83b9eb25"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.39.tar.gz"
+  sha256 "e9d6d91cb3ebbd787157b0040692fed6afff42908f45868de423d651e9f191ef"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.39](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.39) (2022-05-11)

### Deploy

#### Build

- Versio update versions ([`a2f377e`](https://github.com/PurpleBooth/git-moves-together/commit/a2f377e67543e2f834baafc55ec904fc7fa8d40e))


### Deps

#### Fix

- Bump miette from 4.6.0 to 4.7.0 ([`4b6c035`](https://github.com/PurpleBooth/git-moves-together/commit/4b6c035e67a85030b79852eccf3643be4f89474a))
- Bump clap from 3.1.17 to 3.1.18 ([`c13b964`](https://github.com/PurpleBooth/git-moves-together/commit/c13b964104d9fdaca44347b6a63149203acdd3f8))


