### PR TITLE
fix: Update ed-system-search to v1.1.47

### DIFF
--- a/Formula/ed-system-search.rb
+++ b/Formula/ed-system-search.rb
@@ -1,14 +1,8 @@
 class EdSystemSearch < Formula
   desc "Find interesting systems in Elite: Dangerous"
   homepage "https://github.com/PurpleBooth/ed-system-search"
-  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.46.tar.gz"
-  sha256 "8c1ec6fbaa409de0deab0f570ff81ce5307ef4ecd6205f435f510749b8648f51"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ed-system-search-1.1.46"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6274204f9bb1bbe09dd5bb44b5adcf881311b212e870cdacfb1b8cdb9c4e43c5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8d818f8d60fb52333a916eb8a81d55bed231b822126f19417fc6624c7f8fad25"
-  end
+  url "https://github.com/PurpleBooth/ed-system-search/archive/v1.1.47.tar.gz"
+  sha256 "2ba3e16096dafd23e4856d605dff91b7fe2594e1d6f2648267a69f9007937e3c"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.1.47](https://github.com/PurpleBooth/ed-system-search/compare/...v1.1.47) (2022-05-16)

### Deploy

#### Build

- Versio update versions ([`0c5dc50`](https://github.com/PurpleBooth/ed-system-search/commit/0c5dc50357956c654de931c2162a7b5ad3367110))


### Deps

#### Fix

- Bump miette from 4.7.0 to 4.7.1 ([`9e46232`](https://github.com/PurpleBooth/ed-system-search/commit/9e46232ec8c3b1e03af60f9b6b0966509029d770))


