### PR TITLE
fix: Update fast-conventional to v2.3.0

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,14 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.2.11.tar.gz"
-  sha256 "4cf5380059b332d70d0ba419f16191efd1e633f5125d8bbcaf6aa47b21036dd5"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.2.11"
-    sha256 cellar: :any_skip_relocation, big_sur:      "19517cff3e0664f8527b7e6f25629a5bea3bbc511f6d8bf6949c31201d1291e3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "56794e3817ba1f11edee39eaaffa19b6574ce687f0f39ca6373146a8595f0d12"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.3.0.tar.gz"
+  sha256 "cd711f4bc47e9c7cb3680514b2c927f225681d20ef3deffbc68c9c3caa2d3a85"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.3.0](https://github.com/PurpleBooth/fast-conventional/compare/...v2.3.0) (2022-05-16)

### FastConventional

#### Feat

- Add a required scope to force the use of a scope ([`594ea97`](https://github.com/PurpleBooth/fast-conventional/commit/594ea97ae4062f0cc825a34a5c4c20e00a04c789))


### Deploy

#### Build

- Versio update versions ([`3b95bf0`](https://github.com/PurpleBooth/fast-conventional/commit/3b95bf0625b95f3d6a8ff8b8f407dd8fad5633dd))


### Src

#### Feat

- Add scope validation ([`87c4a6c`](https://github.com/PurpleBooth/fast-conventional/commit/87c4a6c0006553b9d727ab38593a7b82ded5d14c))

#### Test

- Remove a print statement ([`6ecc491`](https://github.com/PurpleBooth/fast-conventional/commit/6ecc491a5b6f21655071ecbbbe22e7b1ea1a449c))


