### PR TITLE
fix: Update readable-name-generator to v2.100.33

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.32.tar.gz"
-  sha256 "2ea7f9c36ac494b9c40ec2ba1227a49b94e605285a66633d777c600305c2ade2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.32"
-    sha256 cellar: :any_skip_relocation, big_sur:      "b225cdd72b8ec58921882da6cc7826851f318ff13ff10d3ced63a1ad1cf39b61"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "11ad4d403ff1c4cd9b469fc9156a5e58a1807e102005e474b22a698913262e12"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.33.tar.gz"
+  sha256 "d1d7a5cd65635610eba7e50ef2b345e5eb894759a8bd926920429c4faa83834e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.33](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.33) (2022-05-19)

### Deploy

#### Build

- Versio update versions ([`80e09d1`](https://github.com/PurpleBooth/readable-name-generator/commit/80e09d12fcb50418e3164590b395ac66e01df40f))


### Deps

#### Fix

- Bump miette from 4.7.0 to 4.7.1 ([`9c225b1`](https://github.com/PurpleBooth/readable-name-generator/commit/9c225b1adb09144566d4003ef966a8f06c9fafc5))
- Bump rust from 1.60.0 to 1.61.0 ([`0ce8e44`](https://github.com/PurpleBooth/readable-name-generator/commit/0ce8e4488b3e16643c640b5b34a25eb8da4c4756))


