### PR TITLE
fix: Update git-mit to v5.12.60

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.48.tar.gz"
-  sha256 "2869baff0f5696f8248a9a8dc643c28b5ff64b80dc742fc378e6be851f6becae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.48"
-    sha256 cellar: :any,                 big_sur:      "17fc22be5c74f451e16565ce84cd9f55bff4bd49d69d65c56cf822cdb6c216f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "325517192c48eda0649e4628bbf725f57686577f6d871c45a2b73a0aaabbd9bf"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.60.tar.gz"
+  sha256 "4ad47f1d13f77d1212ea7d1d8b2040f741c7c170cfb2757d5f105aebc5531c79"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.60](https://github.com/PurpleBooth/git-mit/compare/...v5.12.60) (2022-05-20)

### Deploy

#### Build

- Versio update versions ([`3aad3db`](https://github.com/PurpleBooth/git-mit/commit/3aad3db89eead069b61f0ab1ebebc898c2c9a0ad))


### Deps

#### Ci

- Bump PurpleBooth/generate-formula-action from 0.1.8 to 0.1.9 ([`dc60194`](https://github.com/PurpleBooth/git-mit/commit/dc60194005a907b0088e6a1b0587c495eb5767ca))

#### Fix

- Bump rust from 1.60.0 to 1.61.0 ([`37796ce`](https://github.com/PurpleBooth/git-mit/commit/37796ce4b7f28035e983b1c9a67d0d7958aa7c0a))


