### PR TITLE
fix: Update ellipsis to v0.6.46

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.44.tar.gz"
-  sha256 "5d3a8dcee9c9c876e75c4d69ec9ab884acd3c00950e37bd4e5d269a283ed0017"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "4a0f167d866a06d0671aa6691e1e4b266d94bd23bd9b7436f40bf00f9f501348"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6fe9d9551d4c76ac32598089a5c04c5eaaca2dfa3a5d5e1d24e2721c4f1f3b3d"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.46.tar.gz"
+  sha256 "a031dd973de2214feefc63744efab0242a7f6edc29bbf4ef192a38c725646b9b"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.46](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.46) (2022-05-20)

### Deploy

#### Build

- Versio update versions ([`b7c7852`](https://github.com/PurpleBooth/ellipsis/commit/b7c7852f6febfe58840e16f87d14a2bf518ed83d))


