### PR TITLE
fix: Update git-mit to v5.12.61

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.48.tar.gz"
-  sha256 "2869baff0f5696f8248a9a8dc643c28b5ff64b80dc742fc378e6be851f6becae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.48"
-    sha256 cellar: :any,                 big_sur:      "17fc22be5c74f451e16565ce84cd9f55bff4bd49d69d65c56cf822cdb6c216f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "325517192c48eda0649e4628bbf725f57686577f6d871c45a2b73a0aaabbd9bf"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.61.tar.gz"
+  sha256 "a8c09efbbbe0e8ba3d9416669793c40de16ca7b3b5114f80cac34a7a961879fe"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.61](https://github.com/PurpleBooth/git-mit/compare/...v5.12.61) (2022-05-24)

### Deploy

#### Build

- Versio update versions ([`f2858f6`](https://github.com/PurpleBooth/git-mit/commit/f2858f61e1daaef48a4239b50b7eaf6fd1993b53))


### Deps

#### Fix

- Bump regex from 1.5.5 to 1.5.6 ([`5aab8e3`](https://github.com/PurpleBooth/git-mit/commit/5aab8e3c38e7eb124d6393e154a7078c71f9bfc5))
- Bump clap from 3.1.17 to 3.1.18 ([`bcb6aa3`](https://github.com/PurpleBooth/git-mit/commit/bcb6aa359f11b7bfdc394308282717bf3145f697))
- Bump miette from 4.7.0 to 4.7.1 ([`4e424ef`](https://github.com/PurpleBooth/git-mit/commit/4e424ef17200ad1595896da167b131d6cb1fa288))
- Bump git2 from 0.14.3 to 0.14.4 ([`72ab79d`](https://github.com/PurpleBooth/git-mit/commit/72ab79d1d85ce4a3b405508918c036bd9537d13e))


