### PR TITLE
fix: Update git-mit to v5.12.62

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.48.tar.gz"
-  sha256 "2869baff0f5696f8248a9a8dc643c28b5ff64b80dc742fc378e6be851f6becae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.48"
-    sha256 cellar: :any,                 big_sur:      "17fc22be5c74f451e16565ce84cd9f55bff4bd49d69d65c56cf822cdb6c216f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "325517192c48eda0649e4628bbf725f57686577f6d871c45a2b73a0aaabbd9bf"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.62.tar.gz"
+  sha256 "bfff43c9c822ac3b54991134ca1fef43eea5bb9f209d52aaa34321851a1f3ef9"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.62](https://github.com/PurpleBooth/git-mit/compare/...v5.12.62) (2022-05-30)

### Deploy

#### Build

- Versio update versions ([`a18ae6d`](https://github.com/PurpleBooth/git-mit/commit/a18ae6d056471721ef6d8e2e7ca35a4b85f5aff3))


### Deps

#### Ci

- Bump PurpleBooth/generate-formula-action from 0.1.9 to 0.1.10 ([`d928c98`](https://github.com/PurpleBooth/git-mit/commit/d928c98d83d87be7c0517679894997dcf55281cd))

#### Fix

- Bump arboard from 2.1.0 to 2.1.1 ([`ff7fe62`](https://github.com/PurpleBooth/git-mit/commit/ff7fe62844b81e87f039996e7e1b7f36380e84a3))


