### PR TITLE
fix: Update git-mit to v5.12.63

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.48.tar.gz"
-  sha256 "2869baff0f5696f8248a9a8dc643c28b5ff64b80dc742fc378e6be851f6becae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.48"
-    sha256 cellar: :any,                 big_sur:      "17fc22be5c74f451e16565ce84cd9f55bff4bd49d69d65c56cf822cdb6c216f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "325517192c48eda0649e4628bbf725f57686577f6d871c45a2b73a0aaabbd9bf"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.63.tar.gz"
+  sha256 "38ee1844ab5b8f13993dfd5f459d5ab7bd1eb36e8d722bc1cbe4889ec1c74f8f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.63](https://github.com/PurpleBooth/git-mit/compare/...v5.12.63) (2022-06-06)

### Deploy

#### Build

- Versio update versions ([`0658066`](https://github.com/PurpleBooth/git-mit/commit/06580664163f8f40d62ae2031fc68fa3af6fcf84))


### Deps

#### Fix

- Bump comfy-table from 5.0.1 to 6.0.0 ([`c27c738`](https://github.com/PurpleBooth/git-mit/commit/c27c73856890072950c6cb19b45e0e3591a4eb2b))
- Bump tokio from 1.18.2 to 1.19.1 ([`5929042`](https://github.com/PurpleBooth/git-mit/commit/59290428bbea8471ac8fc4fb15cf5c6252af4000))


