### PR TITLE
fix: Update game-of-life to v1.53.65

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.64.tar.gz"
-  sha256 "dda4ca1393d3caa41ce535ee7021e33e31ce02ef92f3709911bf7f3a233cc362"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.64"
-    sha256 cellar: :any_skip_relocation, big_sur:      "fe144893af37987dc54457e6001889718bb5aca4f9b9040ba7d6b91fa81356d0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "68699fdfe965e95a1dd7a575c6beb5aef639268c994a74eca0309d40e9966964"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.65.tar.gz"
+  sha256 "7c978f424d274df5cbe16f5dac9c9e2975e530be96eb25049ab6fee7602be258"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.65](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.65) (2022-06-15)

### Deploy

#### Build

- Versio update versions ([`7170a08`](https://github.com/PurpleBooth/game-of-life/commit/7170a08b582a1bda9d243ee9e27d1aa5faf2100b))


