### PR TITLE
fix: Update hungry-distance to v0.1.32

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.30.tar.gz"
-  sha256 "601d32acc845b9418561292987e1ba61717252d4a7255f2930981b7e8baa95ce"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.30"
-    sha256 cellar: :any_skip_relocation, big_sur:      "feaaa4f5861c3f1929029161ec4c4d66464afc1d3e0712e7dbbbd5da8db36ced"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ac2f04997d24794888b531993805aa039f0904b0815c5b4ec6c8623e00d20ab5"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.32.tar.gz"
+  sha256 "38e917e887980b033f6c1bbc53ae95aa8d6dc1e275acb047d786661050184f8d"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.32](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.32) (2022-06-15)

### Build

- Versio update versions ([`e2f3cf2`](https://github.com/PurpleBooth/hungry-distance/commit/e2f3cf2a4cdb1ae0b993e4e08322d39ea7b11ffb))

### Fix

- Bump clap from 3.1.17 to 3.1.18 ([`8c1bc9c`](https://github.com/PurpleBooth/hungry-distance/commit/8c1bc9c99d82e9747e8b7ebec7f4eb1590a025ae))
- Bump clap from 3.1.18 to 3.2.4 ([`fe4aa68`](https://github.com/PurpleBooth/hungry-distance/commit/fe4aa68c78d087dd23dec0ad33037c347770e680))

