### PR TITLE
fix: Update hungry-distance to v0.1.33

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.32.tar.gz"
-  sha256 "38e917e887980b033f6c1bbc53ae95aa8d6dc1e275acb047d786661050184f8d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.32"
-    sha256 cellar: :any_skip_relocation, big_sur:      "d8882aa27678bb5e87e6644bc65503d73f66111487b84ef86d21dd64ffe091b4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "566bb57a59358b418cd545bdd015fd1080b2432fd59ed64d1331fc2d9b070589"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.33.tar.gz"
+  sha256 "92227c1e94e142c93a103324fc188361dd33f3999492ece06d515105913513fe"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.33](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.33) (2022-06-16)

### Build

- Versio update versions ([`ec67de7`](https://github.com/PurpleBooth/hungry-distance/commit/ec67de788e713b3a25a8424a5274fc7552022699))

### Fix

- Bump clap from 3.2.4 to 3.2.5 ([`fc82932`](https://github.com/PurpleBooth/hungry-distance/commit/fc829323b803bb13d173f37d0e6b9079c1ff6179))

