### PR TITLE
fix: Update ellipsis to v0.6.47

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.46.tar.gz"
-  sha256 "a031dd973de2214feefc63744efab0242a7f6edc29bbf4ef192a38c725646b9b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.46"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0c6c6f95e7a13485ba606aba08604ca8a20329b5ff54e4409603f7d264591faa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e2a066d9b81d6091834bc126c264012aca0cce366be07704361ce45458e70620"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.47.tar.gz"
+  sha256 "4ed4c898181bec79efbdfbe29ce8d5df802529491608d18874e50ad029d3e03e"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.47](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.47) (2022-06-21)

### Deploy

#### Build

- Versio update versions ([`d0d59f9`](https://github.com/PurpleBooth/ellipsis/commit/d0d59f9b0c2893dd194f0ae4915d14779d3fe47e))


