### PR TITLE
fix: Update game-of-life to v1.53.66

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.65.tar.gz"
-  sha256 "7c978f424d274df5cbe16f5dac9c9e2975e530be96eb25049ab6fee7602be258"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.65"
-    sha256 cellar: :any_skip_relocation, big_sur:      "dd0b5721d9a4b657a35913ea683234efba971ac105341c84b4a2c3ac32cfcb2a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "726d3dbdcc7452968fe403b6d549c751e0a769f5ead2c6f44bae8587d5e1fa71"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.66.tar.gz"
+  sha256 "c337b458996029f62884b65adbf24407f5240819703cea13dcecc00e124c98dd"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.66](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.66) (2022-06-22)

### Deploy

#### Build

- Versio update versions ([`4d94108`](https://github.com/PurpleBooth/game-of-life/commit/4d94108bfe7721d689247a3da80fed8d330bb3fa))


