### PR TITLE
fix: Update hungry-distance to v0.1.34

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.33.tar.gz"
-  sha256 "92227c1e94e142c93a103324fc188361dd33f3999492ece06d515105913513fe"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.33"
-    sha256 cellar: :any_skip_relocation, big_sur:      "1e20f9c6ad5fe42826b6ec4878980084fedc15a77bb6bb331b90e310ae3aa847"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0a7c6a6079098db30fd1586771e5c25f62c234e692c59c71f5357d9537b7943d"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.34.tar.gz"
+  sha256 "7a65053d0a51fd27ecbd38f021a9b51d4b5b8998e13af99af5cf0ed9ff96bf4c"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.34](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.34) (2022-06-29)

### Build

- Versio update versions ([`8755b6d`](https://github.com/PurpleBooth/hungry-distance/commit/8755b6d80e6ca669e8f08369d32caf2c803cfc52))

### Fix

- Bump clap from 3.2.5 to 3.2.6 ([`d384414`](https://github.com/PurpleBooth/hungry-distance/commit/d384414cd1a488796f96bf70ebc7b0d02a892229))
- Bump clap from 3.2.6 to 3.2.7 ([`e7d73a0`](https://github.com/PurpleBooth/hungry-distance/commit/e7d73a09493088063adb690e874bef2cf17c7228))

