### PR TITLE
fix: Update ellipsis to v0.6.48

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.47.tar.gz"
-  sha256 "4ed4c898181bec79efbdfbe29ce8d5df802529491608d18874e50ad029d3e03e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.47"
-    sha256 cellar: :any_skip_relocation, big_sur:      "eb3f104764008034b82240635e2a3e33e8d24305ceb16d68c01e7e6fe339751f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4d0571a7a9a397a02d70bcc050b1f6ec94e59bc2689639d450532d8f4800f631"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.48.tar.gz"
+  sha256 "6ddf62900cbde9164f26c23a0ebf63538ceb065fb287e79a85825ce9bbb43145"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.48](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.48) (2022-06-30)

### Deploy

#### Build

- Versio update versions ([`dd7abeb`](https://github.com/PurpleBooth/ellipsis/commit/dd7abeb023b86552d913d4df5dcac8784e8cc105))


