### PR TITLE
fix: Update game-of-life to v1.53.67

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.66.tar.gz"
-  sha256 "c337b458996029f62884b65adbf24407f5240819703cea13dcecc00e124c98dd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.66"
-    sha256 cellar: :any_skip_relocation, big_sur:      "47ccf5ecc8d8716d388911542c57b6814b92e05e5f3825970364d741bb51cc3b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7ca6f8d8858806ff8774d196cd1b429343e01414892fd2ae5ab7237a6cd33806"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.67.tar.gz"
+  sha256 "3d05d3e1afe0db2b72e106ed474faee1faacc770cef673048cabd3b49072e698"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.67](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.67) (2022-07-01)

### Deploy

#### Build

- Versio update versions ([`b5c3fab`](https://github.com/PurpleBooth/game-of-life/commit/b5c3fabe691ed7ec2aed439df9eb761abefaa78f))


