### PR TITLE
fix: Update ellipsis to v0.6.49

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.48.tar.gz"
-  sha256 "6ddf62900cbde9164f26c23a0ebf63538ceb065fb287e79a85825ce9bbb43145"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.48"
-    sha256 cellar: :any_skip_relocation, big_sur:      "37fc591c2a0bae41ac50de9e72bda0defb39492e011a2cacd5d1ab8a416d9a7a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ba00498c69371fea9d154f30c36045d63d9d467ad05e6bfb36ea6fa0201f6ccf"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.49.tar.gz"
+  sha256 "7c229970b325a6a6deb08a11b23bc458a7fef413edabf2a44b5ceaeda359bb59"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.49](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.49) (2022-07-05)

### Deploy

#### Build

- Versio update versions ([`3d6baff`](https://github.com/PurpleBooth/ellipsis/commit/3d6baff01335f37abd269da889cbed26d5a6beb0))


