### PR TITLE
fix: Update git-mit to v5.12.64

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.48.tar.gz"
-  sha256 "2869baff0f5696f8248a9a8dc643c28b5ff64b80dc742fc378e6be851f6becae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.48"
-    sha256 cellar: :any,                 big_sur:      "17fc22be5c74f451e16565ce84cd9f55bff4bd49d69d65c56cf822cdb6c216f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "325517192c48eda0649e4628bbf725f57686577f6d871c45a2b73a0aaabbd9bf"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.64.tar.gz"
+  sha256 "949fd710f1b8f7e101fea99bc08d33a0b3a456933a36ca4955a188537b124153"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.64](https://github.com/PurpleBooth/git-mit/compare/...v5.12.64) (2022-07-06)

### Deploy

#### Build

- Versio update versions ([`e1e6e0f`](https://github.com/PurpleBooth/git-mit/commit/e1e6e0fd127114bf605dddc3840f98b2a8783988))


### Src

#### Fix

- Bump versions ([`24fcc60`](https://github.com/PurpleBooth/git-mit/commit/24fcc60edb609ffbfc6370684d8262005f240231))


