### PR TITLE
fix: Update git-mit to v5.12.65

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.64.tar.gz"
-  sha256 "949fd710f1b8f7e101fea99bc08d33a0b3a456933a36ca4955a188537b124153"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.64"
-    sha256 cellar: :any,                 big_sur:      "2884fa0a911addfaa652fc49f5431e92f0b915f01eebe3b233650b31914fbd6f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a30b05e98a4989a1a5b68b728132a444b086987d457f4eeee2b1428383226196"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.65.tar.gz"
+  sha256 "a6f9a3a833441476fc1db03317071b974d3a729787d80c16ea2464a9fac900c5"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.65](https://github.com/PurpleBooth/git-mit/compare/...v5.12.65) (2022-07-07)

### Deploy

#### Build

- Versio update versions ([`7f6d13f`](https://github.com/PurpleBooth/git-mit/commit/7f6d13f0f3793ea89e008aeb340555ada75f48c9))


### Deps

#### Fix

- Bump criterion from 0.3.5 to 0.3.6 ([`a8a0192`](https://github.com/PurpleBooth/git-mit/commit/a8a0192bfb21791ab4861231d16c2eb26b97e809))


