### PR TITLE
fix: Update git-mit to v5.12.66

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.65.tar.gz"
-  sha256 "a6f9a3a833441476fc1db03317071b974d3a729787d80c16ea2464a9fac900c5"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.65"
-    sha256 cellar: :any,                 big_sur:      "f6cab7c9db150960cfb665ea5352411a2251d93615dceaed1c0d5394c61aa488"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3cc5515efeb870eedaf916ec67762e9f73cfc351f02922cb3c7223ad1947b025"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.66.tar.gz"
+  sha256 "2a8d417280de2560e2502ea56257b0d56a4bfb6f8cfb8a749160b1b23eb795ea"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.66](https://github.com/PurpleBooth/git-mit/compare/...v5.12.66) (2022-07-11)

### Deploy

#### Build

- Versio update versions ([`5b3de79`](https://github.com/PurpleBooth/git-mit/commit/5b3de7997b1967d02e234dde1f56da3259aa0d20))


### Deps

#### Fix

- Bump openssl from 0.10.40 to 0.10.41 ([`35417d7`](https://github.com/PurpleBooth/git-mit/commit/35417d74219f5abd7eaeecaacc185c7f7a926d90))
- Bump serde_yaml from 0.8.24 to 0.8.25 ([`751eff2`](https://github.com/PurpleBooth/git-mit/commit/751eff287028a73b3d612d2923cfe6a8b77e2461))


