### PR TITLE
fix: Update git-mit to v5.12.67

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.66.tar.gz"
-  sha256 "2a8d417280de2560e2502ea56257b0d56a4bfb6f8cfb8a749160b1b23eb795ea"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.66"
-    sha256 cellar: :any,                 big_sur:      "73eb65396448553ecfd92cdd03b7fbc768c69f47aa383420b347aaad5241a32e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "af1e72b84002d0fbae1912460166ca9900d797f49c99f869b43d3543b5b18ae9"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.67.tar.gz"
+  sha256 "2330e25c4a2dfe7c9135bf03a66a43e9eec67bf8cacbd8373172314b44d86410"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.67](https://github.com/PurpleBooth/git-mit/compare/...v5.12.67) (2022-07-12)

### Deploy

#### Build

- Versio update versions ([`c55f990`](https://github.com/PurpleBooth/git-mit/commit/c55f990c7a4931171f621c0c62b4f8990cf436cd))


### Deps

#### Fix

- Bump miette from 5.1.0 to 5.1.1 ([`7212974`](https://github.com/PurpleBooth/git-mit/commit/72129746f0fe370bfc2263cf39b5688c034e1aeb))
- Bump clap from 3.2.8 to 3.2.10 ([`34037f1`](https://github.com/PurpleBooth/git-mit/commit/34037f126bb2ddb67ef16719b794d7d2c21c64f5))


