### PR TITLE
fix: Update hungry-distance to v0.1.35

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.34.tar.gz"
-  sha256 "7a65053d0a51fd27ecbd38f021a9b51d4b5b8998e13af99af5cf0ed9ff96bf4c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.34"
-    sha256 cellar: :any_skip_relocation, big_sur:      "8e66b81a6fc45f61ed3c5477e7ffdf726e239e8715fc0b5513c3895d3a59908c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "83866ffab9fcbf3fed503e30ad0529ddf7c047d113069141de5bbd6c7218ddcc"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.35.tar.gz"
+  sha256 "c0070e0dfc3724a644665a91250d7a8173c29c50311a7244a9c01576071c3f22"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.35](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.35) (2022-07-12)

### Build

- Versio update versions ([`88060f1`](https://github.com/PurpleBooth/hungry-distance/commit/88060f15f8d6a7f98c1ff8655473841a7946170e))

### Fix

- Bump clap from 3.2.7 to 3.2.8 ([`b6bd39a`](https://github.com/PurpleBooth/hungry-distance/commit/b6bd39afb4de362793a946c9a13334a57b6985e4))
- Bump clap from 3.2.8 to 3.2.10 ([`91f1734`](https://github.com/PurpleBooth/hungry-distance/commit/91f1734379aeb7a8501ea8289dc7ada1d2992826))

