### PR TITLE
fix: Update game-of-life to v1.53.69

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.68.tar.gz"
-  sha256 "a517390955821bdcf1896809b82f5949de9e9304db0a139b52241acaa48307c1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.68"
-    sha256 cellar: :any_skip_relocation, big_sur:      "7a9f791c17e6033b46d34d87645d390f6155aa5148da26cd2fc7c1885d5e785d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e1b5c40b2c0bf8ea2b1d3b16a457fd5a67015f36d3c0cb52f4be48f2e2ab5fbd"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.69.tar.gz"
+  sha256 "605c415719a9a311186a264337be785b0757e9b3d90b6627512ff6a1be084a8a"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.69](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.69) (2022-07-14)

### Deploy

#### Build

- Versio update versions ([`9f5340b`](https://github.com/PurpleBooth/game-of-life/commit/9f5340b9a897801e15534f89249cdcf122bfdf0d))


