### PR TITLE
fix: Update git-mit to v5.12.68

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.67.tar.gz"
-  sha256 "2330e25c4a2dfe7c9135bf03a66a43e9eec67bf8cacbd8373172314b44d86410"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.67"
-    sha256 cellar: :any,                 big_sur:      "c16cb9423326afb9725ec8e68ddd8420d34465504881170e63abef83c40eab32"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3733d0e96ca1bca215d249fcf6d5a25a82d1fe11cc64c3503c986457a001f013"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.68.tar.gz"
+  sha256 "9747503b6edf07de1ae9faa3351906270cb03e37da17587ee34fdbdb84e2f6ad"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.68](https://github.com/PurpleBooth/git-mit/compare/...v5.12.68) (2022-07-14)

### Deploy

#### Build

- Versio update versions ([`15340fc`](https://github.com/PurpleBooth/git-mit/commit/15340fcf6a9f28316fe47a49e1dea080636b3593))


### Deps

#### Fix

- Bump tokio from 1.19.2 to 1.20.0 ([`d73e6bc`](https://github.com/PurpleBooth/git-mit/commit/d73e6bce19def95232d7233754bdd654ed2d812f))
- Bump clap from 3.2.10 to 3.2.11 ([`7094fd6`](https://github.com/PurpleBooth/git-mit/commit/7094fd6b5b4937189e68d0c3c20cf0a64873c649))


