### PR TITLE
fix: Update game-of-life to v1.53.70

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.69.tar.gz"
-  sha256 "605c415719a9a311186a264337be785b0757e9b3d90b6627512ff6a1be084a8a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.69"
-    sha256 cellar: :any_skip_relocation, big_sur:      "98806b1e1804e93f9dd12a65e461e03c35498b27d6211c4c67e53e47adae9f6d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7b64d66fab3699f155fec57c7852df623a81dbefff29c7131031d2ad4a20870c"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.70.tar.gz"
+  sha256 "1c724d267ceac7e238786b46f12df3d03daa2a503f2610598accbf8f6c07cca2"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.70](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.70) (2022-07-15)

### Deploy

#### Build

- Versio update versions ([`d89f2d8`](https://github.com/PurpleBooth/game-of-life/commit/d89f2d88eeed1a272da347448b621e39055f50cd))


