### PR TITLE
fix: Update hungry-distance to v0.1.36

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.35.tar.gz"
-  sha256 "c0070e0dfc3724a644665a91250d7a8173c29c50311a7244a9c01576071c3f22"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.35"
-    sha256 cellar: :any_skip_relocation, big_sur:      "43abaad9f0c0fc4a0ab93b882eed6628d4de5a82e4738a4d1d27b7f8a3b27c9b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "add44644b2cd1d8c63be28d44b614c45c9331aec0c45cd716f4dec35a52abd90"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.36.tar.gz"
+  sha256 "2552f8337e931ffab40eaa7564b8bf5fb692ebd0e261d29bccdde49ae7810862"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.36](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.36) (2022-07-15)

### Build

- Versio update versions ([`678af28`](https://github.com/PurpleBooth/hungry-distance/commit/678af280a3ba94922cc04a94360e4a3c1c609fe9))

### Fix

- Bump clap from 3.2.10 to 3.2.11 ([`ede31b0`](https://github.com/PurpleBooth/hungry-distance/commit/ede31b0e287fa8ac5c7870452e2b183d3593e7b2))
- Remove debug output ([`e679495`](https://github.com/PurpleBooth/hungry-distance/commit/e679495bf7b349a44c834ef7836ff6efd8e4882d))
- Bump clap from 3.2.11 to 3.2.12 ([`b45f128`](https://github.com/PurpleBooth/hungry-distance/commit/b45f128d99b7acfdcf779a0cf382a13cb794d894))

