### PR TITLE
fix: Update ellipsis to v0.6.53

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.51.tar.gz"
-  sha256 "4c24f775cc45efd61866d49a61944bc25508ba88f33a574a9f90ab88d944b77b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.51"
-    sha256 cellar: :any_skip_relocation, big_sur:      "ab154346198c7429d60ce4ca6dd26d2ef759ba7fedfa456be9bd8f61b03987d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "69aa302d6bfe3c0436608341379256a92edb18cd887f1b6a3d88a28f96a2abc8"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.53.tar.gz"
+  sha256 "959b100673e20a83320c323791daa02c287d140b2df7c81dd6c4d41e2bf0cd80"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.53](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.53) (2022-07-18)

### Deploy

#### Build

- Versio update versions ([`91654b9`](https://github.com/PurpleBooth/ellipsis/commit/91654b9f56c8626ff4c4196225b63fc30e0f9411))


