### PR TITLE
fix: Update git-mit to v5.12.70

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.69.tar.gz"
-  sha256 "2df7eea006dc50ec50e27142dd7ee2d864214dcffb092003c21709c80ac609ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.69"
-    sha256 cellar: :any,                 big_sur:      "b4323dbac0ee6ac5f982afa0c54ecf253393f73f1a7a538111519dce6b1dad9e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6c7356c186cdd6cc86de8d542d46f03afaa21aec7b0b93a3ab45920d2edaf415"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.70.tar.gz"
+  sha256 "c12a1dffd6d86bf8e004e7dc6d649986d3e95503073624c1b59e053bb517151b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.70](https://github.com/PurpleBooth/git-mit/compare/...v5.12.70) (2022-07-20)

### Deploy

#### Build

- Versio update versions ([`bc619fe`](https://github.com/PurpleBooth/git-mit/commit/bc619feff12406ee1f32e0050a26381999ad92a7))


### Deps

#### Fix

- Bump clap from 3.2.11 to 3.2.12 ([`4be52ed`](https://github.com/PurpleBooth/git-mit/commit/4be52ed9a17dd5d306916e27dfe565055ee97a76))
- Bump clap from 3.2.12 to 3.2.13 ([`8aeead3`](https://github.com/PurpleBooth/git-mit/commit/8aeead3c74c66046f58f5e30d3e97a9c235a3c59))


