### PR TITLE
fix: Update ellipsis to v0.6.54

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.53.tar.gz"
-  sha256 "959b100673e20a83320c323791daa02c287d140b2df7c81dd6c4d41e2bf0cd80"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.53"
-    sha256 cellar: :any_skip_relocation, big_sur:      "17d77d3477a7b40959d90293980f4d4636a4aa88b814ee4cfba0224ae1271c26"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3f4e4257246a0b0fc0f097b571d77f3c53ce29d4d89634d4e6c3a5b2f68d0689"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.54.tar.gz"
+  sha256 "2e9a61efea7b3d2d2621b1b56e9b50f9f8dd1ecd6728adcc51cc704253ef66e5"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.54](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.54) (2022-07-20)

### Deploy

#### Build

- Versio update versions ([`d4f7b51`](https://github.com/PurpleBooth/ellipsis/commit/d4f7b517ef0e1c6d48861434c255f3307504b48c))


