### PR TITLE
fix: Update hungry-distance to v0.1.37

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.36.tar.gz"
-  sha256 "2552f8337e931ffab40eaa7564b8bf5fb692ebd0e261d29bccdde49ae7810862"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.36"
-    sha256 cellar: :any_skip_relocation, big_sur:      "a2a84686734186f482d28cc9c1056117b496ba9539bebb5a136d97f9614f8e48"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "643259daeee1ad3af05ab16d6b6a394e1d008b7f0eb1406a9f4ab66e7760f7ad"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.37.tar.gz"
+  sha256 "5f894cb729b116d7c3be0b910e8f4c97f29a3866b2b3f55e7f10e7649afc20a2"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.37](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.37) (2022-07-21)

### Build

- Versio update versions ([`7c0ea26`](https://github.com/PurpleBooth/hungry-distance/commit/7c0ea2631cfe90bc0ee205c05801f24cde9107e6))

### Fix

- Bump clap from 3.2.12 to 3.2.13 ([`30984b6`](https://github.com/PurpleBooth/hungry-distance/commit/30984b67ffcdb7fef25051fb950cba8ea754297f))
- Bump clap from 3.2.13 to 3.2.14 ([`96e7f99`](https://github.com/PurpleBooth/hungry-distance/commit/96e7f9952ed488a04da4f1a4daa5815ea5166a1c))

