### PR TITLE
fix: Update game-of-life to v1.53.71

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.70.tar.gz"
-  sha256 "1c724d267ceac7e238786b46f12df3d03daa2a503f2610598accbf8f6c07cca2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.70"
-    sha256 cellar: :any_skip_relocation, big_sur:      "b597d36354cb86cdc6c608cb7973cb8c425fc33192b571564f7322feb1f85733"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ef2823caef354fbc5a075262d86a60fe8ab25421539e1743a0b974299d9bc330"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.71.tar.gz"
+  sha256 "492752993f9c083db156c6774d767ab154049911c01db9c65f3e12fb8f552b9f"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.71](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.71) (2022-07-22)

### Deploy

#### Build

- Versio update versions ([`0a97354`](https://github.com/PurpleBooth/game-of-life/commit/0a9735497e57e065a95b6723bd45f2cb77642c42))


