### PR TITLE
fix: Update git-mit to v5.12.72

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.71.tar.gz"
-  sha256 "471a8ad8d2317a40c333d17017a68c798f00c09fe04e3d322c104a17f43b864c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.71"
-    sha256 cellar: :any,                 big_sur:      "c731aa27f0e28f995c4f5040dc90b0a940cec7742d0315f378aab934a6fe53f8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "643860eb94bb7ac9588b5237e07df633ba37a041928b47c13fb008884020563a"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.72.tar.gz"
+  sha256 "8ad9d16dad28dea38062e3ae53088c9b3aedf17699a8e7bebd37175e41f88db1"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.72](https://github.com/PurpleBooth/git-mit/compare/...v5.12.72) (2022-07-26)

### Deploy

#### Build

- Versio update versions ([`73302be`](https://github.com/PurpleBooth/git-mit/commit/73302be9d0817de7e39681d91dfcd0b76a52dbb3))


### Deps

#### Fix

- Bump clap from 3.2.13 to 3.2.14 ([`a949868`](https://github.com/PurpleBooth/git-mit/commit/a94986811252b00746b268aa0b3f76847be7a290))
- Bump tokio from 1.20.0 to 1.20.1 ([`cbbe1a4`](https://github.com/PurpleBooth/git-mit/commit/cbbe1a41bb002e201ad869f796be93a7069e1c4d))
- Bump clap from 3.2.14 to 3.2.15 ([`2ab8f3c`](https://github.com/PurpleBooth/git-mit/commit/2ab8f3cb70e655b2236a2d2219b46ee06fbca452))


