### PR TITLE
fix: Update game-of-life to v1.53.72

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.71.tar.gz"
-  sha256 "492752993f9c083db156c6774d767ab154049911c01db9c65f3e12fb8f552b9f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.71"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0eda5daf5fcb2d41893f4be5dda3f66e7b21849fdd4184dbdec206a5ca4fafef"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "967eacb6f50f77dc6419dfc46cd9df54b0a58e39aad76392306429d09f1b39dc"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.72.tar.gz"
+  sha256 "7f345db43b99ae706b880ecc299c4b5311fe329453e5c2a6ed1630bdb5543e5f"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.72](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.72) (2022-08-01)

### Deploy

#### Build

- Versio update versions ([`41a4b56`](https://github.com/PurpleBooth/game-of-life/commit/41a4b5630b873fa6f49ad0a4d70d127575125d9e))


