### PR TITLE
fix: Update hungry-distance to v0.1.38

### DIFF
--- a/Formula/hungry-distance.rb
+++ b/Formula/hungry-distance.rb
@@ -1,14 +1,8 @@
 class HungryDistance < Formula
   desc "Calculate the distance between two points in an XYZ space"
   homepage "https://github.com/PurpleBooth/hungry-distance"
-  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.37.tar.gz"
-  sha256 "5f894cb729b116d7c3be0b910e8f4c97f29a3866b2b3f55e7f10e7649afc20a2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/hungry-distance-0.1.37"
-    sha256 cellar: :any_skip_relocation, big_sur:      "4d8cb9fe4d70a73a8b02dbe2642cf8c4c91139161ba1ba77be1ff54088246c9d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "92fee4bd3dfcf703aba36d95607aa46f9286f498f18109debfde33f97504712d"
-  end
+  url "https://github.com/PurpleBooth/hungry-distance/archive/v0.1.38.tar.gz"
+  sha256 "de3c9644f44fddf7220d1d9b5540020ce589991e5c10c81977d55a8d2de9a5f6"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.1.38](https://github.com/PurpleBooth/hungry-distance/compare/...v0.1.38) (2022-08-01)

### Build

- Versio update versions ([`8cb28c4`](https://github.com/PurpleBooth/hungry-distance/commit/8cb28c4a1cea4c011023257e415dba724db2c331))

### Fix

- Bump clap from 3.2.14 to 3.2.15 ([`8eeb9f9`](https://github.com/PurpleBooth/hungry-distance/commit/8eeb9f96ac7b72200d4f29ed6efdd1204105fd93))
- Bump clap from 3.2.15 to 3.2.16 ([`a4b26be`](https://github.com/PurpleBooth/hungry-distance/commit/a4b26be3f975b2a1afd396e16077db0831bff34a))

