### PR TITLE
fix: Update git-mit to v5.12.75

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.73.tar.gz"
-  sha256 "5461e1ee09265eb0a09dafeb88cb8d4a13239efb3b2e7139a960bebb00d45ccd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.73"
-    sha256 cellar: :any,                 big_sur:      "a7cd6355bfe041ee97f56364adb4710c30336b3cf23dfb41b8d6e80a14102942"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "79e5cd37992c22375593669824ec3c7efa72c7b2df132ac97dc2f48673d0f33e"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.75.tar.gz"
+  sha256 "875746e35ea90a2a40fc22ada534563d4002c9718816252d9a3c4ecb45d9943a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.75](https://github.com/PurpleBooth/git-mit/compare/...v5.12.75) (2022-08-02)

### Deploy

#### Build

- Versio update versions ([`801a2d2`](https://github.com/PurpleBooth/git-mit/commit/801a2d2745e3cf2d9b490ba496abb985b8d15ba8))


### Deps

#### Fix

- Bump time from 0.3.11 to 0.3.12 ([`6c4a2e5`](https://github.com/PurpleBooth/git-mit/commit/6c4a2e584e748c87b4f519813410ce0c4a561ae0))
- Bump indoc from 1.0.6 to 1.0.7 ([`d532cf7`](https://github.com/PurpleBooth/git-mit/commit/d532cf7b6db8b56d8100c4a464b2a70adda2e31d))


