### PR TITLE
fix: Update ellipsis to v0.6.57

### DIFF
--- a/Formula/ellipsis.rb
+++ b/Formula/ellipsis.rb
@@ -1,14 +1,8 @@
 class Ellipsis < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/ellipsis"
-  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.56.tar.gz"
-  sha256 "4493c9ad825f1f9f941189c294776f22c7023e642d062a6eb442841d842e16e1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/ellipsis-0.6.56"
-    sha256 cellar: :any_skip_relocation, big_sur:      "0f06cf2eb01d21df11fcf3f2eb0c0622df8e7d6e778be877981c13091de1588c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "161d5c62d9a4487ba865ff5972fd75b839e2bb3d15110f243451a0ce9e32f738"
-  end
+  url "https://github.com/PurpleBooth/ellipsis/archive/v0.6.57.tar.gz"
+  sha256 "ecc3844e5eea24a8e2aa17c3d8e2174741140887430229f5d414d282676a2706"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.6.57](https://github.com/PurpleBooth/ellipsis/compare/...v0.6.57) (2022-08-04)

### Deploy

#### Build

- Versio update versions ([`cf875cd`](https://github.com/PurpleBooth/ellipsis/commit/cf875cdfa98c8495e7d07213a67b8232276194ae))


