### PR TITLE
fix: Update git-mit to v5.12.81

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.80.tar.gz"
-  sha256 "80dc78ad990f54ad30367a0afbde6485ff764641bf0529d10805436f701d450e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.80"
-    sha256 cellar: :any,                 big_sur:      "be1110c96f89bccc612b4af8188bd4f4294d71e0a091fb70cdfad560f8ecba80"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2d680df2a4ecc5d1d49f0a0ccca71d06e37b633b4d76dcd0eeba6538cef0f5bd"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.81.tar.gz"
+  sha256 "ba162c97c51eb726eedb82396c0866ba7cf0f2295150d80fdd951c439dd6887b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.81](https://github.com/PurpleBooth/git-mit/compare/...v5.12.81) (2022-08-26)

### Deploy

#### Build

- Versio update versions ([`6cc6821`](https://github.com/PurpleBooth/git-mit/commit/6cc68212b2c2e471de46b7b166e397c5186d654d))


### Deps

#### Fix

- Bump miette from 5.2.0 to 5.3.0 ([`0c3464a`](https://github.com/PurpleBooth/git-mit/commit/0c3464a12d9620e46428d51887ed44bdc99bc5f8))


