### PR TITLE
fix: Update git-mit to v5.12.82

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.81.tar.gz"
-  sha256 "ba162c97c51eb726eedb82396c0866ba7cf0f2295150d80fdd951c439dd6887b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.81"
-    sha256 cellar: :any,                 big_sur:      "fdfa4ee0c50e50d76418a539e2fef821b06368fd74fbffee13b03f727a280f1c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "21cb2a8f7cf88ff1f69a3859541e65ce874102c71d0373cdc351cf2725c2e6c7"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.82.tar.gz"
+  sha256 "09edd323b1517679afaed64cebc274dc2b39f5f792572450a3d2a248cb95cf8f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.82](https://github.com/PurpleBooth/git-mit/compare/...v5.12.82) (2022-08-26)

### Deploy

#### Build

- Versio update versions ([`43cad7e`](https://github.com/PurpleBooth/git-mit/commit/43cad7eb30b528e1a3a6ded6f814f6cc4c5ccd97))


### Deps

#### Fix

- Bump git2 from 0.14.4 to 0.15.0 ([`f5ad370`](https://github.com/PurpleBooth/git-mit/commit/f5ad370be4878e46a4d9c59a2d90b6a4974a33bd))


