### PR TITLE
fix: Update game-of-life to v1.53.74

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.73.tar.gz"
-  sha256 "471ef04dde0f51949ef1e8d7a7ae81f1355b6c693203e84e97e5b6ba2e0dfe07"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.73"
-    sha256 cellar: :any_skip_relocation, big_sur:      "e3a8fcc103654dcc3d1edcf8b3577668c0012029fc845ad79240d3645fb6a17e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c399da829e90c4ffa8031a11da89cb56529c39a3bc2338fb4fb1e5925966d8fe"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.74.tar.gz"
+  sha256 "324c00d5966ee6158bc3439d60f97643252f4563ea867ff8f89f7d23bf20958e"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.74](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.74) (2022-08-30)

### Deploy

#### Build

- Versio update versions ([`3d37f35`](https://github.com/PurpleBooth/game-of-life/commit/3d37f3544925085cfd8713a3c4a240f75540958f))


