### PR TITLE
fix: Update git-mit to v5.12.83

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.82.tar.gz"
-  sha256 "09edd323b1517679afaed64cebc274dc2b39f5f792572450a3d2a248cb95cf8f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.82"
-    sha256 cellar: :any,                 big_sur:      "d8a325538dba8a9486f8f03340394edea3a1f1bf01ec453841f229fb73695c20"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9e2ce812e39f573200b9519b88b9a9af50df3a01f0ba2c2d1791ffad7ae536d4"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.83.tar.gz"
+  sha256 "e09895d709949e9c80a6097fa52729a150d18e11484c48a8104f94a1867cc2f2"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.83](https://github.com/PurpleBooth/git-mit/compare/...v5.12.83) (2022-08-30)

### Deploy

#### Build

- Versio update versions ([`ff9004d`](https://github.com/PurpleBooth/git-mit/commit/ff9004dca39158290c9680e9b5b29b113d73e092))


### Deps

#### Fix

- Bump comfy-table from 6.0.0 to 6.1.0 ([`0b152bb`](https://github.com/PurpleBooth/git-mit/commit/0b152bb559ac5e2d602e12fd6652fc5fdc571fdf))
- Bump clap from 3.2.17 to 3.2.18 ([`f2483c4`](https://github.com/PurpleBooth/git-mit/commit/f2483c4cc8c9f96b82d16bb132faa2be606de074))


