### PR TITLE
fix: Update git-mit to v5.12.84

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.83.tar.gz"
-  sha256 "e09895d709949e9c80a6097fa52729a150d18e11484c48a8104f94a1867cc2f2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.83"
-    sha256 cellar: :any,                 big_sur:      "c95c64f57b812c0875b3d5e4045795bbcf248734e0b24f53d0cf7d8f6396cd90"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1d23d69412a03e3f051487c92cfa1f8923d49a86306d44585945cb4826e99eba"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.84.tar.gz"
+  sha256 "fda6d2d9c963d546e805aadffe0547571a78c6ac8edc8e183c85fdc042f35039"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.84](https://github.com/PurpleBooth/git-mit/compare/...v5.12.84) (2022-08-31)

### Deploy

#### Build

- Versio update versions ([`3ff5d30`](https://github.com/PurpleBooth/git-mit/commit/3ff5d30b8bcb61e457ed5047b35a6bb9704563ce))


### Deps

#### Fix

- Bump which from 4.2.5 to 4.3.0 ([`b702929`](https://github.com/PurpleBooth/git-mit/commit/b70292901577895610a634037da4c5d9c8daec61))
- Bump thiserror from 1.0.32 to 1.0.33 ([`32ee98d`](https://github.com/PurpleBooth/git-mit/commit/32ee98d0787ca89c25588372080a62529663668b))


