### PR TITLE
fix: Update game-of-life to v1.53.75

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.74.tar.gz"
-  sha256 "324c00d5966ee6158bc3439d60f97643252f4563ea867ff8f89f7d23bf20958e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.74"
-    sha256 cellar: :any_skip_relocation, big_sur:      "8654cb1e5ee3b6de73678699ff58ef37ff5e1a2dc14934eba95173df17256936"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "bf3bfd214bc3908d2a6689cc87fbb4dbaaacc18cb7d7394ad6774b4091456f48"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.75.tar.gz"
+  sha256 "2e1e9a5ea1f848d87e519ab2055010d7af83b4fbbf1e46585b1bd954d1235d4a"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.75](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.75) (2022-09-05)

### Deploy

#### Build

- Versio update versions ([`ed1634b`](https://github.com/PurpleBooth/game-of-life/commit/ed1634bf464d9d17a1111d288a0aae3b833f87c6))


