### PR TITLE
fix: Update game-of-life to v1.53.76

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.75.tar.gz"
-  sha256 "2e1e9a5ea1f848d87e519ab2055010d7af83b4fbbf1e46585b1bd954d1235d4a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.75"
-    sha256 cellar: :any_skip_relocation, big_sur:      "7b5d86335867f6ef9bf9e6837e9b03064e1253612a0cc3cdfeaab60a7a3ce5ab"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "43e67d5cd51929da8fde85951b26d2f505e76331a3d3bd417066b94fe938e270"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.76.tar.gz"
+  sha256 "6ad1aefaffec739e2f233210501e6eba46ec7aa77b1fe08767b3a1d0625efa7b"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.76](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.76) (2022-09-19)

### Deploy

#### Build

- Versio update versions ([`4a40188`](https://github.com/PurpleBooth/game-of-life/commit/4a40188772a313d14d65a4bcb950e8e7b5c4f0fa))


