### PR TITLE
fix: Update git-mit to v5.12.86

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.85.tar.gz"
-  sha256 "733cb9fe87cb50d62510cc99846bbeee62a3419cb5827ed504d692c4614b66db"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.85"
-    sha256 cellar: :any,                 big_sur:      "407666612af6b3ce3f7270dda51b88506d46000d25f075599edbf3c1972137a6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c2c58a221770b3c4e3d7bf6af56b5210851332c1e866d3692e443360e0e290c0"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.86.tar.gz"
+  sha256 "5d0aafb93b59e8564f4a5a582023e494784770501b7cc5389f54d93846b48701"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.86](https://github.com/PurpleBooth/git-mit/compare/...v5.12.86) (2022-10-03)

### Deploy

#### Build

- Versio update versions ([`dd4f497`](https://github.com/PurpleBooth/git-mit/commit/dd4f49721b17ca012cdf5a1ae85d6bec15c53317))


### Src

#### Fix

- Follow clippy's advice ([`0a835cd`](https://github.com/PurpleBooth/git-mit/commit/0a835cdbc6fd5e40c5190ffb28c6d17d2beb80e0))


