### PR TITLE
fix: Update git-mit to v5.12.87

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.85.tar.gz"
-  sha256 "733cb9fe87cb50d62510cc99846bbeee62a3419cb5827ed504d692c4614b66db"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.85"
-    sha256 cellar: :any,                 big_sur:      "407666612af6b3ce3f7270dda51b88506d46000d25f075599edbf3c1972137a6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c2c58a221770b3c4e3d7bf6af56b5210851332c1e866d3692e443360e0e290c0"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.87.tar.gz"
+  sha256 "b5c361ee2ada4566e9dc24d06aa3500ac6cf08f2895e16853ebe1d12f035e4b7"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.87](https://github.com/PurpleBooth/git-mit/compare/...v5.12.87) (2022-10-03)

### Deploy

#### Build

- Versio update versions ([`a8b4343`](https://github.com/PurpleBooth/git-mit/commit/a8b434346639b8afa2eb58b2d2e0b99dfdb49fc9))


### Deps

#### Fix

- Bump clap from 3.2.19 to 3.2.21 ([`bd8f531`](https://github.com/PurpleBooth/git-mit/commit/bd8f5316c6bb2610e036c03b8f088aa87c6fa107))
- Bump tokio from 1.20.1 to 1.21.2 ([`e2b3606`](https://github.com/PurpleBooth/git-mit/commit/e2b360687ebcb5af42c87ad8ff795947f03ca16e))
- Bump openssl from 0.10.41 to 0.10.42 ([`77cb4e7`](https://github.com/PurpleBooth/git-mit/commit/77cb4e73c8b056c79c45d97f0242c641ac5dfacf))
- Bump criterion from 0.3.6 to 0.4.0 ([`6b0f5e8`](https://github.com/PurpleBooth/git-mit/commit/6b0f5e813f5e7d1f8aae7134dcb3e9b9e054dd03))


