### PR TITLE
fix: Update git-mit to v5.12.88

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.85.tar.gz"
-  sha256 "733cb9fe87cb50d62510cc99846bbeee62a3419cb5827ed504d692c4614b66db"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.85"
-    sha256 cellar: :any,                 big_sur:      "407666612af6b3ce3f7270dda51b88506d46000d25f075599edbf3c1972137a6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c2c58a221770b3c4e3d7bf6af56b5210851332c1e866d3692e443360e0e290c0"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.88.tar.gz"
+  sha256 "1809bef499e7434c77428b35f40b74ee5b781558d735690014be76f5bfbfe381"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.88](https://github.com/PurpleBooth/git-mit/compare/...v5.12.88) (2022-10-03)

### Deploy

#### Build

- Versio update versions ([`a7f92b9`](https://github.com/PurpleBooth/git-mit/commit/a7f92b9550fd9b66612d8fce93b1386d756b8190))


### Deps

#### Fix

- Bump thiserror from 1.0.33 to 1.0.37 ([`2758c09`](https://github.com/PurpleBooth/git-mit/commit/2758c09dd891584b597872761422e6058a0915a7))
- Bump arboard from 2.1.1 to 3.1.0 ([`5b463c6`](https://github.com/PurpleBooth/git-mit/commit/5b463c6a125c6220c2e320ddef0ea7bcca2af604))
- Bump mit-commit from 3.1.2 to 3.1.3 ([`1891a2f`](https://github.com/PurpleBooth/git-mit/commit/1891a2f7557660a7a1e546a92cee5340451dbe77))


