### PR TITLE
fix: Update game-of-life to v1.53.77

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,14 +1,8 @@
 class GameOfLife < Formula
   desc "PurpleBooth's implementation of Conway's Game of life"
   homepage "https://github.com/PurpleBooth/game-of-life"
-  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.75.tar.gz"
-  sha256 "2e1e9a5ea1f848d87e519ab2055010d7af83b4fbbf1e46585b1bd954d1235d4a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/game-of-life-1.53.75"
-    sha256 cellar: :any_skip_relocation, big_sur:      "7b5d86335867f6ef9bf9e6837e9b03064e1253612a0cc3cdfeaab60a7a3ce5ab"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "43e67d5cd51929da8fde85951b26d2f505e76331a3d3bd417066b94fe938e270"
-  end
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.77.tar.gz"
+  sha256 "52f5c2ae1cfa3fffa9b9b232bb9cd1ca83d2e3309bb5c9fb0941011abee624f8"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v1.53.77](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.77) (2022-10-04)

### Deploy

#### Build

- Versio update versions ([`990cf0b`](https://github.com/PurpleBooth/game-of-life/commit/990cf0b834f82669ff062196a5fda7b2dd517f6a))


