### PR TITLE
fix: Update git-mit to v5.12.89

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.85.tar.gz"
-  sha256 "733cb9fe87cb50d62510cc99846bbeee62a3419cb5827ed504d692c4614b66db"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.85"
-    sha256 cellar: :any,                 big_sur:      "407666612af6b3ce3f7270dda51b88506d46000d25f075599edbf3c1972137a6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c2c58a221770b3c4e3d7bf6af56b5210851332c1e866d3692e443360e0e290c0"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.89.tar.gz"
+  sha256 "3aedc6184b07953bd287ed0df18dfd4a990d41d98fe489bfe57bdd03955c861c"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.89](https://github.com/PurpleBooth/git-mit/compare/...v5.12.89) (2022-10-04)

### Deploy

#### Build

- Versio update versions ([`a48467a`](https://github.com/PurpleBooth/git-mit/commit/a48467ad1936173a126d6dd6ae6dbb265ca6cf58))


### Deps

#### Ci

- Bump ncipollo/release-action from 1.10.0 to 1.11.0 ([`804cd34`](https://github.com/PurpleBooth/git-mit/commit/804cd34e47afc31337be9ca0ab824b3c2e5e635f))
- Bump PurpleBooth/versio-release-action from 0.1.13 to 0.1.14 ([`1537f06`](https://github.com/PurpleBooth/git-mit/commit/1537f06ebb75a7cbe85de8ad306a48dff28d4a31))

#### Fix

- Bump time from 0.3.14 to 0.3.15 ([`5bc0e20`](https://github.com/PurpleBooth/git-mit/commit/5bc0e20b6a99c9608580120b63c555fe41960fa4))


