### PR TITLE
fix: Update readable-name-generator to v2.100.43

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,8 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.42.tar.gz"
-  sha256 "ca8015a9cb5b84157bacc7a87169e20b14368ed52a09f0b5fab0ac145b23bd23"
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.43.tar.gz"
+  sha256 "aff0b56473084206dd805a560b7ed42b3fee7c425812912a3773fe8554754581"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.43](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.43) (2022-10-12)

### Deploy

#### Build

- Versio update versions ([`ead8ee8`](https://github.com/PurpleBooth/readable-name-generator/commit/ead8ee821d4e2ed9c3c0670e624f6e65fc0aab86))


### Deps

#### Fix

- Bump rust from 1.62.1 to 1.64.0 ([`b579917`](https://github.com/PurpleBooth/readable-name-generator/commit/b579917c1f1da90bda3387b207f702026010136e))
- Bump clap from 3.2.16 to 3.2.21 ([`c625f7b`](https://github.com/PurpleBooth/readable-name-generator/commit/c625f7b2cfa1494ca578b1d6b04708096b9596ae))
- Bump miette from 5.2.0 to 5.3.0 ([`1bca2e1`](https://github.com/PurpleBooth/readable-name-generator/commit/1bca2e126a3c21f8a5c65beb7b51f3d63e6529d2))


