### PR TITLE
fix: Update git-moves-together to v2.5.40

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.39.tar.gz"
-  sha256 "e9d6d91cb3ebbd787157b0040692fed6afff42908f45868de423d651e9f191ef"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.39"
-    sha256 cellar: :any,                 big_sur:      "4cad97f029db9ac9df4913c9ed5a60eeaf9a4edab3b963ff14adbb169678baba"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "67dee12f915672c7c88978b9b98a49ceb4331b02a4d71c1fd2f5b5e4ecdeb05a"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.40.tar.gz"
+  sha256 "03528e38095dda8cf609c6a0ac07808964138ac5af7751b257c41c1a9f67b5b7"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.40](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.40) (2022-10-13)

### Deploy

#### Build

- Versio update versions ([`3d18675`](https://github.com/PurpleBooth/git-moves-together/commit/3d1867592a0ce690cf9ef9e8b285a70e9dafa5af))


### Deps

#### Ci

- Bump PurpleBooth/versio-release-action from 0.1.13 to 0.1.15 ([`5434b3f`](https://github.com/PurpleBooth/git-moves-together/commit/5434b3f7a924b8a002b7900edab9323aa2f1d0d9))

#### Fix

- Bump miette from 4.7.0 to 4.7.1 ([`b8cd917`](https://github.com/PurpleBooth/git-moves-together/commit/b8cd917f6addf7454f9a334dd916615380e95832))


