### PR TITLE
fix: Update fast-conventional to v2.3.3

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,8 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.3.2.tar.gz"
-  sha256 "765a766f84b63b1ac3b706e96b998a0fe93bfe7b06b9838091b55cb133eed5cb"
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.3.3.tar.gz"
+  sha256 "6db9de1a241f0aae4303b8467bb8a3217cd84721d4b03ed209004a8ef5b6f263"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.3.3](https://github.com/PurpleBooth/fast-conventional/compare/...v2.3.3) (2022-10-13)

### Deploy

#### Build

- Versio update versions ([`3f56896`](https://github.com/PurpleBooth/fast-conventional/commit/3f56896905f2b03f0c0f2f4ad9d0771ead760838))


### Deps

#### Ci

- Bump PurpleBooth/versio-release-action from 0.1.13 to 0.1.15 ([`018bcb6`](https://github.com/PurpleBooth/fast-conventional/commit/018bcb65c9b2e76b70eed5c05fc263c4b5d31fa2))

#### Fix

- Bump mit-commit from 3.1.3 to 3.1.4 ([`019edeb`](https://github.com/PurpleBooth/fast-conventional/commit/019edebdac974003da038ea36a83436b7c167af7))


### Src

#### Docs

- Format markdown ([`8385558`](https://github.com/PurpleBooth/fast-conventional/commit/83855583c7093fad4e67b0ead7e44b0fb0b036bf))


