### PR TITLE
fix: Update git-mit to v5.12.90

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.89.tar.gz"
-  sha256 "3aedc6184b07953bd287ed0df18dfd4a990d41d98fe489bfe57bdd03955c861c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.89"
-    sha256 cellar: :any,                 big_sur:      "ef3ac79c7d9b702d7f5bf67862255bea5da9d7b02819e75c26ff9519facc574f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "99ab7ab4ff2d1a84a862e7d5ccb8a4f3708092ce730adce2c82d74bfcd34d07e"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.90.tar.gz"
+  sha256 "e4aa2541ae99fe6f0d397c51904dc85f159cc50aa57fb6dc83b724513a316888"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"
@@ -31,12 +25,7 @@ class GitMit < Formula
       system "cargo", "install", "--root", prefix, "--path", "./#{binary}/"
 
       # Completions
-      output = Utils.safe_popen_read("#{bin}/#{binary}", "--completion", "bash")
-      (bash_completion/binary.to_s).write output
-      output = Utils.safe_popen_read("#{bin}/#{binary}", "--completion", "zsh")
-      (zsh_completion/binary.to_s).write output
-      output = Utils.safe_popen_read("#{bin}/#{binary}", "--completion", "fish")
-      (fish_completion/binary.to_s).write output
+      generate_completions_from_executable(bin/"#{binary}", "--completion", shells: [:zsh, :bash, :fish])
 
       # Man pages
       output = Utils.safe_popen_read("help2man", "#{bin}/#{binary}")


### PR DESCRIPTION
## Changelog
### [v5.12.90](https://github.com/PurpleBooth/git-mit/compare/...v5.12.90) (2022-10-14)

### Deploy

#### Build

- Versio update versions ([`77d1f43`](https://github.com/PurpleBooth/git-mit/commit/77d1f43f3587d9dae18ca757016d1b8d99653597))


### Deps

#### Ci

- Bump ncipollo/release-action from 1.11.0 to 1.11.1 ([`3c1fae3`](https://github.com/PurpleBooth/git-mit/commit/3c1fae3eeaefeaf978bcb14887ba93435fbc4a79))
- Bump PurpleBooth/versio-release-action from 0.1.14 to 0.1.15 ([`e3f5ca0`](https://github.com/PurpleBooth/git-mit/commit/e3f5ca0758829bb7d88adda264e152b4e820df10))

#### Fix

- Bump mit-commit from 3.1.3 to 3.1.4 ([`62e6926`](https://github.com/PurpleBooth/git-mit/commit/62e692661b00c2d7247278d27fc298e330c143d7))
- Bump rust from 1.63.0 to 1.64.0 ([`f550b98`](https://github.com/PurpleBooth/git-mit/commit/f550b9886b0b369f56e85e1e3665bbe788e8b301))


### Src

#### Fix

- Update homebrew to use new dsl ([`9e03bec`](https://github.com/PurpleBooth/git-mit/commit/9e03becf08b33d0b2ca5bdd0ed4dc5238f484545))

#### Refactor

- Follow clippy advice ([`17f0d91`](https://github.com/PurpleBooth/git-mit/commit/17f0d91be40a55a637a703ee8fb8cde03a1fd92e))


