### PR TITLE
fix: Update git-mit to v5.12.92

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.91.tar.gz"
-  sha256 "bb86f555370b118946b033633fbec4d96d5502846730d95b77010f7dab98e64c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.91"
-    sha256 cellar: :any,                 big_sur:      "e740188af5e1e64762733d2a85c1a11829cbb7d1ae0f3a15f4446394f466aae9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "cf4573d003d026e9348129e87044be24a93c7118d8c564685352503693513f67"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.92.tar.gz"
+  sha256 "aab003dcb20f0a3426496f0f86873da12fe52ad7b05be79b1ced5cb934498a16"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.92](https://github.com/PurpleBooth/git-mit/compare/...v5.12.92) (2022-10-15)

### Deploy

#### Build

- Versio update versions ([`8101b56`](https://github.com/PurpleBooth/git-mit/commit/8101b561288c44be71a3ed021a1547e3a923e158))


### Src

#### Fix

- Switch to derive version of clap ([`f81e07f`](https://github.com/PurpleBooth/git-mit/commit/f81e07f0d578d91cd9e392a2aaf5deb53affae52))
- Specify the binary name ([`f797fed`](https://github.com/PurpleBooth/git-mit/commit/f797feddd7cb1149e8421b8d1d6c2c879ec100ec))


