### PR TITLE
fix: Update git-mit to v5.12.93

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.92.tar.gz"
-  sha256 "aab003dcb20f0a3426496f0f86873da12fe52ad7b05be79b1ced5cb934498a16"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.92"
-    sha256 cellar: :any,                 big_sur:      "c4d6df54363f9199b16cf7ba78a936e044869cc8fdd38625f07539922f96a363"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e529164fe4050ee2766d6e4f8f41fa804d649bca625209aa643d55b29a1034c2"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.93.tar.gz"
+  sha256 "ca3dbef2efc0b561b84e72c1e497d43bc50fbbb0ac619a4e85f12f3064a5dfaf"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"
@@ -31,7 +25,7 @@ class GitMit < Formula
       system "cargo", "install", "--root", prefix, "--path", "./#{binary}/"
 
       # Completions
-      generate_completions_from_executable(bin/binary, "--completion", shells: [:zsh, :bash, :fish])
+      generate_completions_from_executable(bin/binary, "--completion", shells: [:bash, :elvish, :fish, :powershell, :zsh])
 
       # Man pages
       output = Utils.safe_popen_read("help2man", "#{bin}/#{binary}")


### PR DESCRIPTION
## Changelog
### [v5.12.93](https://github.com/PurpleBooth/git-mit/compare/...v5.12.93) (2022-10-15)

### Homebrew

#### Fix

- Add the full list of shells ([`5a0f742`](https://github.com/PurpleBooth/git-mit/commit/5a0f742a93bb1e9595f9b3f745795665dec450d9))


### Deploy

#### Build

- Versio update versions ([`51c8a80`](https://github.com/PurpleBooth/git-mit/commit/51c8a80fcd939fa0c8414df7360aed8d3296181a))


### Src

#### Fix

- Migrate to derive interface ([`c585dc4`](https://github.com/PurpleBooth/git-mit/commit/c585dc4c50e4780fff2607d3ef1341aa985e0423))
- Migrate to using a derive structure ([`8516a03`](https://github.com/PurpleBooth/git-mit/commit/8516a039dffcdc38d2bf480f03048767a36a5154))


