### PR TITLE
fix: Update git-mit to v5.12.94

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -25,7 +25,13 @@ class GitMit < Formula
       system "cargo", "install", "--root", prefix, "--path", "./#{binary}/"
 
       # Completions
-      generate_completions_from_executable(bin/binary, "--completion", shells: [:bash, :elvish, :fish, :powershell, :zsh])
+      generate_completions_from_executable(bin/binary, "--completion", shells: [
+        :bash, 
+        :elvish, 
+        :fish, 
+        :powershell, 
+        :zsh
+      ])
 
       # Man pages
       output = Utils.safe_popen_read("help2man", "#{bin}/#{binary}")

--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -26,11 +26,11 @@ class GitMit < Formula
 
       # Completions
       generate_completions_from_executable(bin/binary, "--completion", shells: [
-        :bash, 
-        :elvish, 
-        :fish, 
-        :powershell, 
-        :zsh
+        :bash,
+        :elvish,
+        :fish,
+        :powershell,
+        :zsh,
       ])
 
       # Man pages

--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.92.tar.gz"
-  sha256 "aab003dcb20f0a3426496f0f86873da12fe52ad7b05be79b1ced5cb934498a16"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.92"
-    sha256 cellar: :any,                 big_sur:      "c4d6df54363f9199b16cf7ba78a936e044869cc8fdd38625f07539922f96a363"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e529164fe4050ee2766d6e4f8f41fa804d649bca625209aa643d55b29a1034c2"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.94.tar.gz"
+  sha256 "7d7cf1982fb769a3669c835aab5b0e220dc7d6bc89d48d26101aa50cbb6d248e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"
@@ -31,7 +25,7 @@ class GitMit < Formula
       system "cargo", "install", "--root", prefix, "--path", "./#{binary}/"
 
       # Completions
-      generate_completions_from_executable(bin/binary, "--completion", shells: [:zsh, :bash, :fish])
+      generate_completions_from_executable(bin/binary, "--completion", shells: [:bash, :elvish, :fish, :powershell, :zsh])
 
       # Man pages
       output = Utils.safe_popen_read("help2man", "#{bin}/#{binary}")


### PR DESCRIPTION
## Changelog
### [v5.12.94](https://github.com/PurpleBooth/git-mit/compare/...v5.12.94) (2022-10-15)

### Deploy

#### Build

- Versio update versions ([`ea779a2`](https://github.com/PurpleBooth/git-mit/commit/ea779a20711db49231c6deea34e04cc4d978a950))


### Src

#### Fix

- Switch to derive syntax to prepare for upgrade of clap ([`207a0c0`](https://github.com/PurpleBooth/git-mit/commit/207a0c0289f8424bda89f514ae2b6d8e48962706))


