### PR TITLE
fix: Update git-mit to v5.12.95

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.92.tar.gz"
-  sha256 "aab003dcb20f0a3426496f0f86873da12fe52ad7b05be79b1ced5cb934498a16"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.92"
-    sha256 cellar: :any,                 big_sur:      "c4d6df54363f9199b16cf7ba78a936e044869cc8fdd38625f07539922f96a363"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e529164fe4050ee2766d6e4f8f41fa804d649bca625209aa643d55b29a1034c2"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.95.tar.gz"
+  sha256 "47b529cf1b6f18aae4d8a8cf90f6abaaedac0ca5ca5a0634a9f1e8ebfd473b12"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"
@@ -31,7 +25,13 @@ class GitMit < Formula
       system "cargo", "install", "--root", prefix, "--path", "./#{binary}/"
 
       # Completions
-      generate_completions_from_executable(bin/binary, "--completion", shells: [:zsh, :bash, :fish])
+      generate_completions_from_executable(bin/binary, "--completion", shells: [
+        :bash,
+        :elvish,
+        :fish,
+        :powershell,
+        :zsh,
+      ])
 
       # Man pages
       output = Utils.safe_popen_read("help2man", "#{bin}/#{binary}")


### PR DESCRIPTION
## Changelog
### [v5.12.95](https://github.com/PurpleBooth/git-mit/compare/...v5.12.95) (2022-10-16)

### Homebrew

#### Fix

- Reduce line length ([`822b5e8`](https://github.com/PurpleBooth/git-mit/commit/822b5e8602c54db4bf3c84d928714e4e6a20d0bd))


### Deploy

#### Build

- Versio update versions ([`8e62a88`](https://github.com/PurpleBooth/git-mit/commit/8e62a88fe5c90aa03dcde0b67f3cfe1046c54a8f))


### Src

#### Fix

- Switch to using derive method ([`11c99f5`](https://github.com/PurpleBooth/git-mit/commit/11c99f54e15f98b69db22849ec9fa530414ea769))
- Migrate to using parse ([`f52a09c`](https://github.com/PurpleBooth/git-mit/commit/f52a09c2afd0b5c81eeaaca16b51868ad4053bbd))


