### PR TITLE
fix: Update git-mit to v5.12.97

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.96.tar.gz"
-  sha256 "5ddac1fc9ea8e84270143a0ee7c7ff76873a88ebe5902a914daa54315246accd"
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.97.tar.gz"
+  sha256 "a549ae8dba2e472b969975e4ad1dbdd13fe940762f93c261f9efecb83e948915"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"
@@ -25,7 +25,7 @@ class GitMit < Formula
       system "cargo", "install", "--root", prefix, "--path", "./#{binary}/"
 
       # Completions
-      generate_completions_from_executable(bin/binary, "--completion", shells: [
+      generate_completions_from_executable("#{bin}/#{binary}", "--completion", shells: [
         :bash,
         :elvish,
         :fish,


### PR DESCRIPTION
## Changelog
### [v5.12.97](https://github.com/PurpleBooth/git-mit/compare/...v5.12.97) (2022-10-17)

### Homebrew

#### Fix

- Fix the install problem ([`2b47518`](https://github.com/PurpleBooth/git-mit/commit/2b4751873ec4611ea821cabf4ec60db5e530e60c))
- Use interpolated string for generate ([`69fe4ec`](https://github.com/PurpleBooth/git-mit/commit/69fe4ec7d85fb5ed4b55b10775df97387fe2e92c))


### Deploy

#### Build

- Versio update versions ([`1121b24`](https://github.com/PurpleBooth/git-mit/commit/1121b241c80e0ad15181c04ecd015a0333399557))


