### PR TITLE
fix: Update git-moves-together to v2.5.41

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.40.tar.gz"
-  sha256 "03528e38095dda8cf609c6a0ac07808964138ac5af7751b257c41c1a9f67b5b7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.40"
-    sha256 cellar: :any,                 big_sur:      "7b76beeabbe56d3f90e6d57bccb33b95cfaa5410a9d95d78077179a5586eb8ea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "120e619654cf88018f53144f2beab1372ca95443913ab9a4c0b38139e68d9156"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.41.tar.gz"
+  sha256 "519a79c3bce9d7aea07a272b01b55659c1f52dd4a3fffeb93080dfa6388cdf09"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.41](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.41) (2022-10-19)

### Deploy

#### Build

- Versio update versions ([`c92cdd1`](https://github.com/PurpleBooth/git-moves-together/commit/c92cdd1b5a99b4306c82c9a59cd4e13c0c0a0fb6))


### Deps

#### Fix

- Bump comfy-table from 5.0.1 to 6.1.1 ([`606d0e0`](https://github.com/PurpleBooth/git-moves-together/commit/606d0e01584aec2f7256b7a0773c469c662f9fa6))
- Bump git2 from 0.14.2 to 0.15.0 ([`a61ab80`](https://github.com/PurpleBooth/git-moves-together/commit/a61ab8040d4acf268c34e987043241d4625a7683))


