### PR TITLE
fix: Update git-mit to v5.12.101

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.100.tar.gz"
-  sha256 "45084932204c889649486db464b66797dd4546d99ee11a20f24edb9eaedcb217"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.100"
-    sha256 cellar: :any,                 big_sur:      "3bfab3bdd97b2cd3e088f8123664e1ad382f0cc7c51331a0ae96c5481652154d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ea783325ebd0038f39abdb4fb708b0d2c0a5b617e80f46146d34de2bb3996d64"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.101.tar.gz"
+  sha256 "d79be3312c90dc72f6a59a6cf3c50df3da4bc48334d369a8f9d751a00ea973af"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.101](https://github.com/PurpleBooth/git-mit/compare/...v5.12.101) (2022-10-19)

### Deploy

#### Build

- Versio update versions ([`e07f96f`](https://github.com/PurpleBooth/git-mit/commit/e07f96f25c3a315dc2e7f5c3a89f350886e84b10))


### Deps

#### Fix

- Bump arboard from 3.1.0 to 3.1.1 ([`1288f61`](https://github.com/PurpleBooth/git-mit/commit/1288f6141f27df37e3f3585c2f9f90f83adef225))
- Bump clap from 4.0.16 to 4.0.17 ([`ca182b1`](https://github.com/PurpleBooth/git-mit/commit/ca182b1d0603ced3e23d5046e677a50b8b9556e7))


