### PR TITLE
fix: Update git-mit to v5.12.102

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.101.tar.gz"
-  sha256 "d79be3312c90dc72f6a59a6cf3c50df3da4bc48334d369a8f9d751a00ea973af"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.101"
-    sha256 cellar: :any,                 big_sur:      "b2d14a2a5c04e54a08bd429d427030f85ddb1b013a1f4fb9597a7d09f2e27bb1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f99293e90a8b658e2dae3a31e18d4c2c452f3a3c8f4079f49e74df1e3b5cc2b0"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.102.tar.gz"
+  sha256 "3b745491a92df425f2d1ef89c42616a9322275ec90f23f45a828529afc90d12e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.102](https://github.com/PurpleBooth/git-mit/compare/...v5.12.102) (2022-10-19)

### Deploy

#### Build

- Versio update versions ([`db9c911`](https://github.com/PurpleBooth/git-mit/commit/db9c91172e816ac5d0f17b6e0dcabfcd640760be))


### Deps

#### Fix

- Bump comfy-table from 6.1.0 to 6.1.1 ([`39f309f`](https://github.com/PurpleBooth/git-mit/commit/39f309f90001ae0dc803e2b8ed40ca075ab47c7f))
- Bump clap_complete from 4.0.2 to 4.0.3 ([`1d057df`](https://github.com/PurpleBooth/git-mit/commit/1d057df4a2134ba108218ce3d681144cf00bfe65))


