### PR TITLE
fix: Update git-moves-together to v2.5.42

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.41.tar.gz"
-  sha256 "519a79c3bce9d7aea07a272b01b55659c1f52dd4a3fffeb93080dfa6388cdf09"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.41"
-    sha256 cellar: :any,                 big_sur:      "dbc0d567297f0ec0af34aeabc2fd5475298a173f31e38af0ea2cad1b10126857"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0495c6b4bcea64edfd2af65f102fdb7d5374fd6ab7117777939720552f3c8373"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.42.tar.gz"
+  sha256 "e28789acb063cc015f713833ac6708997c63ede530a8f8fabcef6d4f8e4804fc"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.42](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.42) (2022-10-20)

### Deploy

#### Build

- Versio update versions ([`4888ff7`](https://github.com/PurpleBooth/git-moves-together/commit/4888ff7b0028902609a2881719e2fc1c3c0a0ed6))


### Deps

#### Fix

- Bump miette from 4.7.1 to 5.3.0 ([`67e568f`](https://github.com/PurpleBooth/git-moves-together/commit/67e568f2e11b592ea6652316e4e278898fb20810))
- Bump futures from 0.3.24 to 0.3.25 ([`759f48d`](https://github.com/PurpleBooth/git-moves-together/commit/759f48dd96bce8efbb3aa6f087cd2f1ddae48d8b))


