### PR TITLE
fix: Update git-mit to v5.12.104

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.103.tar.gz"
-  sha256 "a5b2dd21f5c3cc6afdb818dd66cb0257907297d53d38f64198520c7c967d80a6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.103"
-    sha256 cellar: :any,                 big_sur:      "31a37ec4e96d4f70a001e1738457f0c1ad5b4b7ff14ced0f94e2968d3d6a6549"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "badf192cef5e8a9d7f70981ea1009cff15de70c9077d7a995ceb6e801f638421"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.104.tar.gz"
+  sha256 "ebc1fd56c8805177c5ac3434aa845ed7c311bb26dc90928c783354dd569a845a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.104](https://github.com/PurpleBooth/git-mit/compare/...v5.12.104) (2022-10-24)

### Deploy

#### Build

- Versio update versions ([`46ddb52`](https://github.com/PurpleBooth/git-mit/commit/46ddb52451875261a93b2f3cc832674d023e6807))


### Deps

#### Fix

- Bump clap from 4.0.17 to 4.0.18 ([`faa69bb`](https://github.com/PurpleBooth/git-mit/commit/faa69bb357b0ceb63b1ed8e05269d871ae5db90b))
- Bump serde_yaml from 0.9.13 to 0.9.14 ([`10fb808`](https://github.com/PurpleBooth/git-mit/commit/10fb808e11453b7d253e3db4f293db40de74d858))


