### PR TITLE
fix: Update git-mit to v5.12.105

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.104.tar.gz"
-  sha256 "ebc1fd56c8805177c5ac3434aa845ed7c311bb26dc90928c783354dd569a845a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.104"
-    sha256 cellar: :any,                 big_sur:      "644870901f5bada0a4679bbd321cfe0572011545b61c180a0ed5d360ffca3b5d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1a553b1067037fcb39fdffeeefa9242897152a69fac1c0a33871360ccfd63012"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.105.tar.gz"
+  sha256 "0451ee4c2260a9ebbb31ef0762d30902472b2cf4a15cf44ece3b0e287523329f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.105](https://github.com/PurpleBooth/git-mit/compare/...v5.12.105) (2022-10-24)

### Deploy

#### Build

- Versio update versions ([`9abc2f1`](https://github.com/PurpleBooth/git-mit/commit/9abc2f1265ed6cb73c1266ba5e17ec5ee08c963c))


### Deps

#### Fix

- Bump time from 0.3.15 to 0.3.16 ([`cdc3416`](https://github.com/PurpleBooth/git-mit/commit/cdc341601db905e85cd1e622a3fc3b06cd42bc84))


