### PR TITLE
fix: Update git-moves-together to v2.5.43

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.42.tar.gz"
-  sha256 "e28789acb063cc015f713833ac6708997c63ede530a8f8fabcef6d4f8e4804fc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.42"
-    sha256 cellar: :any,                 big_sur:      "e89bdf0cf19756aec68779142ef1e12ab5f66ab3bee482b802a2a0ffd0903fad"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7a60e50dfc9472e4ed10364fe75518ec8c21a7fd0f1bc60d1c15047b7fe4c59c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.43.tar.gz"
+  sha256 "e6bd0b830a99b1fe5bc04e985db6581882a50a753dd79a1a3a3f2b80d20f9cbe"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.43](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.43) (2022-10-25)

### Deploy

#### Build

- Versio update versions ([`107afba`](https://github.com/PurpleBooth/git-moves-together/commit/107afba306a93ced0990a0d676ca0d1a920084cd))


### Deps

#### Fix

- Bump time from 0.3.15 to 0.3.16 ([`99855a4`](https://github.com/PurpleBooth/git-moves-together/commit/99855a409e40f37fc029db7aa33e9b3854b967c6))
- Bump clap from 3.2.22 to 3.2.23 ([`69517b0`](https://github.com/PurpleBooth/git-moves-together/commit/69517b00f4cbeefe82ada40d5c4d86fcbf74a0bb))


