### PR TITLE
fix: Update git-moves-together to v2.5.44

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.43.tar.gz"
-  sha256 "e6bd0b830a99b1fe5bc04e985db6581882a50a753dd79a1a3a3f2b80d20f9cbe"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.43"
-    sha256 cellar: :any,                 big_sur:      "65165d90301defcb1dd253190a742e8cf03eb7c71986dd5262840cfad635b496"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ea2aa2e313b883ab844b8fb2aedfe896728cac74b3a7a5801d01894a22aac390"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.44.tar.gz"
+  sha256 "2783565474b72c54aac216778f3652acec343e0037b7576f4ad10af42d9517dd"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.44](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.44) (2022-10-31)

### Deploy

#### Build

- Versio update versions ([`2c7a586`](https://github.com/PurpleBooth/git-moves-together/commit/2c7a5868240e2d2f61f73f398e7647d096335245))


### Deps

#### Fix

- Bump comfy-table from 6.1.1 to 6.1.2 ([`f230ea5`](https://github.com/PurpleBooth/git-moves-together/commit/f230ea51692170fbd691733ab36352026960df28))
- Bump miette from 5.3.0 to 5.4.1 ([`0d9e497`](https://github.com/PurpleBooth/git-moves-together/commit/0d9e4972d884f527d8cdfa04f1696c0da8b6223d))


