### PR TITLE
fix: Update readable-name-generator to v2.100.45

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.44.tar.gz"
-  sha256 "a8c088112ed12145daf2fe2e2e413486d513d44e84893d91fa64d75e544bc266"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "36e87d3a65501127d04f6e48ef2819107d101f7388df54f75708cbbcd69abfb7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7cfff5433328659f5c2e2acc4f2320d5f5d4d6fe8ccf47f9cc62743a7f13b4c0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.45.tar.gz"
+  sha256 "1c41882622ea5e8523432091fab93df5bc5d98418f11bc666203b3634754135d"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.45](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.45) (2022-11-04)

### Deploy

#### Build

- Versio update versions ([`0ffceca`](https://github.com/PurpleBooth/readable-name-generator/commit/0ffceca68d50698c7d04235d8a58df22a7b39bfa))


### Deps

#### Fix

- Bump miette from 5.3.0 to 5.4.1 ([`7e37000`](https://github.com/PurpleBooth/readable-name-generator/commit/7e37000039c1a78d96d10202c209da61a344f78f))
- Bump rust from 1.64.0 to 1.65.0 ([`8d81f4d`](https://github.com/PurpleBooth/readable-name-generator/commit/8d81f4d5af4691741e9e8a76d8e0b82053727605))


