### PR TITLE
fix: Update git-mit to v5.12.107

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.106.tar.gz"
-  sha256 "9aa8f791dc4f1006aa0d1423dd43468a1708c1c0bdedd856ab31204b81fcc0ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.106"
-    sha256 cellar: :any,                 big_sur:      "835606c9615b9bb6d7e77c7fd936a400ae3a760f955fd479d528c3a18513cdf2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3ff60490f972a311e7b493627bc9428080f597207fcbf528146728fad69d5848"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.107.tar.gz"
+  sha256 "4f0a5c07406f50e4212646ae2507aa12f45c1212af39cf438e23abae594b111f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.107](https://github.com/PurpleBooth/git-mit/compare/...v5.12.107) (2022-11-07)

### Deploy

#### Build

- Versio update versions ([`35b6013`](https://github.com/PurpleBooth/git-mit/commit/35b6013f960c33e5fbdef22debf61cb5a3994504))


### Deps

#### Fix

- Bump arboard from 3.1.1 to 3.2.0 ([`bc601f6`](https://github.com/PurpleBooth/git-mit/commit/bc601f6914f1140a3f31317a90bdf47e5f64ca73))


