### PR TITLE
fix: Update git-mit to v5.12.109

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.108.tar.gz"
-  sha256 "8697dcad3f09219b8bab720d0145c53bc0c28654eb6f8207a1aeb5ab57796cf9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.108"
-    sha256 cellar: :any,                 monterey:     "4d3c6a74dc9ce2802cef3d874e646014a8567f65cf6baa357e472d2de0afa19f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "24b08baae946b597839bbba9ff63bdbe10741fee0b8130fc9f8276d4219b0a45"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.109.tar.gz"
+  sha256 "a3627fa04a85205b5ab89c3719b998e2dc28587fc87d34443efcc95aa7458529"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.109](https://github.com/PurpleBooth/git-mit/compare/...v5.12.109) (2022-11-08)

### Deploy

#### Build

- Versio update versions ([`b086faf`](https://github.com/PurpleBooth/git-mit/commit/b086faf9208aeebe558048182b54394f99066d1c))


### Deps

#### Fix

- Bump clap from 4.0.19 to 4.0.22 ([`3749173`](https://github.com/PurpleBooth/git-mit/commit/37491730bbf4a14eb9cdfa44127e12594470bce9))
- Bump rust from 1.64.0 to 1.65.0 ([`9c28236`](https://github.com/PurpleBooth/git-mit/commit/9c2823603e8487473e4174c0d8b1f84a86580c88))
- Bump clap_complete from 4.0.3 to 4.0.5 ([`d46f8a7`](https://github.com/PurpleBooth/git-mit/commit/d46f8a70fabf38696c778446e729ec71358d977b))


