### PR TITLE
fix: Update git-mit to v5.12.111

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.110.tar.gz"
-  sha256 "23a523eab5fbb9dda53916833aa04e6a76df221dfad806f777ceaba98ef873d7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.110"
-    sha256 cellar: :any,                 monterey:     "677318125ae8cb764029ee030dd9b573f2444a012b7b6d3a54057415d06b5e22"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5cdbdc9b2e88eac1963e2cbe1aa2bd0c9fb723a8f8df1e1797de09dceb7e0f02"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.111.tar.gz"
+  sha256 "1b8e7c41bec79888aab40a3be9896b5437db46aed65c6d17454c72d12c93e185"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.111](https://github.com/PurpleBooth/git-mit/compare/...v5.12.111) (2022-11-15)

### Deploy

#### Build

- Versio update versions ([`b514af2`](https://github.com/PurpleBooth/git-mit/commit/b514af2aef62f90978b681fe677a9701ccb81c37))


### Deps

#### Ci

- Bump PurpleBooth/versio-release-action from 0.1.15 to 0.1.16 ([`d7d550b`](https://github.com/PurpleBooth/git-mit/commit/d7d550b263fa4816552e0f67f092a08ab58ea08f))

#### Fix

- Bump clap from 4.0.23 to 4.0.24 ([`054257d`](https://github.com/PurpleBooth/git-mit/commit/054257ddae955b3e83e9bdc1bc58d5743677a83c))


