### PR TITLE
fix: Update git-mit to v5.12.112

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.111.tar.gz"
-  sha256 "1b8e7c41bec79888aab40a3be9896b5437db46aed65c6d17454c72d12c93e185"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.111"
-    sha256 cellar: :any,                 monterey:     "ab81c75ebf261ff568143b92e48770a81f6326b2b21b0476e741dfc032ea9920"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "449f6bec48ad6939198e429d662b011f345cd86ab517cf5b926b2a1e74e9172b"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.112.tar.gz"
+  sha256 "f0d105b020ccfbc8bf5cd0d45df787c0e5d095cf76c232f789ffbafd3dd4ba3e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.112](https://github.com/PurpleBooth/git-mit/compare/...v5.12.112) (2022-11-17)

### Deploy

#### Build

- Versio update versions ([`9019a16`](https://github.com/PurpleBooth/git-mit/commit/9019a16480cc3daa8cf4efb147858e3df979cf01))


### Deps

#### Fix

- Bump clap from 4.0.24 to 4.0.25 ([`7137945`](https://github.com/PurpleBooth/git-mit/commit/713794599520e056e522f17bec61e426f5252f34))
- Bump clap from 4.0.25 to 4.0.26 ([`be9a0c5`](https://github.com/PurpleBooth/git-mit/commit/be9a0c5a4d7c8941e0d51291cd57884f40455daf))


