### PR TITLE
fix: Update git-moves-together to v2.5.46

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.44.tar.gz"
-  sha256 "2783565474b72c54aac216778f3652acec343e0037b7576f4ad10af42d9517dd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.44"
-    sha256 cellar: :any,                 big_sur:      "c9510c8fb9526c642861471985f4c39dcf64d8a1980148707a4772fd0a74d8b1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4cec4a53d5eee4e1aa87938e6f9e90a86f793feccdf73bec41bcbdedcc82645d"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.46.tar.gz"
+  sha256 "3c0f61ea909ef258f6e90ba37def272415e3d7c4d3e61b50966ce08deb83cf90"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.46](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.46) (2022-11-24)

### Deploy

#### Build

- Versio update versions ([`d39b89e`](https://github.com/PurpleBooth/git-moves-together/commit/d39b89ebf764e2960bc3a80d0fb4105f9fe031b0))


### Deps

#### Fix

- Bump time from 0.3.16 to 0.3.17 ([`39c254d`](https://github.com/PurpleBooth/git-moves-together/commit/39c254d794ddcec2aa0a7bcaf7eba47aaafdb073))
- Bump miette from 5.4.1 to 5.5.0 ([`09928dd`](https://github.com/PurpleBooth/git-moves-together/commit/09928dd74944f2b0cf41b2e51ee57c7f0d7dae6d))


