### PR TITLE
fix: Update readable-name-generator to v2.100.46

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.44.tar.gz"
-  sha256 "a8c088112ed12145daf2fe2e2e413486d513d44e84893d91fa64d75e544bc266"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "36e87d3a65501127d04f6e48ef2819107d101f7388df54f75708cbbcd69abfb7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7cfff5433328659f5c2e2acc4f2320d5f5d4d6fe8ccf47f9cc62743a7f13b4c0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.46.tar.gz"
+  sha256 "f0283de6c612b7fd914cdb69522fbf269217b8728ee40a35134b6e6518f514b7"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.46](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.46) (2022-11-24)

### Deploy

#### Build

- Versio update versions ([`8a5062c`](https://github.com/PurpleBooth/readable-name-generator/commit/8a5062c6fb349b0034a9d866c795fc2463f45f6e))


### Deps

#### Ci

- Bump PurpleBooth/versio-release-action from 0.1.15 to 0.1.16 ([`898778d`](https://github.com/PurpleBooth/readable-name-generator/commit/898778d45914436ce4b5be24ef9704a24c64dce5))

#### Fix

- Bump miette from 5.4.1 to 5.5.0 ([`de59466`](https://github.com/PurpleBooth/readable-name-generator/commit/de594662f58c7d9a692d1823d163edd9784d1966))


