### PR TITLE
fix: Update readable-name-generator to v2.100.48

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.44.tar.gz"
-  sha256 "a8c088112ed12145daf2fe2e2e413486d513d44e84893d91fa64d75e544bc266"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "36e87d3a65501127d04f6e48ef2819107d101f7388df54f75708cbbcd69abfb7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7cfff5433328659f5c2e2acc4f2320d5f5d4d6fe8ccf47f9cc62743a7f13b4c0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.48.tar.gz"
+  sha256 "a548a4a60eb4ac1644a4878d0fb0d3c598e882141fe19b9242b12f404762209b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.48](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.48) (2023-01-13)

### Deploy

#### Build

- Versio update versions ([`ea781d3`](https://github.com/PurpleBooth/readable-name-generator/commit/ea781d33f1b78290a79a77bfd1616ace21d429b7))


### Deps

#### Fix

- Bump thiserror from 1.0.37 to 1.0.38 ([`5cd735b`](https://github.com/PurpleBooth/readable-name-generator/commit/5cd735bb31e55ae543a6594e88d6120b801df7cc))
- Bump rust from 1.66.0 to 1.66.1 ([`7aef52c`](https://github.com/PurpleBooth/readable-name-generator/commit/7aef52cdb3072abf054205574c14462c700b7363))


