### PR TITLE
fix: Update git-moves-together to v2.5.48

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.46.tar.gz"
-  sha256 "3c0f61ea909ef258f6e90ba37def272415e3d7c4d3e61b50966ce08deb83cf90"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.46"
-    sha256 cellar: :any,                 monterey:     "6296e2fec5da27e0cc19e27fd29caf2fd566490e0e01ae2327e58b6dceb884a9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ab42ba1de1d905adc3b06cf4606c2b5a97143381d59e0abf8e8d1ac2855bef46"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.48.tar.gz"
+  sha256 "68bf028a34a257a95dd6bc740091b25110ed67cd0d71334673eea3794f7ffbc4"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.48](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.48) (2023-01-14)

### Deploy

#### Build

- Versio update versions ([`1dd0d54`](https://github.com/PurpleBooth/git-moves-together/commit/1dd0d5491d2081ea2c44ee460aa440fc835223ba))


### Deps

#### Fix

- Bump tokio from 1.22.0 to 1.23.0 ([`4e03da4`](https://github.com/PurpleBooth/git-moves-together/commit/4e03da4b765aabcbb31eb31a98a212f94951772d))
- Bump git2 from 0.15.0 to 0.16.0 ([`d12beb8`](https://github.com/PurpleBooth/git-moves-together/commit/d12beb8d68473533646ada223f8cfbcbb88011fc))
- Bump tokio from 1.23.0 to 1.24.1 ([`4681baf`](https://github.com/PurpleBooth/git-moves-together/commit/4681baf57069a0749c39acdf7c7123a56d521f2b))


