### PR TITLE
fix: Update git-moves-together to v2.5.49

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.46.tar.gz"
-  sha256 "3c0f61ea909ef258f6e90ba37def272415e3d7c4d3e61b50966ce08deb83cf90"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.46"
-    sha256 cellar: :any,                 monterey:     "6296e2fec5da27e0cc19e27fd29caf2fd566490e0e01ae2327e58b6dceb884a9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ab42ba1de1d905adc3b06cf4606c2b5a97143381d59e0abf8e8d1ac2855bef46"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.49.tar.gz"
+  sha256 "5646ad19f9634c496c18258fa6b6ab42d7954bf21a62c01c8c5e9d95dfbd0864"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.49](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.49) (2023-01-18)

### Deploy

#### Build

- Versio update versions ([`1d6d77e`](https://github.com/PurpleBooth/git-moves-together/commit/1d6d77e586448a35fb9a606ebc1eb44a9748dcc9))


### Deps

#### Fix

- Bump tokio from 1.24.1 to 1.24.2 ([`6215bd0`](https://github.com/PurpleBooth/git-moves-together/commit/6215bd0397e5763e3285e32b8353840b5cc55a6d))


