### PR TITLE
fix: Update git-mit to v5.12.122

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.112.tar.gz"
-  sha256 "f0d105b020ccfbc8bf5cd0d45df787c0e5d095cf76c232f789ffbafd3dd4ba3e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.112"
-    sha256 cellar: :any,                 monterey:     "5b22d17a58f6e7d89b3ac2fd4460711196a80433d3ee60add7ec009f3c0e5941"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "71ee3d8bb6ea715a133b9726e4d532ad61ac95941f3555de30328ba28a8e0505"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.122.tar.gz"
+  sha256 "47f1e2aef441f82d311a0e15a02722a52f36b583ac74174f8264a42bae09a217"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.122](https://github.com/PurpleBooth/git-mit/compare/...v5.12.122) (2023-01-18)

### Deploy

#### Build

- Versio update versions ([`e819a0e`](https://github.com/PurpleBooth/git-mit/commit/e819a0e25f27fccc343a8c5f93c682a1a2751ca1))


### Deps

#### Fix

- Bump tokio from 1.24.1 to 1.24.2 ([`98d4665`](https://github.com/PurpleBooth/git-mit/commit/98d46657e540880fc654b62f3104a228b40f4e57))


