### PR TITLE
fix: Update git-mit to v5.12.123

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.112.tar.gz"
-  sha256 "f0d105b020ccfbc8bf5cd0d45df787c0e5d095cf76c232f789ffbafd3dd4ba3e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.112"
-    sha256 cellar: :any,                 monterey:     "5b22d17a58f6e7d89b3ac2fd4460711196a80433d3ee60add7ec009f3c0e5941"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "71ee3d8bb6ea715a133b9726e4d532ad61ac95941f3555de30328ba28a8e0505"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.123.tar.gz"
+  sha256 "2b16f1536b6fdce38cbce06f9d0b2f9264cbf0dbac79eb897f2b57f54d62c463"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.123](https://github.com/PurpleBooth/git-mit/compare/...v5.12.123) (2023-01-20)

### Deploy

#### Build

- Versio update versions ([`ef4a806`](https://github.com/PurpleBooth/git-mit/commit/ef4a80647df1d46c54a610ed3039b3b6bdd7ed37))


### Deps

#### Fix

- Bump serde_yaml from 0.9.16 to 0.9.17 ([`90187c4`](https://github.com/PurpleBooth/git-mit/commit/90187c4c5acce682dd1827ceaffc222595019248))
- Bump which from 4.3.0 to 4.4.0 ([`1515264`](https://github.com/PurpleBooth/git-mit/commit/15152647e2407d5f3ed39d34fc830a765924c66c))


