### PR TITLE
fix: Update git-mit to v5.12.124

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.112.tar.gz"
-  sha256 "f0d105b020ccfbc8bf5cd0d45df787c0e5d095cf76c232f789ffbafd3dd4ba3e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.112"
-    sha256 cellar: :any,                 monterey:     "5b22d17a58f6e7d89b3ac2fd4460711196a80433d3ee60add7ec009f3c0e5941"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "71ee3d8bb6ea715a133b9726e4d532ad61ac95941f3555de30328ba28a8e0505"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.124.tar.gz"
+  sha256 "6868abafae50f426401caf2e84c986140725d9e0c03ccf9ab0e45d5f6d677f9c"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.124](https://github.com/PurpleBooth/git-mit/compare/...v5.12.124) (2023-01-20)

### Deploy

#### Build

- Versio update versions ([`cfb323a`](https://github.com/PurpleBooth/git-mit/commit/cfb323aecf80b40b84376af84d283b4d336ed352))


### Deps

#### Fix

- Bump toml from 0.5.10 to 0.5.11 ([`d86f32e`](https://github.com/PurpleBooth/git-mit/commit/d86f32e2254ce1cb5d84d7778fe5e738927c8673))


