### PR TITLE
fix: Update git-moves-together to v2.5.50

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.46.tar.gz"
-  sha256 "3c0f61ea909ef258f6e90ba37def272415e3d7c4d3e61b50966ce08deb83cf90"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.46"
-    sha256 cellar: :any,                 monterey:     "6296e2fec5da27e0cc19e27fd29caf2fd566490e0e01ae2327e58b6dceb884a9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ab42ba1de1d905adc3b06cf4606c2b5a97143381d59e0abf8e8d1ac2855bef46"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.50.tar.gz"
+  sha256 "5ed627aaae6c619aec5131e6d054dbd674d18b0663a5aef52c620ab465c14234"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.50](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.50) (2023-01-21)

### Deploy

#### Build

- Versio update versions ([`d454f05`](https://github.com/PurpleBooth/git-moves-together/commit/d454f05563908c989fa6ab850ab0511d1c77ab0c))


### Deps

#### Fix

- Bump libgit2-sys from 0.14.1+1.5.0 to 0.14.2+1.5.1 ([`13a3a86`](https://github.com/PurpleBooth/git-moves-together/commit/13a3a866ada8d73cdf501f972d33b876df94105b))


