### PR TITLE
fix: Update git-moves-together to v2.5.51

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.50.tar.gz"
-  sha256 "5ed627aaae6c619aec5131e6d054dbd674d18b0663a5aef52c620ab465c14234"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.50"
-    sha256 cellar: :any,                 monterey:     "e2fca73ed41bb2334613e36c1a3d6a8bf464db5f9edd63bcc7523818e23b2f32"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "589197202c937b0d4670d127431dcdd3275da400803cd5fce2bd4ef3d67c6a3f"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.51.tar.gz"
+  sha256 "2741302793fb9074f7a02bc936fbcd6b02f0603060f3664658ba0346606968ee"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.51](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.51) (2023-01-21)

### Deploy

#### Build

- Versio update versions ([`e3e6389`](https://github.com/PurpleBooth/git-moves-together/commit/e3e63896fb1fa5d3515e5bf7931aeb23abd7686f))


### Deps

#### Fix

- Bump git2 from 0.16.0 to 0.16.1 ([`d2ee5f6`](https://github.com/PurpleBooth/git-moves-together/commit/d2ee5f6510e6abd124d1bae625a00489da17af8e))


