### PR TITLE
fix: Update git-mit to v5.12.125

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.124.tar.gz"
-  sha256 "6868abafae50f426401caf2e84c986140725d9e0c03ccf9ab0e45d5f6d677f9c"
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.125.tar.gz"
+  sha256 "03e4b1a3c5712c7b3042773e21b9573088739b34b29aef389106d43c5aa6b353"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.125](https://github.com/PurpleBooth/git-mit/compare/...v5.12.125) (2023-01-21)

### Deploy

#### Build

- Versio update versions ([`197f946`](https://github.com/PurpleBooth/git-mit/commit/197f94667295800a1750175f73d53f63d3ffb59a))


### Deps

#### Fix

- Bump libgit2-sys from 0.14.1+1.5.0 to 0.14.2+1.5.1 ([`88e8e36`](https://github.com/PurpleBooth/git-mit/commit/88e8e36e1c0a34388a019f52067180c85f4db909))
- Bump git2 from 0.16.0 to 0.16.1 ([`1ad6b78`](https://github.com/PurpleBooth/git-mit/commit/1ad6b78a3e262a21d12e6e5105a4e638bd8214c9))


