### PR TITLE
fix: Update git-moves-together to v2.5.52

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.51.tar.gz"
-  sha256 "2741302793fb9074f7a02bc936fbcd6b02f0603060f3664658ba0346606968ee"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.51"
-    sha256 cellar: :any,                 monterey:     "bde091fdfec91beaf9793ecbef7d8556cf58eed5fabf597410483e16d01e9b01"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e184eaa24c44a96b64a48373d5115aa61fd284d30d2174ba34816fb8385333c4"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.52.tar.gz"
+  sha256 "e9d04f863bfb5d20bc26b17c250c886ada6103c276d29854f28a760de3b0a220"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.52](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.52) (2023-01-24)

### Deploy

#### Build

- Versio update versions ([`0309ce8`](https://github.com/PurpleBooth/git-moves-together/commit/0309ce8dae5a5e0aa212637aedef586e8fe95d74))


### Deps

#### Fix

- Bump clap from 4.1.1 to 4.1.3 ([`7fd9baa`](https://github.com/PurpleBooth/git-moves-together/commit/7fd9baa9df50a7d307c03822558921c6d217f738))


