### PR TITLE
fix: Update git-mit to v5.12.127

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.126.tar.gz"
-  sha256 "f8655b91370dc9c24b7b9e13f6841861a01ee10dd407e3573cc2b2114415d86b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.126"
-    sha256 cellar: :any,                 monterey:     "82df983dd449ab0817ddbd69afd2b5b73232e74a72c1d82243c39d0a70da404f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a9b01dc5fedcba3cc7d4cda58253e760f95315b9cc6bc989df221a8944cab2cc"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.127.tar.gz"
+  sha256 "18b8f60038a3aa78972b84c8a8ec7792a50d3b33296cd7e60e4cba2ef8afd814"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.127](https://github.com/PurpleBooth/git-mit/compare/...v5.12.127) (2023-01-24)

### Deploy

#### Build

- Versio update versions ([`647d1e0`](https://github.com/PurpleBooth/git-mit/commit/647d1e0ab12f460f10c37671f80536d6fc739c91))


### Deps

#### Fix

- Bump clap from 4.1.1 to 4.1.3 ([`b599ca4`](https://github.com/PurpleBooth/git-mit/commit/b599ca49419e3ea000f58e974daa6c551a2d8c8a))


