### PR TITLE
fix: Update git-mit to v5.12.128

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.127.tar.gz"
-  sha256 "18b8f60038a3aa78972b84c8a8ec7792a50d3b33296cd7e60e4cba2ef8afd814"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.127"
-    sha256 cellar: :any,                 monterey:     "a656f1f28b6390c4702b7b3f92d8faaaf874b1e6a7cbad72b794d313150a7a65"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9b4621bb9802cfbc0f7dbc23172cb7acbc0ca9a44896578efb8ae2e7dc10a2cb"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.128.tar.gz"
+  sha256 "374c3706d3dcfd77e6ee0749bd133109147d3d7cf2e2dc0751843e0d2d7b6113"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.128](https://github.com/PurpleBooth/git-mit/compare/...v5.12.128) (2023-01-25)

### Deploy

#### Build

- Versio update versions ([`f54262e`](https://github.com/PurpleBooth/git-mit/commit/f54262e359820a27ce77b55c3e2f5ff4f1e95a94))


### Deps

#### Fix

- Bump clap from 4.1.3 to 4.1.4 ([`5ca74dc`](https://github.com/PurpleBooth/git-mit/commit/5ca74dca34333f9d68ab0b414be15c55c91c417a))


