### PR TITLE
fix: Update git-mit to v5.12.129

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.128.tar.gz"
-  sha256 "374c3706d3dcfd77e6ee0749bd133109147d3d7cf2e2dc0751843e0d2d7b6113"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.128"
-    sha256 cellar: :any,                 monterey:     "e216ed585b5164662a8024fb6bdcb9ab6ba7eddc2abdb02fb9a08ae102b011ca"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f01c81253195d77d8fdc75d2f0ebda984d717bde1a3ff2dbc4311c7b113a6339"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.129.tar.gz"
+  sha256 "363a954ca586aedcb3570331cd203f149c35ec46de2ebaca3716e7e7146bcc9a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.129](https://github.com/PurpleBooth/git-mit/compare/...v5.12.129) (2023-01-27)

### Deploy

#### Build

- Versio update versions ([`8ef99dd`](https://github.com/PurpleBooth/git-mit/commit/8ef99ddd1bf6366ab8c626ddb24d41d644255b16))


### Deps

#### Fix

- Bump rust from 1.66.0 to 1.67.0 ([`70cb6b3`](https://github.com/PurpleBooth/git-mit/commit/70cb6b340d5bca124b687385b57ea2d9567428cf))


