### PR TITLE
fix: Update readable-name-generator to v2.100.49

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.44.tar.gz"
-  sha256 "a8c088112ed12145daf2fe2e2e413486d513d44e84893d91fa64d75e544bc266"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "36e87d3a65501127d04f6e48ef2819107d101f7388df54f75708cbbcd69abfb7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7cfff5433328659f5c2e2acc4f2320d5f5d4d6fe8ccf47f9cc62743a7f13b4c0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.49.tar.gz"
+  sha256 "d457e8a0e589043bcc3dc774ef256d3b00aa35fa0200da4016ccd20d58bd3c06"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.49](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.49) (2023-01-27)

### Deploy

#### Build

- Versio update versions ([`5007999`](https://github.com/PurpleBooth/readable-name-generator/commit/50079999817ef59e799f18ccaddba7929ae4744c))


### Deps

#### Fix

- Bump rust from 1.66.1 to 1.67.0 ([`e06f4f1`](https://github.com/PurpleBooth/readable-name-generator/commit/e06f4f1c7998bf75aa0749b3905934dde38a7e8b))


