### PR TITLE
fix: Update git-mit to v5.12.131

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.130.tar.gz"
-  sha256 "312f501015f29b848c0ffa851c5242b406c4c286b5a07960b2270274f313d298"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.130"
-    sha256 cellar: :any,                 monterey:     "1ddc20879a23af10528b5c1e2448247b1aadec10f83a676e2fd833b98bb81477"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b62c95170e95b8b03e68e0fbdf5633c8ca21c4cc5b6a4cec1cc1cdb0c8059364"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.131.tar.gz"
+  sha256 "5073ee8dbbd47bc7906c04bb2e5bf3e0433df0ca5aea9f14ea75b5e661674b2f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.131](https://github.com/PurpleBooth/git-mit/compare/...v5.12.131) (2023-01-30)

### Deploy

#### Build

- Versio update versions ([`e0e983e`](https://github.com/PurpleBooth/git-mit/commit/e0e983e5b88f09edb57df2b1843c4133aa99d934))


### Deps

#### Fix

- Bump tokio from 1.24.2 to 1.25.0 ([`cff2755`](https://github.com/PurpleBooth/git-mit/commit/cff27557ee5801055c16dd912666b78f8c5255a7))
- Bump mit-commit from 3.1.4 to 3.1.5 ([`d809ea9`](https://github.com/PurpleBooth/git-mit/commit/d809ea9a35e8fd8b5be0113cd804092f2ee811b4))


