### PR TITLE
fix: Update git-moves-together to v2.5.53

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,13 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.52.tar.gz"
-  sha256 "e9d04f863bfb5d20bc26b17c250c886ada6103c276d29854f28a760de3b0a220"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.52"
-    sha256 cellar: :any, monterey: "87d71540df6915d9dc1c2bcd98877e42661494d26ec3fba465961e55dfbeea66"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.53.tar.gz"
+  sha256 "aad08a4b93bd0ba821e655ae5f9235fb00a0bef0550ff62a81a4f17f0673b582"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.53](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.53) (2023-01-31)

### Deploy

#### Build

- Versio update versions ([`3024766`](https://github.com/PurpleBooth/git-moves-together/commit/30247667ebffd04ff4745052d69402fefd2822bb))


### Deps

#### Fix

- Bump clap from 4.1.3 to 4.1.4 ([`9b9890a`](https://github.com/PurpleBooth/git-moves-together/commit/9b9890ad9017463a48da85450788ab2196d4d926))
- Bump tokio from 1.24.2 to 1.25.0 ([`e9da479`](https://github.com/PurpleBooth/git-moves-together/commit/e9da479d6b45a56b00152882e6b7f67d6d3b89da))
- Bump futures from 0.3.25 to 0.3.26 ([`12d9119`](https://github.com/PurpleBooth/git-moves-together/commit/12d911916c00a978dce9def0d8ccec88c7cdf91b))


