### PR TITLE
fix: Update git-mit to v5.12.132

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.131.tar.gz"
-  sha256 "5073ee8dbbd47bc7906c04bb2e5bf3e0433df0ca5aea9f14ea75b5e661674b2f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.131"
-    sha256 cellar: :any,                 monterey:     "e59a78a7375120191e2bc91264409cec3faab2b9c449e91cc666a988e33883d8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3e63a8917b738273809f1c113aea3b4ceb4554fbb21ce0ee39dee54eaf12a0d7"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
+  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.132](https://github.com/PurpleBooth/git-mit/compare/...v5.12.132) (2023-01-31)

### Deploy

#### Build

- Versio update versions ([`aaff747`](https://github.com/PurpleBooth/git-mit/commit/aaff74731a1d10298801d61c23d22d2f20abe1ff))


### Deps

#### Fix

- Bump mit-lint from 3.2.2 to 3.2.3 ([`9444de9`](https://github.com/PurpleBooth/git-mit/commit/9444de9945c6fc671699bf6295813ed38d5ca5c9))


