### PR TITLE
fix: Update git-mit to v5.12.133

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.133.tar.gz"
+  sha256 "6be8ea39c798d9062cbe46a9fa35a8d7a4c4aaa028f3fdd5b747aeaec69e3a38"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.133](https://github.com/PurpleBooth/git-mit/compare/...v5.12.133) (2023-02-08)

### Deploy

#### Build

- Versio update versions ([`aa6937d`](https://github.com/PurpleBooth/git-mit/commit/aa6937dc8a33485728a7d05bd84ddf4d179aa746))


### Deps

#### Fix

- Bump openssl-src from 111.24.0+1.1.1s to 111.25.0+1.1.1t ([`435ef89`](https://github.com/PurpleBooth/git-mit/commit/435ef8962665624acc453afcd8d7c1d3ee24b9a6))


