### PR TITLE
fix: Update git-moves-together to v2.5.54

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,14 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.53.tar.gz"
-  sha256 "aad08a4b93bd0ba821e655ae5f9235fb00a0bef0550ff62a81a4f17f0673b582"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.53"
-    sha256 cellar: :any,                 monterey:     "075f22032b4560c26a25f56ce13277996b7aa5f6045d48ac60b525c8653d5544"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3f7fc2e7e742b210003730d4118d21f644c47b22d4f7e4647f0241ce26b7c008"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.54.tar.gz"
+  sha256 "42d393525044cbcc8040ae736287e45cf0d47b6295bb29bc5ae6cd36f7349c4e"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.54](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.54) (2023-02-16)

### Deploy

#### Build

- Versio update versions ([`7b7cb56`](https://github.com/PurpleBooth/git-moves-together/commit/7b7cb56402e6778c3a7ab5d186f88f13e600eb0a))


### Deps

#### Fix

- Bump clap from 4.1.4 to 4.1.6 ([`6a4774a`](https://github.com/PurpleBooth/git-moves-together/commit/6a4774ab214cc497ab99b6192e61d51d3c058767))
- Bump time from 0.3.17 to 0.3.18 ([`0bc75b3`](https://github.com/PurpleBooth/git-moves-together/commit/0bc75b3b21c2172759217959ea98d26563714947))


