### PR TITLE
fix: Update git-mit to v5.12.134

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.134.tar.gz"
+  sha256 "4fb5596185efc81afbed675f9e6cb09d5617c400975aa4ce3dbd6a19da657953"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.134](https://github.com/PurpleBooth/git-mit/compare/...v5.12.134) (2023-02-16)

### Deploy

#### Build

- Versio update versions ([`6d760ad`](https://github.com/PurpleBooth/git-mit/commit/6d760ade18b745fa00367a48b9365af5503c90b9))


### Deps

#### Fix

- Bump time from 0.3.17 to 0.3.18 ([`8d82447`](https://github.com/PurpleBooth/git-mit/commit/8d82447bdf4103fd9b99384d856707d208717c1b))


