### PR TITLE
fix: Update git-mit to v5.12.135

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.135.tar.gz"
+  sha256 "e4154fad93a2a778225490bb5fa88b61fdb51740f4e03f89ea60ebda09733b2c"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.135](https://github.com/PurpleBooth/git-mit/compare/...v5.12.135) (2023-02-16)

### Deploy

#### Build

- Versio update versions ([`31910ed`](https://github.com/PurpleBooth/git-mit/commit/31910edbc323af282d45ef29f83c67fbf52ba5f2))


### Deps

#### Fix

- Bump rust from 1.67.0 to 1.67.1 ([`333f293`](https://github.com/PurpleBooth/git-mit/commit/333f293497337aaad499fff0c66d9e823af47810))


