### PR TITLE
fix: Update git-mit to v5.12.136

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.136.tar.gz"
+  sha256 "42222a4bfe45cc728aedbea8ea020ea7254f7f790b6ceec44c0710ba7d3dac4a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.136](https://github.com/PurpleBooth/git-mit/compare/...v5.12.136) (2023-02-17)

### Deploy

#### Build

- Versio update versions ([`2bff705`](https://github.com/PurpleBooth/git-mit/commit/2bff705a94a6864d97ebef478c2802b28a50c5a9))


### Deps

#### Fix

- Bump time from 0.3.18 to 0.3.19 ([`60e0783`](https://github.com/PurpleBooth/git-mit/commit/60e078351b8f1b0556e67cc91711a446982bc514))


