### PR TITLE
fix: Update git-mit to v5.12.137

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.137.tar.gz"
+  sha256 "0c7150d4ba5075975fff77c39fa3e0d97aabd2d2e6a4bc8c7af17b1315e3da7b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.137](https://github.com/PurpleBooth/git-mit/compare/...v5.12.137) (2023-02-17)

### Deploy

#### Build

- Versio update versions ([`2daaf8a`](https://github.com/PurpleBooth/git-mit/commit/2daaf8a88ec7dc629ebe42c512d2ef98b7447ecd))


### Deps

#### Fix

- Bump clap_complete from 4.1.1 to 4.1.2 ([`9e2c3b8`](https://github.com/PurpleBooth/git-mit/commit/9e2c3b820c6efc07c31eb370ad4df69514544fff))
- Bump clap from 4.1.4 to 4.1.6 ([`a9294c9`](https://github.com/PurpleBooth/git-mit/commit/a9294c93110ff651ac2071227097680999b2f693))


