### PR TITLE
fix: Update git-mit to v5.12.138

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.138.tar.gz"
+  sha256 "e47fbf8ac37309caecc8c7f93de653d59644a672c6a1f5f02f116c97df3ba6db"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.138](https://github.com/PurpleBooth/git-mit/compare/...v5.12.138) (2023-02-24)

### Deploy

#### Build

- Versio update versions ([`f53c7a8`](https://github.com/PurpleBooth/git-mit/commit/f53c7a87f610ef554cc0c43622e4fd5a52279c74))


### Deps

#### Ci

- Bump PurpleBooth/common-pipelines from 0.4.5 to 0.6.50 ([`f28a83b`](https://github.com/PurpleBooth/git-mit/commit/f28a83bbaf4252564425aedc7496170b1c4f4d36))

#### Fix

- Bump clap_complete from 4.1.2 to 4.1.3 ([`a66f609`](https://github.com/PurpleBooth/git-mit/commit/a66f609f0192009ab1c0f542f2d614499e68f905))


