### PR TITLE
fix: Update git-moves-together to v2.5.57

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,13 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.55.tar.gz"
-  sha256 "fecc3822a1ecb57095a50887bb5b5e9ad7654289e38b3fe8f77b34bc14fcf2dc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.55"
-    sha256 cellar: :any, monterey: "d67921fa4daf42d9967b9145c8343813d403290b51b195d60f79cf1646c2222c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.57.tar.gz"
+  sha256 "9c737e352f279393402bdc7bc42b941a186df1b0fbae82e8c6509c859f30bf1a"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.57](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.57) (2023-02-27)

### Deploy

#### Build

- Versio update versions ([`6ad3aca`](https://github.com/PurpleBooth/git-moves-together/commit/6ad3acae2dbc86e22cf278773fa64da61c3884c3))


### Deps

#### Fix

- Bump time from 0.3.19 to 0.3.20 ([`15336e9`](https://github.com/PurpleBooth/git-moves-together/commit/15336e94ad0015ac48b1f931e396dfa06690f19f))


