### PR TITLE
fix: Update readable-name-generator to v2.100.50

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.44.tar.gz"
-  sha256 "a8c088112ed12145daf2fe2e2e413486d513d44e84893d91fa64d75e544bc266"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "36e87d3a65501127d04f6e48ef2819107d101f7388df54f75708cbbcd69abfb7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7cfff5433328659f5c2e2acc4f2320d5f5d4d6fe8ccf47f9cc62743a7f13b4c0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.50.tar.gz"
+  sha256 "2f1f92106edc8f31a75b3a28ddbb39e8a6e87ea259b28be815c6bf2f0311ad86"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.50](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.50) (2023-02-28)

### Deploy

#### Build

- Versio update versions ([`4addc96`](https://github.com/PurpleBooth/readable-name-generator/commit/4addc96bfbca7c66b8c47f3f08c40d395274f5d8))


### Deps

#### Ci

- Bump PurpleBooth/common-pipelines from 0.4.5 to 0.6.50 ([`e63691d`](https://github.com/PurpleBooth/readable-name-generator/commit/e63691d47a047b10b24414f3cefbe5191acdc142))

#### Fix

- Bump rust from 1.67.0 to 1.67.1 ([`248316d`](https://github.com/PurpleBooth/readable-name-generator/commit/248316d80d62b35e323ec5593241f72337fa39d3))


