### PR TITLE
fix: Update git-moves-together to v2.5.58

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,13 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.55.tar.gz"
-  sha256 "fecc3822a1ecb57095a50887bb5b5e9ad7654289e38b3fe8f77b34bc14fcf2dc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.55"
-    sha256 cellar: :any, monterey: "d67921fa4daf42d9967b9145c8343813d403290b51b195d60f79cf1646c2222c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.58.tar.gz"
+  sha256 "fe5eb4c28faf007ad41bb8b59d10eae65a95a612b4b0620575b89adc18e2127f"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.58](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.58) (2023-03-01)

### Deploy

#### Build

- Versio update versions ([`02a76d5`](https://github.com/PurpleBooth/git-moves-together/commit/02a76d5b0c1231b59ba4e7413772fb1b0445867d))


### Deps

#### Fix

- Bump clap from 4.1.6 to 4.1.8 ([`e82980b`](https://github.com/PurpleBooth/git-moves-together/commit/e82980b5f0bb0c23cd21ea41fb51308933f96243))


