### PR TITLE
fix: Update git-mit to v5.12.139

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.139.tar.gz"
+  sha256 "0414d03eabaa77049a5e9f8351a11bce532f017170a1298a6b1dba83d2f79b35"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.139](https://github.com/PurpleBooth/git-mit/compare/...v5.12.139) (2023-03-01)

### Deploy

#### Build

- Versio update versions ([`e83f28b`](https://github.com/PurpleBooth/git-mit/commit/e83f28baae1b2a6eb1530d2e13b79702ab855245))


### Deps

#### Fix

- Bump clap from 4.1.6 to 4.1.8 ([`5eb635f`](https://github.com/PurpleBooth/git-mit/commit/5eb635fba7e782e3c3fb6777db52db1c2ce4e9d8))


