### PR TITLE
fix: Update git-mit to v5.12.140

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.140.tar.gz"
+  sha256 "b29a2e682afff681a5736d31ee8de29353aa1cf7c56713628d6eeaad19cbe90a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.140](https://github.com/PurpleBooth/git-mit/compare/...v5.12.140) (2023-03-01)

### Deploy

#### Build

- Versio update versions ([`b878d59`](https://github.com/PurpleBooth/git-mit/commit/b878d59c10a65c0672ae9c67a1b44cf523a918d5))


### Deps

#### Fix

- Bump time from 0.3.19 to 0.3.20 ([`26ff136`](https://github.com/PurpleBooth/git-mit/commit/26ff136bc11c40786f5a826289fcd322a9888388))
- Bump tempfile from 3.3.0 to 3.4.0 ([`084ecac`](https://github.com/PurpleBooth/git-mit/commit/084ecac2eae752d2570cfe2411315dfaf2aac0a9))


