### PR TITLE
fix: Update git-mit to v5.12.141

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.141.tar.gz"
+  sha256 "69296e3cedbc88f4cdecb6d5d7f5a6a5cd01a696f34b7d2652be6a62fcb1948a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.141](https://github.com/PurpleBooth/git-mit/compare/...v5.12.141) (2023-03-01)

### Deploy

#### Build

- Versio update versions ([`814e80d`](https://github.com/PurpleBooth/git-mit/commit/814e80d9caec74fcf4869483855ff56d0684f301))


### Deps

#### Fix

- Bump clap_complete from 4.1.3 to 4.1.4 ([`0701555`](https://github.com/PurpleBooth/git-mit/commit/0701555b151cea2b20fe9f9b7656440c22603841))


