### PR TITLE
fix: Update git-moves-together to v2.5.59

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,13 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.55.tar.gz"
-  sha256 "fecc3822a1ecb57095a50887bb5b5e9ad7654289e38b3fe8f77b34bc14fcf2dc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.55"
-    sha256 cellar: :any, monterey: "d67921fa4daf42d9967b9145c8343813d403290b51b195d60f79cf1646c2222c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.59.tar.gz"
+  sha256 "abf7b92976abe6e3d0e430dcf50ee00e5cb39499ad04336f540a9c0508edf502"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.59](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.59) (2023-03-02)

### Deploy

#### Build

- Versio update versions ([`f0ea550`](https://github.com/PurpleBooth/git-moves-together/commit/f0ea55017b757c369ed3984a59c502fd87a98049))


### Deps

#### Fix

- Bump tokio from 1.25.0 to 1.26.0 ([`a8c88ed`](https://github.com/PurpleBooth/git-moves-together/commit/a8c88ed1c4ef4cde81f7d4430d1df993ce99c63e))


