### PR TITLE
fix: Update git-mit to v5.12.142

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.142.tar.gz"
+  sha256 "52fbe5ac135d8e3cc914e015443b11214b503d049c11b380da5c8dd175e88d1b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.142](https://github.com/PurpleBooth/git-mit/compare/...v5.12.142) (2023-03-02)

### Deploy

#### Build

- Versio update versions ([`d69fcce`](https://github.com/PurpleBooth/git-mit/commit/d69fcce053e8dce486863f8dc5afea87917ccd7f))


### Deps

#### Ci

- Bump PurpleBooth/common-pipelines from 0.6.50 to 0.6.51 ([`7c5e5d0`](https://github.com/PurpleBooth/git-mit/commit/7c5e5d00043ce27a741de280d305ec7178c0ce3a))

#### Fix

- Bump tokio from 1.25.0 to 1.26.0 ([`e9c197a`](https://github.com/PurpleBooth/git-mit/commit/e9c197a84369bca46a270b66f813bc19fcc50ec1))


