### PR TITLE
fix: Update git-moves-together to v2.5.60

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,13 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.55.tar.gz"
-  sha256 "fecc3822a1ecb57095a50887bb5b5e9ad7654289e38b3fe8f77b34bc14fcf2dc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.55"
-    sha256 cellar: :any, monterey: "d67921fa4daf42d9967b9145c8343813d403290b51b195d60f79cf1646c2222c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.60.tar.gz"
+  sha256 "9894f7babbfc970ac58b5f9da34ce084b87652d628eab6ed8a32a8519c6b1cc0"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.60](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.60) (2023-03-06)

### Deploy

#### Build

- Versio update versions ([`64c2c56`](https://github.com/PurpleBooth/git-moves-together/commit/64c2c56f36a02fc3039bb989cd7fbd45a136c8a6))


### Deps

#### Fix

- Bump thiserror from 1.0.38 to 1.0.39 ([`5b04fda`](https://github.com/PurpleBooth/git-moves-together/commit/5b04fdaaf13220df080d1c8f76eeb98be3073e89))


