### PR TITLE
fix: Update git-mit to v5.12.143

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.143.tar.gz"
+  sha256 "604e2e25c3359a50caa62250103f57c14c5a67acd614478fe7e057a95bcf21b0"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.143](https://github.com/PurpleBooth/git-mit/compare/...v5.12.143) (2023-03-06)

### Deploy

#### Build

- Versio update versions ([`7c8de0e`](https://github.com/PurpleBooth/git-mit/commit/7c8de0e3e9e3b8c3d8c6fe43f2e04b053f12952e))


### Deps

#### Fix

- Bump indoc from 2.0.0 to 2.0.1 ([`cdb0305`](https://github.com/PurpleBooth/git-mit/commit/cdb03053fb828e175a0d7aea5f1d1655c8124d4b))


