### PR TITLE
fix: Update git-mit to v5.12.144

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.144.tar.gz"
+  sha256 "e421b4487efe939d9501b7013faf485993520dfd383aef4e216e85ee554db25e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.144](https://github.com/PurpleBooth/git-mit/compare/...v5.12.144) (2023-03-06)

### Deploy

#### Build

- Versio update versions ([`cb21240`](https://github.com/PurpleBooth/git-mit/commit/cb212403e57f1b684658c3703e7ed4292bcc97b1))


### Deps

#### Fix

- Bump thiserror from 1.0.38 to 1.0.39 ([`4665270`](https://github.com/PurpleBooth/git-mit/commit/46652705ebc5a483ae765cfa3f0b92948356ef78))
- Bump serde_yaml from 0.9.17 to 0.9.19 ([`6e36875`](https://github.com/PurpleBooth/git-mit/commit/6e368759f5ad466b3178a71f49a6ba3dad79a7cd))


