### PR TITLE
fix: Update readable-name-generator to v2.100.51

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.44.tar.gz"
-  sha256 "a8c088112ed12145daf2fe2e2e413486d513d44e84893d91fa64d75e544bc266"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "36e87d3a65501127d04f6e48ef2819107d101f7388df54f75708cbbcd69abfb7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7cfff5433328659f5c2e2acc4f2320d5f5d4d6fe8ccf47f9cc62743a7f13b4c0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.51.tar.gz"
+  sha256 "4d4477d2abd7d0ae6e66cc22f46b929386cce5c15695e54a388ab3d90356d7b6"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.51](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.51) (2023-03-07)

### Deploy

#### Build

- Versio update versions ([`c4932ef`](https://github.com/PurpleBooth/readable-name-generator/commit/c4932efe4d75a8cb758ba01dd8df0bf7e9f5e16b))


### Deps

#### Ci

- Bump PurpleBooth/common-pipelines from 0.6.50 to 0.6.51 ([`7fa5500`](https://github.com/PurpleBooth/readable-name-generator/commit/7fa550044c250379d0f832cbce2c4b2caf6c1596))

#### Fix

- Bump thiserror from 1.0.38 to 1.0.39 ([`f67f6ea`](https://github.com/PurpleBooth/readable-name-generator/commit/f67f6ea5da40c11c09aaf601eb40e1b624ff2994))


