### PR TITLE
fix: Update readable-name-generator to v2.100.52

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.44.tar.gz"
-  sha256 "a8c088112ed12145daf2fe2e2e413486d513d44e84893d91fa64d75e544bc266"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "36e87d3a65501127d04f6e48ef2819107d101f7388df54f75708cbbcd69abfb7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7cfff5433328659f5c2e2acc4f2320d5f5d4d6fe8ccf47f9cc62743a7f13b4c0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.52.tar.gz"
+  sha256 "3fbc5d6854a66ef3f87aaaaf3789cd07500f975ddd8703db6b6dce29f38da66f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.52](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.52) (2023-03-10)

### Deploy

#### Build

- Versio update versions ([`df1d82d`](https://github.com/PurpleBooth/readable-name-generator/commit/df1d82d1c846bd2879abf01a17b7a13206821d97))


### Deps

#### Ci

- Bump PurpleBooth/common-pipelines from 0.6.51 to 0.6.52 ([`1a3570a`](https://github.com/PurpleBooth/readable-name-generator/commit/1a3570aef0b942ebc8007aa4b151c2f89392033f))

#### Fix

- Bump rust from 1.67.1 to 1.68.0 ([`8679ba3`](https://github.com/PurpleBooth/readable-name-generator/commit/8679ba3ef3bfa45e99aca298f865c8fe195bc7a9))


