### PR TITLE
fix: Update git-moves-together to v2.5.61

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,13 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.55.tar.gz"
-  sha256 "fecc3822a1ecb57095a50887bb5b5e9ad7654289e38b3fe8f77b34bc14fcf2dc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.55"
-    sha256 cellar: :any, monterey: "d67921fa4daf42d9967b9145c8343813d403290b51b195d60f79cf1646c2222c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.61.tar.gz"
+  sha256 "e0881c0f8be2696777eb42c2541a7f2bcc757da231aa6b5adb6f94573a72c8a9"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.61](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.61) (2023-03-13)

### Deploy

#### Build

- Versio update versions ([`71781f5`](https://github.com/PurpleBooth/git-moves-together/commit/71781f59a6b27bef33a33b668caa844591e60539))


### Deps

#### Fix

- Bump futures from 0.3.26 to 0.3.27 ([`04a7e35`](https://github.com/PurpleBooth/git-moves-together/commit/04a7e3582d69afde62b1ff555786fe2cf5cb4b59))


