### PR TITLE
fix: Update git-moves-together to v2.5.62

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,13 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.55.tar.gz"
-  sha256 "fecc3822a1ecb57095a50887bb5b5e9ad7654289e38b3fe8f77b34bc14fcf2dc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.55"
-    sha256 cellar: :any, monterey: "d67921fa4daf42d9967b9145c8343813d403290b51b195d60f79cf1646c2222c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.62.tar.gz"
+  sha256 "fb13115d71e4baf221bff4ac65c5cc86aee939ac2dfea3659f8a9810bd170f08"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.62](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.62) (2023-03-14)

### Deploy

#### Build

- Versio update versions ([`490de50`](https://github.com/PurpleBooth/git-moves-together/commit/490de50388aaaa66336c953820c08c04334e0d8b))


### Deps

#### Fix

- Bump miette from 5.5.0 to 5.6.0 ([`ce88829`](https://github.com/PurpleBooth/git-moves-together/commit/ce8882930233ac568b715669d5dddfe266a68cbc))


