### PR TITLE
fix: Update git-mit to v5.12.146

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.132.tar.gz"
-  sha256 "a763d62998c8968c8e2cddf21e4ee1d6483bcf8efe07259e548d11577e33a798"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.132"
-    sha256 cellar: :any,                 monterey:     "c96404776a64a44c38bf0d1bf3f4e4f7e88cb22f5caf2d3fd4606861d35be8cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f16fd68210f937f6ef6b1dd003115ff975eb100359d340d7c5637677a9ff1ef"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.146.tar.gz"
+  sha256 "3405a7c7e8a37a365aae8896cf6cb0031f7efcf03d2d734e08344759ad5e433c"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"
@@ -59,7 +53,7 @@ class GitMit < Formula
     output = Utils.popen_read("#{bin}/git-mit-config", "mit", "example")
     (testpath/"git-mit.toml").write output
     system "#{bin}/git-mit", "-c", "git-mit.toml", "se"
-    system "git-mit-relates-to", "#12356"
+    system "#{bin}/git-mit-relates-to", "#12356"
     system "git", "add", testpath
     system "git", "commit", "-m", "Example Commit"
     system "#{bin}/git-mit-config", "lint", "available"


### PR DESCRIPTION
## Changelog
### [v5.12.146](https://github.com/PurpleBooth/git-mit/compare/...v5.12.146) (2023-03-14)

### Deploy

#### Build

- Versio update versions ([`078104d`](https://github.com/PurpleBooth/git-mit/commit/078104d02455445ceee124485d90833f0cfd935d))


### Deps

#### Ci

- Bump PurpleBooth/common-pipelines from 0.6.52 to 0.6.53 ([`17d9376`](https://github.com/PurpleBooth/git-mit/commit/17d93760a139a2c54d54715d6166fa94b12b7850))

#### Fix

- Bump miette from 5.5.0 to 5.6.0 ([`aea0193`](https://github.com/PurpleBooth/git-mit/commit/aea01932cd5b4e7de1a8a7c5774cd538ac6bc75c))
- Bump toml from 0.7.2 to 0.7.3 ([`a1f44d1`](https://github.com/PurpleBooth/git-mit/commit/a1f44d1751e0049bd10282d0c155399930f05340))


