### PR TITLE
fix: Update readable-name-generator to v2.100.53

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.44.tar.gz"
-  sha256 "a8c088112ed12145daf2fe2e2e413486d513d44e84893d91fa64d75e544bc266"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "36e87d3a65501127d04f6e48ef2819107d101f7388df54f75708cbbcd69abfb7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7cfff5433328659f5c2e2acc4f2320d5f5d4d6fe8ccf47f9cc62743a7f13b4c0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/v2.100.53.tar.gz"
+  sha256 "11965cc1aa0dd700331a7df7cf38fbb46ed0031f6c6e79115037494312b6d0d6"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.53](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.53) (2023-09-04)

### Deps

#### Chore

- Upgrade clap ([`67f08a7`](https://github.com/PurpleBooth/readable-name-generator/commit/67f08a7fda01739c6893b0a3c6dc190c6d17d1b9))


### Version

#### Chore

- V2.100.53  ([`552f48f`](https://github.com/PurpleBooth/readable-name-generator/commit/552f48f4beb0839b1d35d341e3f6ffc07539465a))


