### PR TITLE
fix: Update git-mit to v5.12.148

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.147.tar.gz"
-  sha256 "82f62f860b34bc4691b6fc5b61e0ebe6f4a365ed59b418c43f5b329e855d684d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.147"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "73bdb58642c1d7022428cb29e32faa8eb7b568a530033acc4f3bb6d791d849e1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.148.tar.gz"
+  sha256 "8f91c2d6eb922d51a258be248e99a6be680f36c10bc6dd99c4131d9fc6589889"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.148](https://github.com/PurpleBooth/git-mit/compare/...v5.12.148) (2023-09-26)

### Deps

#### Ci

- Bump ncipollo/release-action from 1.12.0 to 1.13.0 ([`de89a9f`](https://github.com/PurpleBooth/git-mit/commit/de89a9f395e6f4a8844ed2dce192fc9b867ce7fe))
- Bump actions/checkout from 3 to 4 ([`507f10a`](https://github.com/PurpleBooth/git-mit/commit/507f10ae8e0da496bfbcd6f963e797102f2ab2bb))

#### Fix

- Bump regex from 1.9.4 to 1.9.5 ([`b8c8574`](https://github.com/PurpleBooth/git-mit/commit/b8c85749e088f330ada648d87b21d9732defd780))
- Bump thiserror from 1.0.47 to 1.0.48 ([`2fc9255`](https://github.com/PurpleBooth/git-mit/commit/2fc92552980edceeae8f908daf44be1f2b1d1781))
- Bump clap_complete from 4.4.0 to 4.4.1 ([`9a336fb`](https://github.com/PurpleBooth/git-mit/commit/9a336fb25dcd1f492dc8fcded535bb7471c9e624))
- Bump rust from 1.72.0 to 1.72.1 ([`c120932`](https://github.com/PurpleBooth/git-mit/commit/c120932aefd9232c810bf67c0e9f1f737baedd07))
- Bump git2 from 0.16.1 to 0.18.1 ([`4152d17`](https://github.com/PurpleBooth/git-mit/commit/4152d17165e76aab28edfe0756316783a03332ca))


### Version

#### Chore

- V5.12.148  ([`77e2d2a`](https://github.com/PurpleBooth/git-mit/commit/77e2d2ac3b55fe903297cc5694bebeb347802d80))


