### PR TITLE
fix: Update git-mit to v5.12.149

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.147.tar.gz"
-  sha256 "82f62f860b34bc4691b6fc5b61e0ebe6f4a365ed59b418c43f5b329e855d684d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.147"
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "238ab0bee446621d334d7174a87cde504beafb1bb677c2228799ce73666ab5cb"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.149.tar.gz"
+  sha256 "adb2b734d0b7912c4dc86498e9a9bd93d71cfc24576dba2ad60b7987d1c881fd"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.149](https://github.com/PurpleBooth/git-mit/compare/...v5.12.149) (2023-09-26)

### Deps

#### Fix

- Bump toml from 0.7.6 to 0.8.0 ([`66c94ff`](https://github.com/PurpleBooth/git-mit/commit/66c94ff4564873ecbf8d7aa4ae853595521d4db9))
- Bump criterion from 0.4.0 to 0.5.1 ([`8e7bdce`](https://github.com/PurpleBooth/git-mit/commit/8e7bdce62fcd3fff1e4617d7455c5341f793a9be))
- Bump clap_complete from 4.4.1 to 4.4.2 ([`c2eee98`](https://github.com/PurpleBooth/git-mit/commit/c2eee98eab990a02598d055255e752fc76868d7f))
- Bump clap from 4.4.1 to 4.4.5 ([`f65af73`](https://github.com/PurpleBooth/git-mit/commit/f65af732e5a5f758484f22e1c16d6c81dfb7cfd8))
- Bump comfy-table from 6.2.0 to 7.0.1 ([`4e42234`](https://github.com/PurpleBooth/git-mit/commit/4e42234fe07ff93633655c60e67a09595bf9c518))


### Version

#### Chore

- V5.12.149  ([`eaadd9d`](https://github.com/PurpleBooth/git-mit/commit/eaadd9dd52165c1beeba8b94de7452fc9b920b14))


