### PR TITLE
fix: Update git-mit to v5.12.150

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.149.tar.gz"
-  sha256 "adb2b734d0b7912c4dc86498e9a9bd93d71cfc24576dba2ad60b7987d1c881fd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.149"
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "cd964ab46f4ca291efdddea71b5285ec09660fc0f4381260cd643b1cbbce2a3e"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.150.tar.gz"
+  sha256 "387126f978d7cf2e1cd2f60e9aec3e2d1eddce62f0dc8f861a212dc4fe97e419"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.150](https://github.com/PurpleBooth/git-mit/compare/...v5.12.150) (2023-09-27)

### Deps

#### Ci

- Bump nick-invision/retry from 2.8.2 to 2.9.0 ([`035a4e9`](https://github.com/PurpleBooth/git-mit/commit/035a4e9a637f25c552826dc828ae9c72a13a2774))

#### Fix

- Bump thiserror from 1.0.48 to 1.0.49 ([`bb37e30`](https://github.com/PurpleBooth/git-mit/commit/bb37e30a1773410cb0b94c57bd95087ebca3af03))
- Bump mit-commit from 3.1.7 to 3.1.8 ([`7f4de85`](https://github.com/PurpleBooth/git-mit/commit/7f4de855bf2b014d7c94545c2e25b7e3abaadfed))


### Version

#### Chore

- V5.12.150  ([`7a9091d`](https://github.com/PurpleBooth/git-mit/commit/7a9091de3eafd8856dbddf4bf983d3fb3890e994))


