### PR TITLE
fix: Update git-mit to v5.12.151

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.150.tar.gz"
-  sha256 "387126f978d7cf2e1cd2f60e9aec3e2d1eddce62f0dc8f861a212dc4fe97e419"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.150"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b8d655eba2827cdecdebf47dd50b8fbb75debce24d2d03e2b9769d56c0557f65"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.151.tar.gz"
+  sha256 "a2c8d637322f30ecf6544be4d3fa8c0c42d648fe66c1068f64efcb8ad0c7acf8"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.151](https://github.com/PurpleBooth/git-mit/compare/...v5.12.151) (2023-09-27)

### Deps

#### Fix

- Bump time from 0.3.28 to 0.3.29 ([`0383de0`](https://github.com/PurpleBooth/git-mit/commit/0383de023ee2f67297f2d8c75409d35df171dece))
- Bump which from 4.4.0 to 4.4.2 ([`50d6142`](https://github.com/PurpleBooth/git-mit/commit/50d6142738a6421cf2cb2d922ac1aa558c44f5b1))
- Bump toml from 0.8.0 to 0.8.1 ([`b770986`](https://github.com/PurpleBooth/git-mit/commit/b77098662d1690bd876d67f2af68ac5ef170621a))


### Version

#### Chore

- V5.12.151  ([`cba6726`](https://github.com/PurpleBooth/git-mit/commit/cba6726063428bbac13dd7ea33966c7ca72eb596))


