### PR TITLE
fix: Update git-mit to v5.12.152

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.151.tar.gz"
-  sha256 "a2c8d637322f30ecf6544be4d3fa8c0c42d648fe66c1068f64efcb8ad0c7acf8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.151"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f3a4ec3c6f6e0e38ed704d1855f74dbc03f7fc08384a8e6b7d646a847dd86adb"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.152.tar.gz"
+  sha256 "320baa12d514cff6c4a6c4be60d923cba079b162f5d005e4cb9e1745a1622b2c"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.152](https://github.com/PurpleBooth/git-mit/compare/...v5.12.152) (2023-09-27)

### Deps

#### Fix

- Bump indoc from 2.0.3 to 2.0.4 ([`4dabed8`](https://github.com/PurpleBooth/git-mit/commit/4dabed88726db568428b127303c405483cd153d5))
- Bump mit-lint from 3.2.3 to 3.2.7 ([`11968d2`](https://github.com/PurpleBooth/git-mit/commit/11968d29dd73a0fb69bb0ce6479a3405982062e0))


### Version

#### Chore

- V5.12.152  ([`f3978ac`](https://github.com/PurpleBooth/git-mit/commit/f3978ac926d8bb545e5902a159206010f1990dfa))


