### PR TITLE
fix: Update git-mit to v5.12.153

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.152.tar.gz"
-  sha256 "320baa12d514cff6c4a6c4be60d923cba079b162f5d005e4cb9e1745a1622b2c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.152"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "668564dfe79608c4f1ff9761332a1a9560a5d1e79dc23ff05339aedd7b4da30c"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.153.tar.gz"
+  sha256 "839fe0943f7050645aaacf6c60e4d4f0b0604564117b0f3545ac7e574ec92fc3"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.153](https://github.com/PurpleBooth/git-mit/compare/...v5.12.153) (2023-09-29)

### Deps

#### Fix

- Bump clap from 4.4.5 to 4.4.6 ([`37ed198`](https://github.com/PurpleBooth/git-mit/commit/37ed1986fd2a0f6509643c5b9802569a7f966dc3))
- Bump clap_complete from 4.4.2 to 4.4.3 ([`b7d5852`](https://github.com/PurpleBooth/git-mit/commit/b7d585239d3e1c09c535b2f51e1f511e6e4cc41c))


### Version

#### Chore

- V5.12.153  ([`bb06dce`](https://github.com/PurpleBooth/git-mit/commit/bb06dce67f9aef353490c02fce746ef4469d25fb))


