### PR TITLE
fix: Update git-mit to v5.12.154

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.153.tar.gz"
-  sha256 "839fe0943f7050645aaacf6c60e4d4f0b0604564117b0f3545ac7e574ec92fc3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.153"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "404a0c23729892b56951cf2bdee12df0e15396c1448da7395b714f8ad52d780c"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.154.tar.gz"
+  sha256 "0efdd9fca83a1243ddd0a67d01fca92f555f232bc948e3db2a78d6126454560f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.154](https://github.com/PurpleBooth/git-mit/compare/...v5.12.154) (2023-10-02)

### Deps

#### Fix

- Bump regex from 1.9.5 to 1.9.6 ([`6385458`](https://github.com/PurpleBooth/git-mit/commit/6385458bcc9622ad8f14ca96e229942a3a639faf))


### Version

#### Chore

- V5.12.154  ([`697b8a9`](https://github.com/PurpleBooth/git-mit/commit/697b8a9c628c04bd5572a05cd886b56045992056))


