### PR TITLE
fix: Update git-mit to v5.12.156

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.155.tar.gz"
-  sha256 "22d52a465a62c7fa7f08c91a3a96512ee6413f2e079c86d973dcc27f7a217b9b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.155"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0ee10e4677f9d08e57d1e4c6b769cf37639ddad7d382fa4b9fe270af83e97ee5"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.156.tar.gz"
+  sha256 "839bb13ef84e2e6e16c156fb2aa736e5c48355682518baa4ea4470810719dd78"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.156](https://github.com/PurpleBooth/git-mit/compare/...v5.12.156) (2023-10-06)

### Deps

#### Fix

- Bump rust from 1.72.1 to 1.73.0 ([`ffa2ad1`](https://github.com/PurpleBooth/git-mit/commit/ffa2ad174936c572ae91c1a1b7bd5df7fcd34e7f))


### Version

#### Chore

- V5.12.156  ([`9226cbd`](https://github.com/PurpleBooth/git-mit/commit/9226cbda9f73b8cccb98a14bcebce4131cd94668))


