### PR TITLE
fix: Update git-mit to v5.12.157

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.156.tar.gz"
-  sha256 "839bb13ef84e2e6e16c156fb2aa736e5c48355682518baa4ea4470810719dd78"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.156"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a344f4367a104e667c550c6c2966935551abb55e024683ed5350e6923ccf5197"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.157.tar.gz"
+  sha256 "8db0468d778af64b1c21862aa3a3ba9e08d01523e12f32fd5240abfee20d6c04"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.157](https://github.com/PurpleBooth/git-mit/compare/...v5.12.157) (2023-10-09)

### Deps

#### Fix

- Bump tokio from 1.32.0 to 1.33.0 ([`e7c79cf`](https://github.com/PurpleBooth/git-mit/commit/e7c79cf52be77e84ddce3dd97b6f0556536b5453))


### Version

#### Chore

- V5.12.157  ([`37eee83`](https://github.com/PurpleBooth/git-mit/commit/37eee831dbbb047d247a191cd72a90fafbac99a9))


