### PR TITLE
fix: Update git-mit to v5.12.161

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.160.tar.gz"
-  sha256 "5f5fe9d8081bedca537a4aa666b533936e406651c9ade51379dbf730b3656e6e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.160"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b58856ba028b968e74841ea4506db64b3dc0d5684e0031eba12428af49401c74"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.161.tar.gz"
+  sha256 "2b6e983bedc6a29e323af0dedf2faca564e98d23642d9634d680fc999e446e31"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.161](https://github.com/PurpleBooth/git-mit/compare/...v5.12.161) (2023-10-18)

### Deps

#### Fix

- Bump which from 4.4.2 to 5.0.0 ([`0cd9f95`](https://github.com/PurpleBooth/git-mit/commit/0cd9f9573a5945958e62611809570f30a242518c))


### Version

#### Chore

- V5.12.161  ([`771b39b`](https://github.com/PurpleBooth/git-mit/commit/771b39b9431d89f01c496775ea8d2913446da317))


