### PR TITLE
fix: Update git-mit to v5.12.164

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.163.tar.gz"
-  sha256 "64dd942e9fb4a1663d4360625071a948db68146b23ba3fbd44184165a48b692f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.163"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0a4f42663e160763496904574a2a4766eba4de4fc9cf700797f24adf68d9d708"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.164.tar.gz"
+  sha256 "d99517243109895db0a9e22604f5497d06bae37870692dd2c223b2093b4e76ae"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.164](https://github.com/PurpleBooth/git-mit/compare/...v5.12.164) (2023-10-23)

### Deps

#### Fix

- Bump comfy-table from 7.0.1 to 7.1.0 ([`074631b`](https://github.com/PurpleBooth/git-mit/commit/074631b19c898887597e09da6a2321f2e8c09067))


### Version

#### Chore

- V5.12.164  ([`713272b`](https://github.com/PurpleBooth/git-mit/commit/713272b575bf8b64329890dcb724a17b5400b377))


