### PR TITLE
fix: Update git-mit to v5.12.166

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.166.tar.gz"
+  sha256 "42d1423fda411f998ce94e1cd022adeb8fe9df55cf0a863e67cd3d45d0330553"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.166](https://github.com/PurpleBooth/git-mit/compare/...v5.12.166) (2023-10-25)

### Deps

#### Fix

- Bump clap_complete from 4.4.3 to 4.4.4 ([`e4fdff7`](https://github.com/PurpleBooth/git-mit/commit/e4fdff7a97fd4aa22682ae371fb40ae0f7775343))
- Bump clap from 4.4.6 to 4.4.7 ([`a20fe9f`](https://github.com/PurpleBooth/git-mit/commit/a20fe9fc3a70d25aa42e80d0ced21bd9b81ed739))


### Version

#### Chore

- V5.12.166  ([`2897a90`](https://github.com/PurpleBooth/git-mit/commit/2897a903736d4212cd22f0971e8436a1eba4ef4b))


