### PR TITLE
fix: Update git-mit to v5.12.167

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.167.tar.gz"
+  sha256 "89e60bd780e60efdaf0508fbe27e22eec370c83c0f136a4442f9fdf04cb23074"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.167](https://github.com/PurpleBooth/git-mit/compare/...v5.12.167) (2023-10-26)

### Deps

#### Fix

- Bump serde_yaml from 0.9.25 to 0.9.27 ([`bbb6db3`](https://github.com/PurpleBooth/git-mit/commit/bbb6db34c79bf9305efd7559f58af773c2895c43))


### Version

#### Chore

- V5.12.167  ([`844f089`](https://github.com/PurpleBooth/git-mit/commit/844f089d22e62feda721fdaeeea2b9df1fcfc2f9))


