### PR TITLE
fix: Update git-mit to v5.12.168

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.168.tar.gz"
+  sha256 "56a3779cc52f9d96c8b1aeef7afff606cf717da5486edcc6aa904c4e234df46d"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.168](https://github.com/PurpleBooth/git-mit/compare/...v5.12.168) (2023-10-27)

### Deps

#### Fix

- Bump toml from 0.8.4 to 0.8.5 ([`b0155cc`](https://github.com/PurpleBooth/git-mit/commit/b0155cc9f8dff5a0477e6191f86049de015b9f04))
- Bump tempfile from 3.8.0 to 3.8.1 ([`b7bf706`](https://github.com/PurpleBooth/git-mit/commit/b7bf70617cb74480c6a86d86fa2b34c6a238fe37))


### Version

#### Chore

- V5.12.168  ([`ba315ff`](https://github.com/PurpleBooth/git-mit/commit/ba315ffb0d90d5069c4eab1a2d0223b26f2c9ef1))


