### PR TITLE
fix: Update git-mit to v5.12.169

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.169.tar.gz"
+  sha256 "76d438b5c62401071bb3fb863a12380e918641d2845a018ca431e3480778dc10"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.169](https://github.com/PurpleBooth/git-mit/compare/...v5.12.169) (2023-10-30)

### Deps

#### Fix

- Bump toml from 0.8.5 to 0.8.6 ([`cf6370e`](https://github.com/PurpleBooth/git-mit/commit/cf6370ed2828f0add8b7c383d1055dfaab877e3d))


### Version

#### Chore

- V5.12.169  ([`fcc447d`](https://github.com/PurpleBooth/git-mit/commit/fcc447d13163eb606f5334ab6c938b910925ef38))


