### PR TITLE
fix: Update git-mit to v5.12.170

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.170.tar.gz"
+  sha256 "688d3adc7be0737b95c358c06f7579a8c19db3c176e7fcc3aad9db6963268ca0"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.170](https://github.com/PurpleBooth/git-mit/compare/...v5.12.170) (2023-11-02)

### Deps

#### Fix

- Bump openssl from 0.10.57 to 0.10.58 ([`ed065cb`](https://github.com/PurpleBooth/git-mit/commit/ed065cbaa8230292e4d50b6ba9fe0761b93480a0))


### Version

#### Chore

- V5.12.170  ([`3b48506`](https://github.com/PurpleBooth/git-mit/commit/3b48506134b8c8a647dc9f2315a3c806b6db1af9))


