### PR TITLE
fix: Update git-mit to v5.12.171

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.171.tar.gz"
+  sha256 "21b480081adc5df4f098c4de08829be4796b311a1c26f064960ab34da7799c47"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.171](https://github.com/PurpleBooth/git-mit/compare/...v5.12.171) (2023-11-06)

### Deps

#### Fix

- Bump openssl from 0.10.58 to 0.10.59 ([`2532f86`](https://github.com/PurpleBooth/git-mit/commit/2532f867e99254be06cf7d4293cd40bbcc9df4eb))


### Version

#### Chore

- V5.12.171  ([`a93f5c0`](https://github.com/PurpleBooth/git-mit/commit/a93f5c0bea48cd6a62a1127784cdac1ab6a30e1a))


