### PR TITLE
fix: Update git-mit to v5.12.173

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.173.tar.gz"
+  sha256 "b26595133c513099488854b92d313033b63b8a6652ec33188f3b0ba198642c90"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.173](https://github.com/PurpleBooth/git-mit/compare/...v5.12.173) (2023-11-10)

### Deps

#### Fix

- Bump tokio from 1.33.0 to 1.34.0 ([`c64e3af`](https://github.com/PurpleBooth/git-mit/commit/c64e3af600dec6add715b4d86b130716111e1dee))


### Version

#### Chore

- V5.12.173  ([`23734f9`](https://github.com/PurpleBooth/git-mit/commit/23734f9a3be7a46d6d48727df8b3e558d596ad28))


