### PR TITLE
fix: Update git-mit to v5.12.174

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.174.tar.gz"
+  sha256 "71b19835c2bba1bce335f62c8a90ac0ae94c8692dfc8e8d22db931d01c6014d5"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.174](https://github.com/PurpleBooth/git-mit/compare/...v5.12.174) (2023-11-13)

### Deps

#### Fix

- Bump clap from 4.4.7 to 4.4.8 ([`d1b17f4`](https://github.com/PurpleBooth/git-mit/commit/d1b17f4aa5941560b4072ee28c8e279e0b2275c4))


### Version

#### Chore

- V5.12.174  ([`50bcc97`](https://github.com/PurpleBooth/git-mit/commit/50bcc97a9a8d7dd83e262891e5040ebce6ab701b))


