### PR TITLE
fix: Update git-mit to v5.12.175

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.175.tar.gz"
+  sha256 "6db4eacc38a6c9ac742e87469f495e933b491ce556e60e0b9e609aa86a079c21"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.175](https://github.com/PurpleBooth/git-mit/compare/...v5.12.175) (2023-11-17)

### Deps

#### Fix

- Bump rust from 1.73.0 to 1.74.0 ([`d9339dc`](https://github.com/PurpleBooth/git-mit/commit/d9339dced920b4361afe6e47dedb5f77ea63dbe5))


### Version

#### Chore

- V5.12.175  ([`fea5581`](https://github.com/PurpleBooth/git-mit/commit/fea55819453133342777a5c7f2b3d28d553f1660))


