### PR TITLE
fix: Update git-mit to v5.12.176

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.176.tar.gz"
+  sha256 "e28f1243f1e9a0f7a8f6ac12769b07c8187f33903f29d8cac74141924ad6dc30"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.176](https://github.com/PurpleBooth/git-mit/compare/...v5.12.176) (2023-11-21)

### Deps

#### Fix

- Bump arboard from 3.2.1 to 3.3.0 ([`6e8bb6d`](https://github.com/PurpleBooth/git-mit/commit/6e8bb6dd9c79d56afec3970445899125a6338840))


### Version

#### Chore

- V5.12.176  ([`777beb8`](https://github.com/PurpleBooth/git-mit/commit/777beb874ecab6ae5391719cbe1f41e98f10c790))


