### PR TITLE
fix: Update git-mit to v5.12.177

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.177.tar.gz"
+  sha256 "7136303382939b7d5f2172e9aa11c3262c9373fd41f0860e5b26619d60377f45"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.177](https://github.com/PurpleBooth/git-mit/compare/...v5.12.177) (2023-11-23)

### Deps

#### Fix

- Bump openssl from 0.10.59 to 0.10.60 ([`221df88`](https://github.com/PurpleBooth/git-mit/commit/221df88e9a2c2ea9d97221f2e2b322af668f4396))


### Version

#### Chore

- V5.12.177  ([`1f0929b`](https://github.com/PurpleBooth/git-mit/commit/1f0929b080c4e7e0536d9e5b68bcb987a5138d10))


