### PR TITLE
fix: Update git-mit to v5.12.178

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.178.tar.gz"
+  sha256 "1b6caed99bc4f17b8c85510e8a24e3efa4bc26e8697f5efd20add8d19e937ace"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.178](https://github.com/PurpleBooth/git-mit/compare/...v5.12.178) (2023-11-29)

### Deps

#### Fix

- Bump clap from 4.4.8 to 4.4.10 ([`e1f1323`](https://github.com/PurpleBooth/git-mit/commit/e1f1323406154770ab506c454337903ea829caf3))


### Version

#### Chore

- V5.12.178  ([`01db491`](https://github.com/PurpleBooth/git-mit/commit/01db491ebdaca33c130cdf0db7ae5d6c50da125e))


