### PR TITLE
fix: Update git-mit to v5.12.179

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.179.tar.gz"
+  sha256 "f0c165a78c9cb2dd78766a37f111a9dd9aa0b21ed34fe1585c5383b4476a8d54"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.179](https://github.com/PurpleBooth/git-mit/compare/...v5.12.179) (2023-12-05)

### Deps

#### Fix

- Bump openssl from 0.10.60 to 0.10.61 ([`b9aba2c`](https://github.com/PurpleBooth/git-mit/commit/b9aba2c0a8967f06486ccc4de6e187597ca17435))
- Bump clap from 4.4.10 to 4.4.11 ([`000147b`](https://github.com/PurpleBooth/git-mit/commit/000147b2b018347feb28cc9e108ecb02f9243a20))


### Version

#### Chore

- V5.12.179  ([`ed1bb3d`](https://github.com/PurpleBooth/git-mit/commit/ed1bb3d4fc1ed12d1c7c75a41d7502198945af70))


