### PR TITLE
fix: Update git-mit to v5.12.180

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.180.tar.gz"
+  sha256 "c900b2710dc6324704fcb79e7f11cecc70951d9eae304cab7ea1b3f0509e4046"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.180](https://github.com/PurpleBooth/git-mit/compare/...v5.12.180) (2023-12-11)

### Deps

#### Fix

- Bump tokio from 1.34.0 to 1.35.0 ([`a42c217`](https://github.com/PurpleBooth/git-mit/commit/a42c2173d55d0e766c20663a781e6089c6bd0886))


### Version

#### Chore

- V5.12.180  ([`9f992a0`](https://github.com/PurpleBooth/git-mit/commit/9f992a0c127e4bfc933a0f90099474963838f96f))


