### PR TITLE
fix: Update git-mit to v5.12.181

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.181.tar.gz"
+  sha256 "3941675c2889f14883ba3eb72a5631dc76e6b6e7c3675d0721e5952b5490f1d0"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.181](https://github.com/PurpleBooth/git-mit/compare/...v5.12.181) (2023-12-19)

### Deps

#### Ci

- Bump actions/download-artifact from 3 to 4 ([`3346e7a`](https://github.com/PurpleBooth/git-mit/commit/3346e7a63949f3cdf31b182e1ab5b7d9c67fb390))

#### Fix

- Bump thiserror from 1.0.50 to 1.0.51 ([`d3e44ad`](https://github.com/PurpleBooth/git-mit/commit/d3e44ad623c1505284d9300972f765d8ce3c0afc))
- Bump time from 0.3.30 to 0.3.31 ([`702bf0f`](https://github.com/PurpleBooth/git-mit/commit/702bf0f1cbf2f239a25c8c9ca606a7deae4a0ad2))


### Version

#### Chore

- V5.12.181  ([`6f7b067`](https://github.com/PurpleBooth/git-mit/commit/6f7b0677fcca9f32d175c89d6326129aa9f49943))


