### PR TITLE
fix: Update git-mit to v5.12.182

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.182.tar.gz"
+  sha256 "7fc659ee9aae6efc0bdbb547b4445864e01712ea12006dc8cdd4b122b50f67dc"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.182](https://github.com/PurpleBooth/git-mit/compare/...v5.12.182) (2023-12-28)

### Deps

#### Fix

- Bump tokio from 1.35.0 to 1.35.1 ([`5ad202e`](https://github.com/PurpleBooth/git-mit/commit/5ad202e9761bf9365ba37b606794d0fbb203e532))
- Bump unsafe-libyaml from 0.2.9 to 0.2.10 ([`a8031da`](https://github.com/PurpleBooth/git-mit/commit/a8031da909ca541e427648d73ace26c46f436523))
- Bump thiserror from 1.0.51 to 1.0.52 ([`d8a27b7`](https://github.com/PurpleBooth/git-mit/commit/d8a27b733e2abe11a0c402dec52aafa6935c8e3b))
- Bump openssl from 0.10.61 to 0.10.62 ([`735399b`](https://github.com/PurpleBooth/git-mit/commit/735399b49d59836acf02e5177442b9cd28a0b15f))
- Bump serde_yaml from 0.9.27 to 0.9.29 ([`8642f1d`](https://github.com/PurpleBooth/git-mit/commit/8642f1dd0ac019a8df30562ce6640016a9f9d57b))
- Bump tempfile from 3.8.1 to 3.9.0 ([`b842c46`](https://github.com/PurpleBooth/git-mit/commit/b842c466c34dbd3e8a04472d485abca0bf6894fa))
- Bump clap_complete from 4.4.4 to 4.4.5 ([`b57badb`](https://github.com/PurpleBooth/git-mit/commit/b57badba7b7494c08ab8f7f48904c080eda4c9cb))


### Version

#### Chore

- V5.12.182  ([`b7cde9d`](https://github.com/PurpleBooth/git-mit/commit/b7cde9d1075b8e05fe11ff7339b2cc301784d25c))


