### PR TITLE
fix: Update git-mit to v5.12.183

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.183.tar.gz"
+  sha256 "66226bbf8b7f79f9026fb753fc6731c61ad0bb1f0f0b846b7c0626cb5d58c8c0"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.183](https://github.com/PurpleBooth/git-mit/compare/...v5.12.183) (2024-01-02)

### Deps

#### Fix

- Bump serde_yaml from 0.9.29 to 0.9.30 ([`23a1ffa`](https://github.com/PurpleBooth/git-mit/commit/23a1fface3f5ab1a638ea345c71aa7b658876b16))


### Version

#### Chore

- V5.12.183  ([`11a24a5`](https://github.com/PurpleBooth/git-mit/commit/11a24a591984aab066b79ecea5ce5c383845e1c5))


