### PR TITLE
fix: Update git-mit to v5.12.184

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.184.tar.gz"
+  sha256 "71d048225dad3dc114a9b5f36afbe3d806e5a0c0e54a1915dbff3c45b766cff5"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.184](https://github.com/PurpleBooth/git-mit/compare/...v5.12.184) (2024-01-02)

### Deps

#### Fix

- Bump clap from 4.4.11 to 4.4.12 ([`fab63f4`](https://github.com/PurpleBooth/git-mit/commit/fab63f4b674841ef29b507e13faba4252ecea2bf))


### Version

#### Chore

- V5.12.184  ([`e8636a4`](https://github.com/PurpleBooth/git-mit/commit/e8636a4f2a41cb1c80067b1e4e91816cc761a315))


