### PR TITLE
fix: Update git-mit to v5.12.185

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.185.tar.gz"
+  sha256 "42d7959f3bb691ee8388244b3b12e762e03e48d79905631b61c3bf989f60d4c8"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.185](https://github.com/PurpleBooth/git-mit/compare/...v5.12.185) (2024-01-22)

### Deps

#### Fix

- Bump clap from 4.4.12 to 4.4.13 ([`0211a9b`](https://github.com/PurpleBooth/git-mit/commit/0211a9b1c01b019a85ca8ec27ed41629759d37a1))
- Bump clap_complete from 4.4.5 to 4.4.6 ([`b29463b`](https://github.com/PurpleBooth/git-mit/commit/b29463be757d4342cb0f9767936ce950dfba316b))
- Bump clap from 4.4.13 to 4.4.14 ([`e40d31c`](https://github.com/PurpleBooth/git-mit/commit/e40d31ceaf9f5b4f9f2f5b80e7e7758cc2117c75))
- Bump thiserror from 1.0.52 to 1.0.56 ([`fb32184`](https://github.com/PurpleBooth/git-mit/commit/fb32184f1a4210b4856307f3bbfd835c0a39cb0e))


### Src

#### Fix

- Clippy ([`d9fca9d`](https://github.com/PurpleBooth/git-mit/commit/d9fca9d34d53651d02db85211ff347a255719570))


### Version

#### Chore

- V5.12.185  ([`9fc53b0`](https://github.com/PurpleBooth/git-mit/commit/9fc53b0f9fcbe87a5a2b09c4f4613482841956a1))


