### PR TITLE
fix: Update git-mit to v5.12.186

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/v5.12.165.tar.gz"
-  sha256 "18a7844f5eea39d8412c336ccb1110b05563f505be40a0c3d1f29bc2bfc8ded1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "456787098bdb29ff0d54de4e260711f842fbcafedaa12a2940a322aed0cd2292"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.186.tar.gz"
+  sha256 "f1fb1541308d772646077caf05f9886515584fbc4542a1ce51dff914888cc8f0"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.186](https://github.com/PurpleBooth/git-mit/compare/...v5.12.186) (2024-01-23)

### Homebrew

#### Fix

- Correct url to match what homebrew expects ([`27f43c7`](https://github.com/PurpleBooth/git-mit/commit/27f43c7198727fa381971cbe2acebac39eb87c0e))


### Deps

#### Fix

- Bump openssl from 0.10.62 to 0.10.63 ([`76f8736`](https://github.com/PurpleBooth/git-mit/commit/76f8736d3391ca0cfc3413a17d780c174bbb159e))


### Version

#### Chore

- V5.12.186  ([`1dd9b67`](https://github.com/PurpleBooth/git-mit/commit/1dd9b67dac56ffdd331e9ee618f1fac275c58f9d))


