### PR TITLE
fix: Update fast-conventional to v2.3.5

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,13 +1,8 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.3.4.tar.gz"
-  sha256 "09fb01ad57f30aa0c0ffd65a7d9504d62aba1dad9a1ba3cbe0c3da26af75ebab"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.4"
-    sha256 cellar: :any, big_sur: "8504860d6b163c2ecab5f8b6e7103d182c2b1ed4f5f79538b71538b4547753fd"
-  end
+  url "https://github.com/PurpleBooth/fast-conventional/archive/v2.3.5.tar.gz"
+  sha256 "115f8e05cf22f5285d5daab33a4d79b6ebf0618bdc726b08f36845420d01790b"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## Changelog
### [v2.3.5](https://github.com/PurpleBooth/fast-conventional/compare/...v2.3.5) (2024-02-15)

### Mergify

#### Ci

- Configuration update ([`5a067fe`](https://github.com/PurpleBooth/fast-conventional/commit/5a067fe210f3250438fff442392c361ac9e835f7))


### Deploy

#### Build

- Versio update versions ([`dc871d4`](https://github.com/PurpleBooth/fast-conventional/commit/dc871d46f248c9770b8a912cad33480079c4bb84))


### Deps

#### Ci

- Bump PurpleBooth/versio-release-action from 0.1.15 to 0.1.17 ([`1c0896b`](https://github.com/PurpleBooth/fast-conventional/commit/1c0896b5d824ac3768acc635fd7ac5da11bdd95d))

#### Fix

- Bump serde from 1.0.145 to 1.0.147 ([`b65ce13`](https://github.com/PurpleBooth/fast-conventional/commit/b65ce1319a532088208222e207b239af852cbdd8))
- Bumping dependencies ([`69373bb`](https://github.com/PurpleBooth/fast-conventional/commit/69373bb42e137da920c8f6be426ce69cc9a1afee))
- Bump inquire from 0.4.0 to 0.5.1 ([`37b9bde`](https://github.com/PurpleBooth/fast-conventional/commit/37b9bde73bf55c60c8fe85503607846bffc0d7ff))
- Bump miette from 5.3.0 to 5.4.1 ([`4eac481`](https://github.com/PurpleBooth/fast-conventional/commit/4eac481994cd901c604eeea227b7c6e05ab8bf97))
- Bump inquire from 0.5.1 to 0.5.2 ([`d46eadf`](https://github.com/PurpleBooth/fast-conventional/commit/d46eadfed92392da4bc0977fae33f6f726a0b096))
- Bump clap_complete from 4.0.3 to 4.0.5 ([`1dcd8bc`](https://github.com/PurpleBooth/fast-conventional/commit/1dcd8bc5556d52723c416961375150543c243a17))
- Bump serde_yaml from 0.9.14 to 0.9.17 ([`9fbaafd`](https://github.com/PurpleBooth/fast-conventional/commit/9fbaafd51d6400a1c51296882ffc416b2f083783))
- Bump miette from 5.4.1 to 5.5.0 ([`6964832`](https://github.com/PurpleBooth/fast-conventional/commit/6964832854c80cd6c5ae08d97a4cc2fc8a271a9d))
- Bump serde from 1.0.147 to 1.0.152 ([`9996ed5`](https://github.com/PurpleBooth/fast-conventional/commit/9996ed5c4fae11d573102777a241c986fb914bbf))
- Bump libgit2-sys from 0.14.0+1.5.0 to 0.14.2+1.5.1 ([`61d105c`](https://github.com/PurpleBooth/fast-conventional/commit/61d105c0f8f56784c8dd389c8a35b89fc32ea323))
- Bump git2 from 0.15.0 to 0.16.1 ([`b41d281`](https://github.com/PurpleBooth/fast-conventional/commit/b41d2816c6777558a1f213f2c079b205897ccb62))
- Bump nom from 7.1.1 to 7.1.3 ([`8d0fbf5`](https://github.com/PurpleBooth/fast-conventional/commit/8d0fbf5ff62f112c54eb0d8216c943f8626be1c0))
- Bump thiserror from 1.0.37 to 1.0.38 ([`9c65a99`](https://github.com/PurpleBooth/fast-conventional/commit/9c65a994a0a4cff85543d816437240c4567199ec))
- Bump inquire from 0.5.2 to 0.5.3 ([`8fc3f0a`](https://github.com/PurpleBooth/fast-conventional/commit/8fc3f0a2c9a2e359ecb2a71cbdc14ebde594e984))
- Bump mit-commit from 3.1.4 to 3.1.5 ([`6125a79`](https://github.com/PurpleBooth/fast-conventional/commit/6125a79f07d5f0150ad06b1d53da4181c36dcb4a))
- Bump versions ([`745adc8`](https://github.com/PurpleBooth/fast-conventional/commit/745adc87c559e8330a0800ea04598f1b96e1fdd8))
- Bump inquire from 0.5.3 to 0.6.2 ([`f40078c`](https://github.com/PurpleBooth/fast-conventional/commit/f40078c462f60c5da2f69815ae97cda75c959a7d))
- Bump git2 from 0.16.1 to 0.18.1 ([`22e5490`](https://github.com/PurpleBooth/fast-conventional/commit/22e54908b7f6401f89a0b05b06caef2e81046a2a))
- Bump serde_yaml from 0.9.30 to 0.9.31 ([`e04542f`](https://github.com/PurpleBooth/fast-conventional/commit/e04542f9e4c074307e2b7e20f275a8db2dfaebb1))
- Bump serde from 1.0.195 to 1.0.196 ([`fcdab89`](https://github.com/PurpleBooth/fast-conventional/commit/fcdab89d963b8065c95935be8678645e3fcf0acf))
- Bump clap_complete from 4.4.9 to 4.4.10 ([`4a621e2`](https://github.com/PurpleBooth/fast-conventional/commit/4a621e2a9d2dbc499865f20251298df52fc4c5f7))
- Bump miette from 5.10.0 to 7.0.0 ([`9f99012`](https://github.com/PurpleBooth/fast-conventional/commit/9f99012dcc632f36808db5abe678b08c968455ef))
- Bump tempfile from 3.9.0 to 3.10.0 ([`a30e37a`](https://github.com/PurpleBooth/fast-conventional/commit/a30e37a92cd776ee4b630e94092d66ed811b696e))
- Bump git2 from 0.18.1 to 0.18.2 ([`ce481d3`](https://github.com/PurpleBooth/fast-conventional/commit/ce481d3f3068ab02e62844d2b6194016d6e8d33c))
- Bump clap_complete from 4.4.10 to 4.5.0 ([`f8506b2`](https://github.com/PurpleBooth/fast-conventional/commit/f8506b279c15699e3fc5336fc16761f6d5d94a02))
- Bump clap from 4.4.18 to 4.5.0 ([`fa74db1`](https://github.com/PurpleBooth/fast-conventional/commit/fa74db19ed93233c9ff18b4daace086bf25e27ae))
- Bump thiserror from 1.0.56 to 1.0.57 ([`a8a5c91`](https://github.com/PurpleBooth/fast-conventional/commit/a8a5c91aec16670c145154b630d75a66b3a0c775))


### Src

#### Docs

- Change the tests to match the new output from Miette ([`bbcbb34`](https://github.com/PurpleBooth/fast-conventional/commit/bbcbb34dd154926dda60cbebb797a64297bec247))

#### Fix

- Clippy advice ([`21d0d09`](https://github.com/PurpleBooth/fast-conventional/commit/21d0d09bd1bb70074f27ddc6669b183f12c90969))

#### Refactor

- Use standard min length validator ([`4dd652f`](https://github.com/PurpleBooth/fast-conventional/commit/4dd652f0ff8b6475bae42c274c75a586cccba4ef))

#### Test

- Correct output to match new clap format ([`d8f7225`](https://github.com/PurpleBooth/fast-conventional/commit/d8f7225d3b1b45a4bfd9e9ff747b5f5b5e79bf85))


### Versio

#### Build

- Remove now unused version pattern ([`08c21d5`](https://github.com/PurpleBooth/fast-conventional/commit/08c21d57071043b1b04fefe3f9bd6716c8fc548c))


