### PR TITLE
fix: Update git-mit to v5.12.187

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.186.tar.gz"
-  sha256 "f1fb1541308d772646077caf05f9886515584fbc4542a1ce51dff914888cc8f0"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.187.tar.gz"
+  sha256 "493b7c9ed8223921942f0a6d4f570a513931e2ccd0c0576addd0b5f6fab42626"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.187](https://github.com/PurpleBooth/git-mit/compare/...v5.12.187) (2024-02-15)

### Mergify

#### Ci

- Configuration update (#1369) ([`107470a`](https://github.com/PurpleBooth/git-mit/commit/107470a84de92be2e3c376ff09c43579a9732dcb))


### Deps

#### Fix

- Bump libgit2-sys from 0.16.1+1.7.1 to 0.16.2+1.7.2 ([`01ca0e6`](https://github.com/PurpleBooth/git-mit/commit/01ca0e6c7d3c272e3ec38d76bd8f6f343eb55672))


### Version

#### Chore

- V5.12.187  ([`4ace365`](https://github.com/PurpleBooth/git-mit/commit/4ace3658ee63f04ca6c873eca59f1235778865c2))


