### PR TITLE
fix: Update git-mit to v5.12.188

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.186.tar.gz"
-  sha256 "f1fb1541308d772646077caf05f9886515584fbc4542a1ce51dff914888cc8f0"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.188.tar.gz"
+  sha256 "10d6511bd41b82620f2cc4eacdd13665ace37c61f93c197a1dd7f109afc7442a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.188](https://github.com/PurpleBooth/git-mit/compare/...v5.12.188) (2024-02-15)

### Deps

#### Ci

- Bump actions/cache from 3 to 4 ([`5f16a8c`](https://github.com/PurpleBooth/git-mit/commit/5f16a8c6569169300bfe5b8f790a67e623339823))
- Bump nick-invision/retry from 2.9.0 to 3.0.0 ([`b18a10b`](https://github.com/PurpleBooth/git-mit/commit/b18a10bb033fbe27c48019261ee7b4e4114aa37a))
- Bump ncipollo/release-action from 1.13.0 to 1.14.0 ([`92d0755`](https://github.com/PurpleBooth/git-mit/commit/92d0755f6c415f06a7a3513c0cb7c56640c4d4ae))

#### Fix

- Bump regex from 1.10.2 to 1.10.3 ([`e867935`](https://github.com/PurpleBooth/git-mit/commit/e8679357d0c75a718237fadf3792880fc39f9134))
- Bump time from 0.3.31 to 0.3.34 ([`5fc778d`](https://github.com/PurpleBooth/git-mit/commit/5fc778dbdea21bc1cc50c08d105bdd9cfcb533de))
- Bump tokio from 1.35.1 to 1.36.0 ([`b8a55bd`](https://github.com/PurpleBooth/git-mit/commit/b8a55bd8e1d9567bf1aceffaca75696a18b5d353))
- Bump toml from 0.8.8 to 0.8.10 ([`b7d75a0`](https://github.com/PurpleBooth/git-mit/commit/b7d75a03698d6bb22f5ac1abd2d6eade29c280b1))
- Bump rust from 1.74.0 to 1.76.0 ([`0ce12e9`](https://github.com/PurpleBooth/git-mit/commit/0ce12e9d9ce4229373b6bba46d95eac494e7820f))


### Version

#### Chore

- V5.12.188  ([`1c73e7b`](https://github.com/PurpleBooth/git-mit/commit/1c73e7b155fac340142be8261b43d760dfc7eba2))


