### PR TITLE
fix: Update git-mit to v5.12.189

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.186.tar.gz"
-  sha256 "f1fb1541308d772646077caf05f9886515584fbc4542a1ce51dff914888cc8f0"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.189.tar.gz"
+  sha256 "d461fe9755d5bea9d77a31421e8a913c91337fddac76169d851392312a6cf46a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.189](https://github.com/PurpleBooth/git-mit/compare/...v5.12.189) (2024-02-15)

### Deps

#### Fix

- Bump git2 from 0.18.1 to 0.18.2 ([`3a72d38`](https://github.com/PurpleBooth/git-mit/commit/3a72d38e2bf87fed6fa43b5d1b615b0ba7e63940))


### Version

#### Chore

- V5.12.189  ([`9bfcf73`](https://github.com/PurpleBooth/git-mit/commit/9bfcf73a31b7e05dddc0ff19d4e7ed2f83a1f00d))


