### PR TITLE
fix: Update git-mit to v5.12.190

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.186.tar.gz"
-  sha256 "f1fb1541308d772646077caf05f9886515584fbc4542a1ce51dff914888cc8f0"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.190.tar.gz"
+  sha256 "bb18ed2ce683875e052d576aacb7e29e0f1f505c53aa415bb090f5e19c6e028a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.190](https://github.com/PurpleBooth/git-mit/compare/...v5.12.190) (2024-02-15)

### Deps

#### Fix

- Bump serde_yaml from 0.9.30 to 0.9.31 ([`f820ef0`](https://github.com/PurpleBooth/git-mit/commit/f820ef067ce60527b6afdb23be29ac40caa37562))
- Bump tempfile from 3.9.0 to 3.10.0 ([`26f06c2`](https://github.com/PurpleBooth/git-mit/commit/26f06c2af84908ce1c4c4026714f0c238affd8f8))
- Bump clap from 4.4.14 to 4.5.0 ([`f0de0ee`](https://github.com/PurpleBooth/git-mit/commit/f0de0eeb690cbb990c589c7084de55c69bfc3f61))


### Version

#### Chore

- V5.12.190  ([`8c0fe53`](https://github.com/PurpleBooth/git-mit/commit/8c0fe530e90ad5c564a4e770b3fae6a3300b17c6))


