### PR TITLE
fix: Update git-mit to v5.12.191

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.186.tar.gz"
-  sha256 "f1fb1541308d772646077caf05f9886515584fbc4542a1ce51dff914888cc8f0"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.191.tar.gz"
+  sha256 "103d5d5b0eec662252f2bf95829eabd69c1153ace7d9141de9bb12dd8707a1b9"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.191](https://github.com/PurpleBooth/git-mit/compare/...v5.12.191) (2024-02-15)

### Deps

#### Fix

- Bump thiserror from 1.0.56 to 1.0.57 ([`01007c9`](https://github.com/PurpleBooth/git-mit/commit/01007c9a0bd8e6e417978fe773faf44bc4dd00e3))
- Bump arboard from 3.3.0 to 3.3.1 ([`bc87b0c`](https://github.com/PurpleBooth/git-mit/commit/bc87b0c6834f35479cd3ab02843d8da10da5491f))
- Bump which from 5.0.0 to 6.0.0 ([`f4e0c36`](https://github.com/PurpleBooth/git-mit/commit/f4e0c36e375c14a8d7cef4fe7a34f0e7b830a4e0))
- Bump clap_complete from 4.4.6 to 4.5.0 ([`5a389c8`](https://github.com/PurpleBooth/git-mit/commit/5a389c855fb6b0036f3d9033e72df039ac5dbba7))


### Version

#### Chore

- V5.12.191  ([`fff35fb`](https://github.com/PurpleBooth/git-mit/commit/fff35fbc1671ae2b10fd12e1d80c03ba8de14a28))


