### PR TITLE
fix: Update git-mit to v5.12.192

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.191.tar.gz"
-  sha256 "103d5d5b0eec662252f2bf95829eabd69c1153ace7d9141de9bb12dd8707a1b9"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.192.tar.gz"
+  sha256 "6f295f7f403c82c11aec4cad8644e0a5dd12a98033050165e01df2946ec2e7ed"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.192](https://github.com/PurpleBooth/git-mit/compare/...v5.12.192) (2024-04-10)

### Deps

#### Ci

- Bump actions/upload-artifact from 3 to 4 ([`ab99569`](https://github.com/PurpleBooth/git-mit/commit/ab9956981471c5c732b9fcfef1ba6dc6598688fc))
- Bump PurpleBooth/generate-formula-action from 0.1.10 to 0.1.11 ([`f4ff0c4`](https://github.com/PurpleBooth/git-mit/commit/f4ff0c4f5c43644da31b045f3a51e493f119722c))


### Version

#### Chore

- V5.12.192 ([`7dfa652`](https://github.com/PurpleBooth/git-mit/commit/7dfa6521fe60cdde0518e50bf64dad4148b163df))


