### PR TITLE
fix: Update git-mit to v5.12.194

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.192.tar.gz"
-  sha256 "6f295f7f403c82c11aec4cad8644e0a5dd12a98033050165e01df2946ec2e7ed"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.194.tar.gz"
+  sha256 "a24f07e69eb5f16b2d5769625a791b50d9b71bcb947bdf3a7b9c7f905b063d3c"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.194](https://github.com/PurpleBooth/git-mit/compare/...v5.12.194) (2024-04-11)

### Deps

#### Fix

- Bump time from 0.3.35 to 0.3.36 ([`b45b93f`](https://github.com/PurpleBooth/git-mit/commit/b45b93fd9f874243dc86eb9c18c60e645f7935e5))


### Version

#### Chore

- V5.12.194 ([`daeecca`](https://github.com/PurpleBooth/git-mit/commit/daeeccafcf2f9979274daa2696b9d3a2da0c950d))


