### PR TITLE
fix: Update git-mit to v5.12.195

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.194.tar.gz"
-  sha256 "a24f07e69eb5f16b2d5769625a791b50d9b71bcb947bdf3a7b9c7f905b063d3c"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.195.tar.gz"
+  sha256 "a805310fc5bc61235f3e88061e0f727059ab28bcc284fd4166a45e7702f4f408"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.195](https://github.com/PurpleBooth/git-mit/compare/...v5.12.195) (2024-04-12)

### Deps

#### Fix

- Bump rust from 1.77.0 to 1.77.2 ([`5e54a6a`](https://github.com/PurpleBooth/git-mit/commit/5e54a6adabb94bff38f2226c5a9a6af16ed2117c))


### Version

#### Chore

- V5.12.195 ([`690f41b`](https://github.com/PurpleBooth/git-mit/commit/690f41b686f933bfa53aed2aca27b25107735bdd))


