### PR TITLE
fix: Update git-mit to v5.12.196

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,10 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.195.tar.gz"
-  sha256 "a805310fc5bc61235f3e88061e0f727059ab28bcc284fd4166a45e7702f4f408"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.195"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1f50fb16c563b71afbac25e93ff4768b8db90885e551928909eb821d6594bc5d"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.196.tar.gz"
+  sha256 "3651078487df6fa54e992b2e01ceca15a36c564b4a2ff350368bdd8af504eea8"
   depends_on "help2man" => :build
-  depends_on "rust" => :build
+  depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"
   on_linux do
     depends_on "libxcb"


### PR DESCRIPTION
## Changelog
### [v5.12.196](https://github.com/PurpleBooth/git-mit/compare/...v5.12.196) (2024-04-13)

### Version

#### Chore

- V5.12.196 ([`c2997b8`](https://github.com/PurpleBooth/git-mit/commit/c2997b89b1fd0daf3e2581bd00dedc10f2512c1a))


