### PR TITLE
fix: Update git-mit to v5.12.197

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.196.tar.gz"
-  sha256 "3651078487df6fa54e992b2e01ceca15a36c564b4a2ff350368bdd8af504eea8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.196"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b44c2717fc839384f5d3ba607a2a92af445ea53eb0a14b019ae10391b0f1cfa9"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.197.tar.gz"
+  sha256 "d1aa4cd53f42c76d264552bf6778eacc9cc6b0e37a7c64ea195596d88e8215f5"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.197](https://github.com/PurpleBooth/git-mit/compare/...v5.12.197) (2024-04-22)

### Deps

#### Fix

- Bump thiserror from 1.0.58 to 1.0.59 ([`73632c5`](https://github.com/PurpleBooth/git-mit/commit/73632c5b30058663db97e5529517a2bc0d340bb9))


### Version

#### Chore

- V5.12.197 ([`f495afa`](https://github.com/PurpleBooth/git-mit/commit/f495afa4173654b25ac4c2495c68ba32b0e0392e))


