### PR TITLE
fix: Update git-mit to v5.12.198

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.197.tar.gz"
-  sha256 "d1aa4cd53f42c76d264552bf6778eacc9cc6b0e37a7c64ea195596d88e8215f5"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.198.tar.gz"
+  sha256 "4a79be9649cc388ba65e56f3e7715150c9d57bfaae2906591fd606b0c0d54aa3"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.198](https://github.com/PurpleBooth/git-mit/compare/...v5.12.198) (2024-04-29)

### Deps

#### Fix

- Bump arboard from 3.3.2 to 3.4.0 ([`522ed62`](https://github.com/PurpleBooth/git-mit/commit/522ed6268397786ccc0824962d8bd685cf207539))


### Version

#### Chore

- V5.12.198 ([`7c16438`](https://github.com/PurpleBooth/git-mit/commit/7c164381f8214a6321d4f1376301aad0282b74a3))


