### PR TITLE
fix: Update git-mit to v5.12.199

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.198.tar.gz"
-  sha256 "4a79be9649cc388ba65e56f3e7715150c9d57bfaae2906591fd606b0c0d54aa3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.198"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "40e4d0cf742be38f2219cc81215f9df243df46bd5400b0bfe6f412bf6750ad6c"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.199.tar.gz"
+  sha256 "00f6ee473356adef2404ddd9e474c0bfe436fc38b6864fa58aba922bc236d63b"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.199](https://github.com/PurpleBooth/git-mit/compare/...v5.12.199) (2024-05-03)

### Deps

#### Fix

- Bump rust from 1.77.2 to 1.78.0 ([`40896b0`](https://github.com/PurpleBooth/git-mit/commit/40896b0c79f6b8d9701f255c87ed205224ffc508))


### Version

#### Chore

- V5.12.199 ([`b90df4a`](https://github.com/PurpleBooth/git-mit/commit/b90df4af84c536491da95010fc3c1903a9089d86))


