### PR TITLE
fix: Update git-mit to v5.12.205

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.204.tar.gz"
-  sha256 "9ee71d07e836bf049b0363e80e4d37e26cad6796fddf3e86a570c0c735631b27"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.204"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "53c3d6b20fe3db8ed1a196e588afd1b93f1331c9ea7071a3fef431383a9f99a7"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.205.tar.gz"
+  sha256 "4201aa1b58ec7e83e6f083b149f06e954c9e23a04b998e8ea0aec7a61a170df9"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.205](https://github.com/PurpleBooth/git-mit/compare/...v5.12.205) (2024-06-07)

### Deps

#### Fix

- Bump clap_complete from 4.5.2 to 4.5.4 ([`5cc968b`](https://github.com/PurpleBooth/git-mit/commit/5cc968be214e7777111f0c91ab74bdbaed101031))


### Version

#### Chore

- V5.12.205 ([`8e79df6`](https://github.com/PurpleBooth/git-mit/commit/8e79df6204362876cc9c5ac58b1e32a0e536718a))


