### PR TITLE
fix: Update git-mit to v5.12.206

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.205.tar.gz"
-  sha256 "4201aa1b58ec7e83e6f083b149f06e954c9e23a04b998e8ea0aec7a61a170df9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.205"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "83ee12ba66039cf8668dc22d82b8fc682d319eaba02236c1b46af727212386f0"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.206.tar.gz"
+  sha256 "c1013452eeb0ed20a88b22c4c4a0228320867f8a1093ab96f234ecd3d4370cec"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.206](https://github.com/PurpleBooth/git-mit/compare/...v5.12.206) (2024-06-10)

### Deps

#### Fix

- Bump clap_complete from 4.5.4 to 4.5.5 ([`33c93ad`](https://github.com/PurpleBooth/git-mit/commit/33c93adfa5468a6fa48d5028efbae1283053d41f))
- Bump regex from 1.10.4 to 1.10.5 ([`3bd8a9b`](https://github.com/PurpleBooth/git-mit/commit/3bd8a9bd9a1649fc6123a66aa7eca44671039946))


### Version

#### Chore

- V5.12.206 ([`a9cf908`](https://github.com/PurpleBooth/git-mit/commit/a9cf908e7420948d975bb3e4f01e41856ea9b70a))


