### PR TITLE
fix: Update git-mit to v5.12.207

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.206.tar.gz"
-  sha256 "c1013452eeb0ed20a88b22c4c4a0228320867f8a1093ab96f234ecd3d4370cec"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.206"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4edf1bd652d73021f1813705bd828284b3879994cda8d5450f7ce78bf57510fa"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
+  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.207](https://github.com/PurpleBooth/git-mit/compare/...v5.12.207) (2024-06-11)

### Deps

#### Fix

- Bump clap from 4.5.6 to 4.5.7 ([`b699622`](https://github.com/PurpleBooth/git-mit/commit/b699622d9b5d7b3701d902a4d9e9fd0583250782))


### Version

#### Chore

- V5.12.207 ([`b72e15b`](https://github.com/PurpleBooth/git-mit/commit/b72e15bbb3219dd19bbfa39be25b375cc7c2a728))


