### PR TITLE
fix: Update git-mit to v5.12.210

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.210.tar.gz"
+  sha256 "3e2caeef1220724896b11af77c888d6737a424b513b2857bd6c3cd2bbf978ed3"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.210](https://github.com/PurpleBooth/git-mit/compare/...v5.12.210) (2024-06-20)

### Deps

#### Fix

- Bump clap_complete from 4.5.5 to 4.5.6 ([`c2cb0c9`](https://github.com/PurpleBooth/git-mit/commit/c2cb0c9a0b768462e7b12e9c58b16d4ad3cbdb8e))


### Version

#### Chore

- V5.12.210 ([`b8ac0b6`](https://github.com/PurpleBooth/git-mit/commit/b8ac0b6e62d9aae494aa5effb1b5e528dea950c5))


