### PR TITLE
fix: Update git-mit to v5.12.211

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.211.tar.gz"
+  sha256 "02cb3b6fbaff1cebe9a3298c910153bd9c4608cf45de37c9c0c1c76bf4d19772"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.211](https://github.com/PurpleBooth/git-mit/compare/...v5.12.211) (2024-07-01)

### Deps

#### Fix

- Bump clap_complete from 4.5.6 to 4.5.7 ([`4de416e`](https://github.com/PurpleBooth/git-mit/commit/4de416edc3a88f4734f8e3fd47f9d2a329b9b997))
- Bump clap from 4.5.7 to 4.5.8 ([`8d3abe8`](https://github.com/PurpleBooth/git-mit/commit/8d3abe8d70dfe3377d4f359be4fdceb51c8e7118))


### Version

#### Chore

- V5.12.211 ([`fc98fcf`](https://github.com/PurpleBooth/git-mit/commit/fc98fcfca4d06390ef85f46b702857d9a751a2c0))


