### PR TITLE
fix: Update git-mit to v5.12.212

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.212.tar.gz"
+  sha256 "3ac7fc7a34384e1ceba7127da25a2141a485bcdd0cc9337c0f4faab40dc47991"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.212](https://github.com/PurpleBooth/git-mit/compare/...v5.12.212) (2024-07-09)

### Deps

#### Fix

- Bump clap from 4.5.8 to 4.5.9 ([`5341bf6`](https://github.com/PurpleBooth/git-mit/commit/5341bf6b4414519d1be1d6d390b2873405fe9cac))


### Version

#### Chore

- V5.12.212 ([`cb0a77b`](https://github.com/PurpleBooth/git-mit/commit/cb0a77bac3c87f33b43acfc7f95cf5d53a34ae93))


