### PR TITLE
fix: Update git-mit to v5.12.213

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.213.tar.gz"
+  sha256 "8b0bbd898c4c62bddcf8131c4c434d6982ca3e4576f5fb5d704881549b140ebf"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.213](https://github.com/PurpleBooth/git-mit/compare/...v5.12.213) (2024-07-11)

### Deps

#### Fix

- Bump clap_complete from 4.5.7 to 4.5.8 ([`d44dc7a`](https://github.com/PurpleBooth/git-mit/commit/d44dc7ad16b73aaaf811ce8eb614589a235a1c13))


### Version

#### Chore

- V5.12.213 ([`55ad499`](https://github.com/PurpleBooth/git-mit/commit/55ad499085628bce4a212948dd22cf483f934a13))


