### PR TITLE
fix: Update git-mit to v5.12.214

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.214.tar.gz"
+  sha256 "5843799e1e0ce460e818b74d037017020eef2cf082198562ab9781400f51c1ff"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.214](https://github.com/PurpleBooth/git-mit/compare/...v5.12.214) (2024-07-12)

### Deps

#### Fix

- Bump thiserror from 1.0.61 to 1.0.62 ([`0d044eb`](https://github.com/PurpleBooth/git-mit/commit/0d044eba681398c50d40b800b53a603634259635))


### Version

#### Chore

- V5.12.214 ([`ea36348`](https://github.com/PurpleBooth/git-mit/commit/ea36348edddd3eb44c2ee26b98110ddc5cd192c2))


