### PR TITLE
fix: Update git-mit to v5.12.215

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.215.tar.gz"
+  sha256 "1be95582813df4f268605611354827e366e517132969dcf59b918aaa66afe578"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.215](https://github.com/PurpleBooth/git-mit/compare/...v5.12.215) (2024-07-17)

### Deps

#### Fix

- Bump tokio from 1.38.0 to 1.38.1 ([`464e706`](https://github.com/PurpleBooth/git-mit/commit/464e706d26452263ef2a125b7a0095168fc28cfc))


### Version

#### Chore

- V5.12.215 ([`f84b354`](https://github.com/PurpleBooth/git-mit/commit/f84b3542e42737331beefd6ce601231927ece0da))


