### PR TITLE
fix: Update git-mit to v5.12.216

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.216.tar.gz"
+  sha256 "53b6771637856834184fb3e8d3ef6e5b30c96fdf1a3f4674b49f7dcb399f1ac0"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.216](https://github.com/PurpleBooth/git-mit/compare/...v5.12.216) (2024-07-18)

### Deps

#### Fix

- Bump thiserror from 1.0.62 to 1.0.63 ([`1f4aa1e`](https://github.com/PurpleBooth/git-mit/commit/1f4aa1ed78d383aaefec590e7109ce7926fd149c))
- Bump toml from 0.8.14 to 0.8.15 ([`16450f8`](https://github.com/PurpleBooth/git-mit/commit/16450f86ecef3bfaba2ca5f064e67adf7ed77595))


### Version

#### Chore

- V5.12.216 ([`5c17da3`](https://github.com/PurpleBooth/git-mit/commit/5c17da36e0ea71d273b6ef2f3ce19d381919fa9a))


