### PR TITLE
fix: Update git-mit to v5.12.217

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.217.tar.gz"
+  sha256 "2d7ab29f7ef0b896a0ff4d8c483dddb0cf724548ae3ab4dd96be5002d9ea4f6d"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.217](https://github.com/PurpleBooth/git-mit/compare/...v5.12.217) (2024-07-22)

### Deps

#### Fix

- Bump openssl from 0.10.64 to 0.10.66 ([`66a3d4f`](https://github.com/PurpleBooth/git-mit/commit/66a3d4f3df1f21ba5f962057e9f9c46b4fa86624))


### Version

#### Chore

- V5.12.217 ([`22d989d`](https://github.com/PurpleBooth/git-mit/commit/22d989d6d51d98f5b17f5107a28f2698018d9ca5))


