### PR TITLE
fix: Update git-mit to v5.12.218

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.218.tar.gz"
+  sha256 "e3fb50c8be77b8fa124febdde82773cceaca00e74ecce1c5c8afd48d65445adb"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.218](https://github.com/PurpleBooth/git-mit/compare/...v5.12.218) (2024-07-24)

### Deps

#### Fix

- Bump clap from 4.5.9 to 4.5.10 ([`06b6eb3`](https://github.com/PurpleBooth/git-mit/commit/06b6eb3133e6be0addc0db8b8e8ff159882fdae5))
- Bump tokio from 1.38.1 to 1.39.1 ([`9cff646`](https://github.com/PurpleBooth/git-mit/commit/9cff64618f81fff457a96ffc71c49626f864aa7c))


### Version

#### Chore

- V5.12.218 ([`2ad6038`](https://github.com/PurpleBooth/git-mit/commit/2ad6038600efba1f3471661310b0848a3e135abb))


