### PR TITLE
fix: Update git-mit to v5.12.219

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.219.tar.gz"
+  sha256 "bf49aae5d2de1dd4282facba2866cb91cad296f8bfe37f9336d24bbbff8d8e49"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.219](https://github.com/PurpleBooth/git-mit/compare/...v5.12.219) (2024-07-24)

### Deps

#### Fix

- Bump clap_complete from 4.5.8 to 4.5.9 ([`540645e`](https://github.com/PurpleBooth/git-mit/commit/540645e72b52ca5e55da0014cffc336133067ab8))


### Version

#### Chore

- V5.12.219 ([`e9f2a84`](https://github.com/PurpleBooth/git-mit/commit/e9f2a84d7d096583b05c9fd2d310a004702f0d0e))


