### PR TITLE
fix: Update git-mit to v5.12.220

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.220.tar.gz"
+  sha256 "89089957633268aac8a0f70bb120f0ac8db0da598614598fe5cd2786791a62a4"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.12.220](https://github.com/PurpleBooth/git-mit/compare/...v5.12.220) (2024-07-26)

### Deps

#### Fix

- Bump clap_complete from 4.5.9 to 4.5.11 ([`9cbaa02`](https://github.com/PurpleBooth/git-mit/commit/9cbaa0278a6db8fb44005a3098f5fce16eb9140e))
- Bump rust from 1.79.0 to 1.80.0 ([`1491801`](https://github.com/PurpleBooth/git-mit/commit/1491801c9cf562c19d05e123a36bef8f42291197))
- Bump toml from 0.8.15 to 0.8.16 ([`e3acbc0`](https://github.com/PurpleBooth/git-mit/commit/e3acbc0e419987e8a3e3c54ab9d22e6f0397e62a))
- Bump clap from 4.5.10 to 4.5.11 ([`d7fdaf6`](https://github.com/PurpleBooth/git-mit/commit/d7fdaf686b58a0a6f10f04feb2cb158033ee4b9b))


### Version

#### Chore

- V5.12.220 ([`eff6670`](https://github.com/PurpleBooth/git-mit/commit/eff66704a0dccdb426dacd564a6decbd9e82635d))


