### PR TITLE
fix: Update git-mit to v5.13.0

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.12.207.tar.gz"
-  sha256 "7163400425e28a709e703babe5e93bf93f050a710202d608241de5e186b34214"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.12.207"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "850f20cbac9f4a8dce75d538f98f9547112fe75a2747f650556eccf40c63fde1"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.0.tar.gz"
+  sha256 "63ba497d01677167edca6965a2a152711dbe9347aa374ba8e76ff8a18163458d"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.0](https://github.com/PurpleBooth/git-mit/compare/...v5.13.0) (2024-07-26)

### Version

#### Chore

- V5.13.0 ([`8d733e6`](https://github.com/PurpleBooth/git-mit/commit/8d733e62668398e4cf1cc5bd5c163b40d102ac1d))


