### PR TITLE
fix: Update git-mit to v5.13.1

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.0.tar.gz"
-  sha256 "63ba497d01677167edca6965a2a152711dbe9347aa374ba8e76ff8a18163458d"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.1.tar.gz"
+  sha256 "72f5d4325f74063b487038533de93102c9071da2013557d0a4b8fd872ea86c97"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.1](https://github.com/PurpleBooth/git-mit/compare/...v5.13.1) (2024-07-26)

### Version

#### Chore

- V5.13.1 ([`8ee89d6`](https://github.com/PurpleBooth/git-mit/commit/8ee89d67f47949e94f0d19e48a8337a85f265582))


