### PR TITLE
fix: Update git-mit to v5.13.2

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.1.tar.gz"
-  sha256 "72f5d4325f74063b487038533de93102c9071da2013557d0a4b8fd872ea86c97"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "974b4e542afa47df66f021c4911269ce15ddb89f8a4963e006e9d8a8731d55a7"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.2.tar.gz"
+  sha256 "45dbeee12af98c6985ad7fcb5279c8ba5bc1c61daf6a2b87a7053d201ac2ba91"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.2](https://github.com/PurpleBooth/git-mit/compare/...v5.13.2) (2024-07-29)

### Deps

#### Fix

- Bump tokio from 1.39.1 to 1.39.2 ([`db55753`](https://github.com/PurpleBooth/git-mit/commit/db557535795a63719a4fc65a810efea8bcb820a8))


### Version

#### Chore

- V5.13.2 ([`a13eaed`](https://github.com/PurpleBooth/git-mit/commit/a13eaed308a832914a162d040fba0782b20ef26a))


