### PR TITLE
fix: Update git-mit to v5.13.3

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.2.tar.gz"
-  sha256 "45dbeee12af98c6985ad7fcb5279c8ba5bc1c61daf6a2b87a7053d201ac2ba91"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "44ce6dc9b70188246c86943981cfe7202727fb1f1e29aaba8078ec145094770a"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.3.tar.gz"
+  sha256 "d83360f63d494af5d52e618f1f8e680f1f859a5ab0bf4099ca1277a12374ea5a"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.3](https://github.com/PurpleBooth/git-mit/compare/...v5.13.3) (2024-07-30)

### Deps

#### Fix

- Bump which from 6.0.1 to 6.0.2 ([`8607473`](https://github.com/PurpleBooth/git-mit/commit/86074737699b6170455724eb463ca1e97b6addc1))


### Version

#### Chore

- V5.13.3 ([`849026e`](https://github.com/PurpleBooth/git-mit/commit/849026e7a10cf116f3dc0d086d4783f30714b8e1))


