### PR TITLE
fix: Update readable-name-generator to v2.100.54

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.44.tar.gz"
-  sha256 "a8c088112ed12145daf2fe2e2e413486d513d44e84893d91fa64d75e544bc266"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "36e87d3a65501127d04f6e48ef2819107d101f7388df54f75708cbbcd69abfb7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7cfff5433328659f5c2e2acc4f2320d5f5d4d6fe8ccf47f9cc62743a7f13b4c0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.54.tar.gz"
+  sha256 "81e785a83557977932bb49f0b2b20d8159d53820c3e0ea3e6b50d62cfc1f2196"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.54](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.54) (2024-07-31)

### Homebrew

#### Fix

- Fix urls in template ([`e72668f`](https://github.com/PurpleBooth/readable-name-generator/commit/e72668f07d1f0427d9920dd9a76dd7d2964855cd))


### Deps

#### Fix

- Bump versions ([`7c09d15`](https://github.com/PurpleBooth/readable-name-generator/commit/7c09d1556472415552373fa96ae1b6cce1dbe7ee))


### Version

#### Chore

- V2.100.54 ([`cd6220d`](https://github.com/PurpleBooth/readable-name-generator/commit/cd6220d9cccbf926eb3ce2933e0aa4c2847c4028))


