### PR TITLE
fix: Update git-mit to v5.13.4

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,13 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.3.tar.gz"
-  sha256 "d83360f63d494af5d52e618f1f8e680f1f859a5ab0bf4099ca1277a12374ea5a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "34990e4a713a0891acb042d7da143d7023dea15c663255f9d0d5c9d1e7757011"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.4.tar.gz"
+  sha256 "92e2356414f0fd3029585ab6636db18973ba0b8dc81044aaa33ac25c3710e27b"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.4](https://github.com/PurpleBooth/git-mit/compare/...v5.13.4) (2024-07-31)

### Deps

#### Fix

- Bump toml from 0.8.16 to 0.8.17 ([`a8443ff`](https://github.com/PurpleBooth/git-mit/commit/a8443ffcb170f36f13de7e015b763c1175c13f7d))


### Version

#### Chore

- V5.13.4 ([`41eba9d`](https://github.com/PurpleBooth/git-mit/commit/41eba9dd5839c9f539bb348eb9d6b280f8f75aed))


