### PR TITLE
fix: Update readable-name-generator to v2.100.55

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,14 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.44.tar.gz"
-  sha256 "a8c088112ed12145daf2fe2e2e413486d513d44e84893d91fa64d75e544bc266"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.44"
-    sha256 cellar: :any_skip_relocation, big_sur:      "36e87d3a65501127d04f6e48ef2819107d101f7388df54f75708cbbcd69abfb7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7cfff5433328659f5c2e2acc4f2320d5f5d4d6fe8ccf47f9cc62743a7f13b4c0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.55.tar.gz"
+  sha256 "e3420b7589c18b8452558eb628f3d9e357b0c5eeac5e30b4f5e75dfa1c0043e0"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.55](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.55) (2024-08-01)

### Mergify

#### Ci

- Configuration update ([`4135ada`](https://github.com/PurpleBooth/readable-name-generator/commit/4135ada508f24d89da626cd36ea5e9c3be13a758))


### Deps

#### Fix

- Bump clap from 4.4.18 to 4.5.13 ([`f96b94c`](https://github.com/PurpleBooth/readable-name-generator/commit/f96b94c341cbd1921786aef0a5b2dc55e0d0e4ab))
- Bump miette from 5.10.0 to 7.2.0 ([`7cb6d46`](https://github.com/PurpleBooth/readable-name-generator/commit/7cb6d46f5c42a3debc0c8b2efcc82bedda847a4b))
- Bump thiserror from 1.0.56 to 1.0.63 ([`b4da1da`](https://github.com/PurpleBooth/readable-name-generator/commit/b4da1da217dbc601ea7ea6796ea30a06bbcc2dc8))
- Bump clap_complete from 4.4.9 to 4.5.12 ([`7b34a13`](https://github.com/PurpleBooth/readable-name-generator/commit/7b34a133930ed0d791152dd59029e5957de07320))


### Version

#### Chore

- V2.100.55 ([`c9f7113`](https://github.com/PurpleBooth/readable-name-generator/commit/c9f7113c5b1be25f6133b1243dc223fb84978610))


