### PR TITLE
fix: Update git-mit to v5.13.5

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.4.tar.gz"
-  sha256 "92e2356414f0fd3029585ab6636db18973ba0b8dc81044aaa33ac25c3710e27b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.4"
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "76c649ad8c45c570205dcc82b08332a2c21b6ec9c6017310952bcb26df37c89a"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.5.tar.gz"
+  sha256 "58f64690425d731abbeece7d175313caadf0cee6a88dc9be2f47719e16f25768"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.5](https://github.com/PurpleBooth/git-mit/compare/...v5.13.5) (2024-08-01)

### Deps

#### Ci

- Bump PurpleBooth/common-pipelines from 0.6.53 to 0.8.9 ([`0fe4cf5`](https://github.com/PurpleBooth/git-mit/commit/0fe4cf57589b3451efbd4b0a47c0415412854fd3))
- Bump PurpleBooth/common-pipelines from 0.8.9 to 0.8.15 ([`8db87c1`](https://github.com/PurpleBooth/git-mit/commit/8db87c1d9ff9740656885d06c90ae76a82ca01ac))

#### Fix

- Bump clap_complete from 4.5.11 to 4.5.12 ([`35a6dac`](https://github.com/PurpleBooth/git-mit/commit/35a6dacdcb85d7ab1aad5e5818dfcea1fd48f30a))
- Bump toml from 0.8.17 to 0.8.19 ([`83f0253`](https://github.com/PurpleBooth/git-mit/commit/83f02531d3f137ac4846edd373c2f62f163d6bf4))


### Version

#### Chore

- V5.13.5 ([`43285a4`](https://github.com/PurpleBooth/git-mit/commit/43285a42afabc3d42819f829e587b4330dbaa561))


