### PR TITLE
fix: Update git-mit to v5.13.6

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.4.tar.gz"
-  sha256 "92e2356414f0fd3029585ab6636db18973ba0b8dc81044aaa33ac25c3710e27b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.4"
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "76c649ad8c45c570205dcc82b08332a2c21b6ec9c6017310952bcb26df37c89a"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.6.tar.gz"
+  sha256 "3a57ccaec1b8c3429f38b1e9b83a0d398d4ba3df53b4c0fc2015c49b4d31d2cc"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.6](https://github.com/PurpleBooth/git-mit/compare/...v5.13.6) (2024-08-01)

### Deps

#### Fix

- Bump clap from 4.5.11 to 4.5.13 ([`43e8822`](https://github.com/PurpleBooth/git-mit/commit/43e88224933cf0fa5baecbb59428cb654c92921e))


### Version

#### Chore

- V5.13.6 ([`90c12e3`](https://github.com/PurpleBooth/git-mit/commit/90c12e350521dddabc4f56e27ae127829058c937))


