### PR TITLE
fix: Update git-moves-together to v2.5.63

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,13 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.63.tar.gz"
+  url "https://github.com/PurpleBooth/git-moves-together/archive/v2.5.63.tar.gz"
   sha256 "62b7274dc78d4668a455c1e769a58275b4869de42f16472eb1c222f8c90ca612"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.55"
-    sha256 cellar: :any, monterey: "d67921fa4daf42d9967b9145c8343813d403290b51b195d60f79cf1646c2222c"
-  end
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.63](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.63) (2024-08-02)

### Mergify

#### Ci

- Configuration update ([`c429863`](https://github.com/PurpleBooth/git-moves-together/commit/c4298630dcfc6790efa72d655482f38034a84348))


### Deploy

#### Build

- Versio update versions ([`d6c4096`](https://github.com/PurpleBooth/git-moves-together/commit/d6c409629d212bbe38cc62173908e73f992227bb))


