### PR TITLE
fix: Update git-moves-together to v2.5.64

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,13 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.63.tar.gz"
-  sha256 "62b7274dc78d4668a455c1e769a58275b4869de42f16472eb1c222f8c90ca612"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.55"
-    sha256 cellar: :any, monterey: "d67921fa4daf42d9967b9145c8343813d403290b51b195d60f79cf1646c2222c"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.64.tar.gz"
+  sha256 "95e83657eb32b9bba9921ebd375a199fa7a3a0f48d325a34b1db2de7217d126e"
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v2.5.64](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.64) (2024-08-02)

### Version

#### Chore

- V2.5.64 ([`3430926`](https://github.com/PurpleBooth/git-moves-together/commit/34309266897c7db52e3f1a0c71181baa1c96a119))


