### PR TITLE
fix: Update git-moves-together to v2.5.65

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,16 +1,11 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.64.tar.gz"
-  sha256 "95e83657eb32b9bba9921ebd375a199fa7a3a0f48d325a34b1db2de7217d126e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.64"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "022421f11eadea0e6fd120039d0b10ad8565252881663b22eb8f5971616a18ce"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.65.tar.gz"
+  sha256 "7f9317610bf60530c900bd14ab45d2d64a9b2ba54588032a112b48df02b84553"
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   on_linux do
     depends_on "zlib"
   end


### PR DESCRIPTION
## Changelog
### [v2.5.65](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.65) (2024-08-02)

### Version

#### Chore

- V2.5.65 ([`5fa4c5b`](https://github.com/PurpleBooth/git-moves-together/commit/5fa4c5bb66c8bb7b1c7bfa561b77c7dec6f312d1))


