### PR TITLE
fix: Update whatismyip to v0.11.2

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.10.42.tar.gz"
-  sha256 "539be954bce2b4f3c287c075c069cd5b58c4270392ea31ef13ec62d8038dcc47"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.10.1"
-    sha256 cellar: :any_skip_relocation, big_sur:      "be138bd5b4d3b2ee49a84128151a83dd660626aa16a7e5f262f07cd9a6532ec3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6080d4abc11721cf67bca8a79f386a98058f102c3c1ce5e81c3ac4d06610a5fc"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.11.2.tar.gz"
+  sha256 "4249b7aa8312866779414feef8a2080329a9d6478237c54884c4c3aba7dab868"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.11.2](https://github.com/PurpleBooth/whatismyip/compare/...v0.11.2) (2024-08-03)

### Version

#### Chore

- V0.11.2 ([`604561a`](https://github.com/PurpleBooth/whatismyip/commit/604561ac76dbf57e98f54582e50301f75741d2f1))


