### PR TITLE
fix: Update git-moves-together to v2.5.66

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,15 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.65.tar.gz"
-  sha256 "7f9317610bf60530c900bd14ab45d2d64a9b2ba54588032a112b48df02b84553"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.65"
-    sha256 cellar: :any,                 arm64_sonoma: "b8ce732f0bca52ff49d0cec3a8485686a463bef7a190340a4cfba5e200a3e8f0"
-    sha256 cellar: :any,                 ventura:      "b3cca5217cd4c98f4a4605a890f93e19126b1af0dc4b63145b6490e63eea6ad6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6298fbfa786d88ee2a1219cc84bfc18b9319c7ad9fc3f58e160982d9ee650cca"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.66.tar.gz"
+  sha256 "30ab1a1ceeff2bb3df4e98decc48e0471ad7c7f584841cf3e5854396e8acc7e2"
 
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v2.5.66](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.66) (2024-08-05)

### Deps

#### Fix

- Bump tempfile from 3.10.1 to 3.11.0 ([`f0ab32e`](https://github.com/PurpleBooth/git-moves-together/commit/f0ab32e15825f8faf60e9ec91293cc2a6e31c66f))


### Version

#### Chore

- V2.5.66 ([`bfce564`](https://github.com/PurpleBooth/git-moves-together/commit/bfce564072c0b54823a8b00c9e5b8a97cb8042c9))


