### PR TITLE
fix: Update git-mit to v5.13.8

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.7.tar.gz"
-  sha256 "5b62c67fcf7085622f17a5adb66dac58ff8bb3c8397818adce22e2deda63ee03"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.7"
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "96b6ee0aa3e484843c217b37d2b4c360320d15bdb8a71afbffaea708d2d4212c"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.8.tar.gz"
+  sha256 "df38690885f78223d8abadaa597b2acc1a0fa41a56190d1f644d6da81c986d77"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.8](https://github.com/PurpleBooth/git-mit/compare/...v5.13.8) (2024-08-05)

### Mergify

#### Ci

- Configuration update ([`080cb80`](https://github.com/PurpleBooth/git-mit/commit/080cb80b8fe6262342641bda87fe5430840be65e))


### Deps

#### Chore

- Update purplebooth/common-pipelines action to v0.8.25 ([`36ffbfe`](https://github.com/PurpleBooth/git-mit/commit/36ffbfe482d0c47abe14946bf654bbb026535514))

#### Ci

- Bump PurpleBooth/common-pipelines from 0.8.15 to 0.8.23 ([`96b37ab`](https://github.com/PurpleBooth/git-mit/commit/96b37ab5a193c56c2a70e9d898e91ea3077ff6cc))
- Bump PurpleBooth/generate-formula-action from 0.1.11 to 0.1.13 ([`29abb7d`](https://github.com/PurpleBooth/git-mit/commit/29abb7d801394f8c35193106a1cb877a2c816b7f))

#### Fix

- Update rust crate regex to v1.10.6 ([`a919210`](https://github.com/PurpleBooth/git-mit/commit/a91921054b6c281ef8f72bac1c95728f0b00af4c))


### Version

#### Chore

- V5.13.8 ([`69dfb80`](https://github.com/PurpleBooth/git-mit/commit/69dfb80fb34ebabe1dc8f5b54c2247f4478302cb))


