### PR TITLE
fix: Update git-mit to v5.13.9

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.7.tar.gz"
-  sha256 "5b62c67fcf7085622f17a5adb66dac58ff8bb3c8397818adce22e2deda63ee03"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.7"
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "96b6ee0aa3e484843c217b37d2b4c360320d15bdb8a71afbffaea708d2d4212c"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.9.tar.gz"
+  sha256 "d6896d719a0ee235593cedf5aade020a29c03ee1f4ed4b24aa152fafc8d28ed6"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.9](https://github.com/PurpleBooth/git-mit/compare/...v5.13.9) (2024-08-05)

### Deps

#### Fix

- Bump tempfile from 3.10.1 to 3.11.0 ([`1a83074`](https://github.com/PurpleBooth/git-mit/commit/1a8307406e7120f730d06a3e52a303ad9dd09111))
- Bump regex from 1.10.5 to 1.10.6 ([`be15042`](https://github.com/PurpleBooth/git-mit/commit/be15042d915d5073f972ea07222c8665917a211c))


### Version

#### Chore

- V5.13.9 ([`57f01ae`](https://github.com/PurpleBooth/git-mit/commit/57f01ae267a02660f22985c55227a7326f7bf4d9))


