### PR TITLE
fix: Update git-moves-together to v2.5.67

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,15 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.65.tar.gz"
-  sha256 "7f9317610bf60530c900bd14ab45d2d64a9b2ba54588032a112b48df02b84553"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.65"
-    sha256 cellar: :any,                 arm64_sonoma: "b8ce732f0bca52ff49d0cec3a8485686a463bef7a190340a4cfba5e200a3e8f0"
-    sha256 cellar: :any,                 ventura:      "b3cca5217cd4c98f4a4605a890f93e19126b1af0dc4b63145b6490e63eea6ad6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6298fbfa786d88ee2a1219cc84bfc18b9319c7ad9fc3f58e160982d9ee650cca"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.67.tar.gz"
+  sha256 "b80d6e33cb0556d11750316b0c1b01e5c1ee46b8741285dc29e8910323164c4e"
 
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v2.5.67](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.67) (2024-08-07)

### Deps

#### Fix

- Bump tempfile from 3.11.0 to 3.12.0 ([`6986302`](https://github.com/PurpleBooth/git-moves-together/commit/69863021e6e9c0c55fe2f7aeec79f3c5daf8e8b2))


### Version

#### Chore

- V2.5.67 ([`ea9004f`](https://github.com/PurpleBooth/git-moves-together/commit/ea9004f31991c24e033467ce812d2bc6418638e0))


