### PR TITLE
fix: Update whatismyip to v0.11.3

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.11.2.tar.gz"
-  sha256 "4249b7aa8312866779414feef8a2080329a9d6478237c54884c4c3aba7dab868"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.11.2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "37da53cbf1f5b57d44d5ff5b61a2a86ecf776feb7839769123e1539da146b599"
-    sha256 cellar: :any_skip_relocation, ventura:      "b8cc14bb080a58cd4c8d525e0edaadef3c72fc0a7f1e537af91672355c73c244"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f8f08e75be10b3dbca7414d835679e33fc30d65fe68736842f85acfc33b90f8f"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.11.3.tar.gz"
+  sha256 "072849a6a043f2639ea621fffb01b58c028658ef11c3c514cccab4f92df184c2"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.11.3](https://github.com/PurpleBooth/whatismyip/compare/...v0.11.3) (2024-08-08)

### Deps

#### Fix

- Bump clap from 4.5.13 to 4.5.14 ([`c57968d`](https://github.com/PurpleBooth/whatismyip/commit/c57968de3aff6ce1bac663aaf32bf78f6b1f0b0f))


### Version

#### Chore

- V0.11.3 ([`3daedf4`](https://github.com/PurpleBooth/whatismyip/commit/3daedf4317bbe533aab9ab6bf82a7f083da103c7))


