### PR TITLE
fix: Update readable-name-generator to v2.100.57

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,8 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.56.tar.gz"
-  sha256 "f0bda90ba1bac8ba05aafdf242a28b30a7e7f51047f5d94e28ad7434bfb4aa3c"
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.57.tar.gz"
+  sha256 "84aa9955bfecb5c2c87dd60f1ba0d1b583db7ffc5b5844d732dbf117fe4962da"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test
@@ -12,16 +12,17 @@ class ReadableNameGenerator < Formula
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
 
     # Completions
-    generate_completions_from_executable(bin/"readable-name-generator", "--completion-shell", shells: [:bash, :zsh, :fish])
+    generate_completions_from_executable(bin/"readable-name-generator", "--completion-shell",
+shells: [:bash, :zsh, :fish])
 
     # Man pages
-    output = Utils.safe_popen_read("help2man", "#{bin}/readable-name-generator")
+    output = Utils.safe_popen_read("help2man", bin/"readable-name-generator")
     (man1/"readable-name-generator.1").write output
   end
 
   test do
-    system "#{bin}/readable-name-generator", "-h"
-    system "#{bin}/readable-name-generator", "-V"
+    system bin/"readable-name-generator", "-h"
+    system bin/"readable-name-generator", "-V"
     system "specdown run --temporary-workspace-dir --add-path \"#{bin}\" \"#{prefix}/README.md\""
   end
 end


### PR DESCRIPTION
## Changelog
### [v2.100.57](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.57) (2024-08-08)

### Deps

#### Chore

- Pin rust docker tag to fcbb950 ([`7adde3c`](https://github.com/PurpleBooth/readable-name-generator/commit/7adde3cb44dc780ce042c95eb7d68f6029ae2089))

#### Fix

- Bump clap from 4.5.13 to 4.5.14 ([`6f8ebe3`](https://github.com/PurpleBooth/readable-name-generator/commit/6f8ebe31f4c934424e87f1bae1059994cd9cd1e6))


### Version

#### Chore

- V2.100.57 ([`23ec7fa`](https://github.com/PurpleBooth/readable-name-generator/commit/23ec7fa2a8e122e7aca52af010785ac8187d44d1))


