### PR TITLE
fix: Update readable-name-generator to v2.100.58

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,8 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.56.tar.gz"
-  sha256 "f0bda90ba1bac8ba05aafdf242a28b30a7e7f51047f5d94e28ad7434bfb4aa3c"
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.58.tar.gz"
+  sha256 "8d1a0d1d8bc2289f375d8f617ecf8884f16a947537382f6b8f8662e87409fa38"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test
@@ -12,16 +12,17 @@ class ReadableNameGenerator < Formula
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
 
     # Completions
-    generate_completions_from_executable(bin/"readable-name-generator", "--completion-shell", shells: [:bash, :zsh, :fish])
+    generate_completions_from_executable(bin/"readable-name-generator", "--completion-shell",
+shells: [:bash, :zsh, :fish])
 
     # Man pages
-    output = Utils.safe_popen_read("help2man", "#{bin}/readable-name-generator")
+    output = Utils.safe_popen_read("help2man", bin/"readable-name-generator")
     (man1/"readable-name-generator.1").write output
   end
 
   test do
-    system "#{bin}/readable-name-generator", "-h"
-    system "#{bin}/readable-name-generator", "-V"
+    system bin/"readable-name-generator", "-h"
+    system bin/"readable-name-generator", "-V"
     system "specdown run --temporary-workspace-dir --add-path \"#{bin}\" \"#{prefix}/README.md\""
   end
 end


### PR DESCRIPTION
## Changelog
### [v2.100.58](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.58) (2024-08-08)

### Deps

#### Fix

- Bump clap_complete from 4.5.12 to 4.5.13 ([`9dc65b7`](https://github.com/PurpleBooth/readable-name-generator/commit/9dc65b77f048105584e4281c382e36f90c51ec33))


### Version

#### Chore

- V2.100.58 ([`a76fcc8`](https://github.com/PurpleBooth/readable-name-generator/commit/a76fcc86830db0c0303b5c5efa7e16326f695caa))


