### PR TITLE
fix: Update git-moves-together to v2.5.68

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,15 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.65.tar.gz"
-  sha256 "7f9317610bf60530c900bd14ab45d2d64a9b2ba54588032a112b48df02b84553"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.65"
-    sha256 cellar: :any,                 arm64_sonoma: "b8ce732f0bca52ff49d0cec3a8485686a463bef7a190340a4cfba5e200a3e8f0"
-    sha256 cellar: :any,                 ventura:      "b3cca5217cd4c98f4a4605a890f93e19126b1af0dc4b63145b6490e63eea6ad6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6298fbfa786d88ee2a1219cc84bfc18b9319c7ad9fc3f58e160982d9ee650cca"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.68.tar.gz"
+  sha256 "d047a02f60d7884a0181a38116ee9103ea37b70a0df788b49b87956b0404a52a"
 
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v2.5.68](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.68) (2024-08-09)

### Deps

#### Fix

- Bump clap from 4.5.13 to 4.5.14 ([`405b996`](https://github.com/PurpleBooth/git-moves-together/commit/405b996d60b31de4b4d58c1ffc4f9ddb416af758))


### Version

#### Chore

- V2.5.68 ([`02b3b35`](https://github.com/PurpleBooth/git-moves-together/commit/02b3b350044f012dffa76e7e59def2b311ec867a))


