### PR TITLE
fix: Update git-mit to v5.13.10

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.7.tar.gz"
-  sha256 "5b62c67fcf7085622f17a5adb66dac58ff8bb3c8397818adce22e2deda63ee03"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.7"
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "96b6ee0aa3e484843c217b37d2b4c360320d15bdb8a71afbffaea708d2d4212c"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.10.tar.gz"
+  sha256 "bdb7f6653331fb1c7d9329732b24a959e45948d0eef8bc8510af1c02b8f23f83"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.10](https://github.com/PurpleBooth/git-mit/compare/...v5.13.10) (2024-08-09)

### Deps

#### Chore

- Update rust crate tempfile to v3.12.0 ([`54d3448`](https://github.com/PurpleBooth/git-mit/commit/54d34489c59fb46c1bc248d8ffeb9f10f0e1e56d))

#### Ci

- Bump PurpleBooth/common-pipelines from 0.8.25 to 0.8.26 ([`4bacc07`](https://github.com/PurpleBooth/git-mit/commit/4bacc07c5da8ce2c5f8d55040d47e10a2c08156f))
- Bump PurpleBooth/common-pipelines from 0.8.26 to 0.8.27 ([`57b2307`](https://github.com/PurpleBooth/git-mit/commit/57b230746e09263c77a586307e94d966da2891f1))

#### Fix

- Bump clap from 4.5.13 to 4.5.14 ([`01e3d80`](https://github.com/PurpleBooth/git-mit/commit/01e3d804213e65132c683751bcf41790f78d1d8b))


### Version

#### Chore

- V5.13.10 ([`df94c21`](https://github.com/PurpleBooth/git-mit/commit/df94c2174c5c8659c5a961c4deb3cef401152e3f))


