### PR TITLE
fix: Update git-mit to v5.13.11

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.7.tar.gz"
-  sha256 "5b62c67fcf7085622f17a5adb66dac58ff8bb3c8397818adce22e2deda63ee03"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.7"
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "96b6ee0aa3e484843c217b37d2b4c360320d15bdb8a71afbffaea708d2d4212c"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.11.tar.gz"
+  sha256 "d34efc9b08d0735f8a4b779720bd6e50bd0ebd0b12d69feed4a6f91aff2fd8aa"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
## Changelog
### [v5.13.11](https://github.com/PurpleBooth/git-mit/compare/...v5.13.11) (2024-08-09)

### Deps

#### Fix

- Bump clap_complete from 4.5.12 to 4.5.13 ([`9a88f9f`](https://github.com/PurpleBooth/git-mit/commit/9a88f9f7e4bea33e2cb45653ec69286e3dac2ac0))
- Bump rust from 1.80.0 to 1.80.1 ([`2bbd67e`](https://github.com/PurpleBooth/git-mit/commit/2bbd67e498c2ab112cc93251b3f9159a8537900b))


### Version

#### Chore

- V5.13.11 ([`f9c585f`](https://github.com/PurpleBooth/git-mit/commit/f9c585f833bc8050c9f3d9caab2573d8b977f717))


