### PR TITLE
fix: Update whatismyip to v0.11.4

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
   desc "Manage and provision dotfiles"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.11.2.tar.gz"
-  sha256 "4249b7aa8312866779414feef8a2080329a9d6478237c54884c4c3aba7dab868"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.11.2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "37da53cbf1f5b57d44d5ff5b61a2a86ecf776feb7839769123e1539da146b599"
-    sha256 cellar: :any_skip_relocation, ventura:      "b8cc14bb080a58cd4c8d525e0edaadef3c72fc0a7f1e537af91672355c73c244"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f8f08e75be10b3dbca7414d835679e33fc30d65fe68736842f85acfc33b90f8f"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.11.4.tar.gz"
+  sha256 "32037e1969c2a1c28e379c37d93b42baac940963a4ec2ec0dd32eb7a53e9ea88"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.11.4](https://github.com/PurpleBooth/whatismyip/compare/...v0.11.4) (2024-08-11)

### Deps

#### Fix

- Update rust crate clap to v4.5.15 ([`fbb093a`](https://github.com/PurpleBooth/whatismyip/commit/fbb093ad907ada9a632096ac88f9951f518e491f))


### Version

#### Chore

- V0.11.4 ([`6d03056`](https://github.com/PurpleBooth/whatismyip/commit/6d03056ab643da39d6399a886b0d5338890728e6))


