### PR TITLE
fix: Update git-mit to v5.13.13

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.12.tar.gz"
-  sha256 "1904c73b705a44e0436149b6c40af8f92f248f3ac3266234baeb352b97c4407c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.12"
-    sha256 cellar: :any,                 arm64_sonoma: "9bd3257650582881bd35308a18182be3adc20ac0cd0db238c6bdff16271d0819"
-    sha256 cellar: :any,                 ventura:      "82a648fbdfd7f06a0524ce9272a0f057a0188af3c36eb628a648835ab7b085e5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3a90d18fbb803ba34d96e8b3a6d1ba84451215961c972badfe18af764fc73c9d"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.13.tar.gz"
+  sha256 "11b2a6f7080f8983aa42b179014872b3baeddcc2804260c02b942966bd641a2b"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v5.13.13](https://github.com/PurpleBooth/git-mit/compare/...v5.13.13) (2024-08-12)

### Deps

#### Fix

- Update rust crate clap to v4.5.15 ([`5c7bc96`](https://github.com/PurpleBooth/git-mit/commit/5c7bc96f3173da361c06202d39da806166082588))
- Update rust crate clap_complete to v4.5.14 ([`8f3a936`](https://github.com/PurpleBooth/git-mit/commit/8f3a9366a57fe40f7f44d80f9c9e409725e07afc))


### Version

#### Chore

- V5.13.13 ([`9b99556`](https://github.com/PurpleBooth/git-mit/commit/9b99556000c4f0216b1a7f2f6c1faf16b14735dd))


