### PR TITLE
fix: Update git-mit to v5.13.14

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.13.tar.gz"
-  sha256 "11b2a6f7080f8983aa42b179014872b3baeddcc2804260c02b942966bd641a2b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.13"
-    sha256 cellar: :any,                 arm64_sonoma: "6459fde8e3deb42995fa06b29563af850705c397f459e7a5e8702b524084fda3"
-    sha256 cellar: :any,                 ventura:      "7632b57573f67b8945ca6cb305b46e57ad0840d68a8ee316b63d12d4ecbbbb6b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "177a2cad0d7c20d3d46131b32832d1ed8d0b9d960fa12f1875493887961b38c5"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.14.tar.gz"
+  sha256 "c55a316a7fa74fee4a068b5564ba62606fd25d6b0155695df676d261ba90f127"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v5.13.14](https://github.com/PurpleBooth/git-mit/compare/...v5.13.14) (2024-08-13)

### Deps

#### Fix

- Update rust crate clap_complete to v4.5.16 ([`235b635`](https://github.com/PurpleBooth/git-mit/commit/235b635489822ec8274c760bd91f972933acb1ac))


### Version

#### Chore

- V5.13.14 ([`76ca725`](https://github.com/PurpleBooth/git-mit/commit/76ca725661fa232b5dd548608fc57b4dedf4eaee))


