### PR TITLE
fix: Update readable-name-generator to v2.100.60

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,8 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.58.tar.gz"
-  sha256 "8d1a0d1d8bc2289f375d8f617ecf8884f16a947537382f6b8f8662e87409fa38"
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.60.tar.gz"
+  sha256 "06aabce4aedd6f38a1661c1498f36dbb884a0d1da0d0f05e52475262a9a08a50"
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "specdown/repo/specdown" => :test


### PR DESCRIPTION
## Changelog
### [v2.100.60](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.60) (2024-08-13)

### Deps

#### Fix

- Update rust crate clap to v4.5.15 ([`432d299`](https://github.com/PurpleBooth/readable-name-generator/commit/432d2997dc4312eedd6e9684f174e964dbf1e914))
- Update rust crate clap_complete to v4.5.16 ([`1af7c37`](https://github.com/PurpleBooth/readable-name-generator/commit/1af7c3776e691a7dbc8eaef76d5490f2fbc822e6))


### Version

#### Chore

- V2.100.60 ([`f19d987`](https://github.com/PurpleBooth/readable-name-generator/commit/f19d987fb85e5c861a7f3f5431b44e1cb41a060d))


