### PR TITLE
fix: Update readable-name-generator to v2.100.61

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,11 +1,10 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.58.tar.gz"
-  sha256 "8d1a0d1d8bc2289f375d8f617ecf8884f16a947537382f6b8f8662e87409fa38"
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.61.tar.gz"
+  sha256 "8b652967fe32be648faeb19f14e9e0467a0fbc3e66d87f755ad7c975db145ca1"
   depends_on "help2man" => :build
   depends_on "rust" => :build
-  depends_on "specdown/repo/specdown" => :test
 
   def install
     # Build binary
@@ -23,6 +22,6 @@ shells: [:bash, :zsh, :fish])
   test do
     system bin/"readable-name-generator", "-h"
     system bin/"readable-name-generator", "-V"
-    system "specdown run --temporary-workspace-dir --add-path \"#{bin}\" \"#{prefix}/README.md\""
+    assert_match "gregarious_pauli", shell_output(bin/"readable-name-generator --initial-seed 1")
   end
 end


### PR DESCRIPTION
## Changelog
### [v2.100.61](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.100.61) (2024-08-14)

### Deps

#### Chore

- Update rust:latest docker digest to 536c1a4 ([`e4e0c83`](https://github.com/PurpleBooth/readable-name-generator/commit/e4e0c83027e7218f736128e203fa1606f46bcf7b))
- Update rust:latest docker digest to 29fe437 ([`fbca3bb`](https://github.com/PurpleBooth/readable-name-generator/commit/fbca3bb692f16e37a2000c329cea9155a54c2fc3))

#### Fix

- Update rust crate anarchist-readable-name-generator-lib to v0.1.2 ([`e499278`](https://github.com/PurpleBooth/readable-name-generator/commit/e49927834d6449ba56e429eb2af9189ecf1c80a1))


### Version

#### Chore

- V2.100.61 ([`d0ce6df`](https://github.com/PurpleBooth/readable-name-generator/commit/d0ce6df7e4074e8f33319496bd4dfc94a7bc9a4b))


