### PR TITLE
fix: Update readable-name-generator to v2.101.0

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.100.61.tar.gz"
-  sha256 "8b652967fe32be648faeb19f14e9e0467a0fbc3e66d87f755ad7c975db145ca1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.100.61"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "f1afbf007d6aae5a6f453f16b7e73fcab7ea019f38024f2cda1beeb6d1812c17"
-    sha256 cellar: :any_skip_relocation, ventura:      "acce9f3ba038cec52f103d03861bb1e191c44f84d3374bd0f906ac424e9cd8a5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ac937f01931e7520d80f2b3576875681bad4c8adec63b988a3e69e9e3cd551ba"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.101.0.tar.gz"
+  sha256 "373537683d6c9a90fe7bdbf184ca7ab1a8b197dbd7403fedeaff23c5f458d40d"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v2.101.0](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.101.0) (2024-08-15)

### Version

#### Chore

- V2.101.0 ([`4c5bc1b`](https://github.com/PurpleBooth/readable-name-generator/commit/4c5bc1bbd52ac9d37e02b5cf663535ec639244c9))


