### PR TITLE
fix: Update readable-name-generator to v2.101.2

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.101.1.tar.gz"
-  sha256 "1851116448928ec75e8d18b087163aee14e8a4956e2d5ef7567bbac9dce873b5"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.101.1"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "dd75ff4f282c532a58353a5b9e7429c479e967d44bb24df07b7a93a83cb59d00"
-    sha256 cellar: :any_skip_relocation, ventura:      "91a32afe1cded99aa1851087d876d5a5afd54daa2fa44cb07804401ebaf2211e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "73f84acd6b35a75581054a01ce25ac2509cc0e2dd78837ea4c4aa9a87efd9811"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.101.2.tar.gz"
+  sha256 "e3cfdfcfe6822c12f59cc002e52d6963693ee23239d18c58a2bd93950c0d8b20"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v2.101.2](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.101.2) (2024-08-15)

### Version

#### Chore

- V2.101.2 ([`76faede`](https://github.com/PurpleBooth/readable-name-generator/commit/76faedede9597285d956670a73daec775731acba))


