### PR TITLE
fix: Update whatismyip to v0.11.5

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
-  desc "Manage and provision dotfiles"
+  desc "Work out what your IP is"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.11.4.tar.gz"
-  sha256 "32037e1969c2a1c28e379c37d93b42baac940963a4ec2ec0dd32eb7a53e9ea88"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.11.4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "d3e5a17f86a07c377569c816c34b8a62ad728eeead00c0e00175eb8b9f3afb05"
-    sha256 cellar: :any_skip_relocation, ventura:      "c79cd0cc110d4f649425743ad08a677eaaa4f4b1cf426de3e9cea28ee44f08b2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "11f55b9d96fc26665bdf0d55bd2007f22b557821ce9c5be652cf9556d037868e"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.11.5.tar.gz"
+  sha256 "7ba750311bbf63f7caba66edf5e5e0ddce17516bd71f91cedad0558acdb70bed"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.11.5](https://github.com/PurpleBooth/whatismyip/compare/...v0.11.5) (2024-08-16)

### Deps

#### Fix

- Bump clap from 4.5.15 to 4.5.16 ([`de41a27`](https://github.com/PurpleBooth/whatismyip/commit/de41a27219682213f4eea9a4936604472054e7a4))


### Version

#### Chore

- V0.11.5 ([`7555ece`](https://github.com/PurpleBooth/whatismyip/commit/7555ecea20be5eabc0124bf731519a35c25695d0))


