### PR TITLE
fix: Update readable-name-generator to v2.101.3

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.101.2.tar.gz"
-  sha256 "e3cfdfcfe6822c12f59cc002e52d6963693ee23239d18c58a2bd93950c0d8b20"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.101.2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "96c5058749906028edea25b896439d687243fa51f49ddfde28743cbbd28944b5"
-    sha256 cellar: :any_skip_relocation, ventura:      "694257c7573b218eb50bd6c79d29b08b0b4c65ba44ab1b55c25aaa7a71479c52"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "fe1b59e9e811775f84a914da370a1f24ad38de46cd2c41bdaf3d0ada0b78dda8"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.101.3.tar.gz"
+  sha256 "1c4b75a653817c5cfbab56c1d2817382448dd74429c68d5bb490cb448573e047"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v2.101.3](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.101.3) (2024-08-16)

### Deps

#### Chore

- Pin dependencies ([`d4ea8c7`](https://github.com/PurpleBooth/readable-name-generator/commit/d4ea8c77da6652fc76a24f0bb31698cb6f8102ca))

#### Fix

- Update rust crate clap to v4.5.16 ([`470d198`](https://github.com/PurpleBooth/readable-name-generator/commit/470d198bb615c4ce749a902033f51c6e1f3994ad))
- Bump clap_complete from 4.5.16 to 4.5.17 ([`8916a9c`](https://github.com/PurpleBooth/readable-name-generator/commit/8916a9ced487f786141c719b0106d7f0b1fde4ce))


### Version

#### Chore

- V2.101.3 ([`533e58e`](https://github.com/PurpleBooth/readable-name-generator/commit/533e58e73f7af5def6013a57682d351a9155f197))


