### PR TITLE
fix: Update git-mit to v5.13.19

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.18.tar.gz"
-  sha256 "091966e5632e7f28594b2ec21e59b6e2fdb342e91c0a943ab077fac196870a9b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.18"
-    sha256 cellar: :any,                 arm64_sonoma: "ba0e8bde60d2675bbdd1c46e4c9b2b7c82aeb9768fba73561780305d07ab642f"
-    sha256 cellar: :any,                 ventura:      "a76ede50472786bf277b0f9e35b6881d326e0aa6330635bfc15e069f81880b12"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9c135da035eda081e4a31ca290f45f3e9e4b5ffd52de9e0c52e40b7dfa66aacf"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.19.tar.gz"
+  sha256 "4e878f404f780b93f04d02a4bbd53823274cc75c986d53e90ffa93e10ee55544"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v5.13.19](https://github.com/PurpleBooth/git-mit/compare/...v5.13.19) (2024-08-18)

### Deps

#### Fix

- Update rust crate tokio to v1.39.3 ([`d7c0bd1`](https://github.com/PurpleBooth/git-mit/commit/d7c0bd13a6c7bb90ed460ad2981b2afb19944730))


### Version

#### Chore

- V5.13.19 ([`ffc4aaa`](https://github.com/PurpleBooth/git-mit/commit/ffc4aaa007e07bac7f08b840aade45bb983b904e))


