### PR TITLE
fix: Update git-mit to v5.13.20

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.19.tar.gz"
-  sha256 "4e878f404f780b93f04d02a4bbd53823274cc75c986d53e90ffa93e10ee55544"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.19"
-    sha256 cellar: :any,                 arm64_sonoma: "7068e0638b1eec90b6701bd478e5b364350f28af2b02dcac5a8997ec2548c92d"
-    sha256 cellar: :any,                 ventura:      "b4cc646ace5ff5d7274e7c5221a9db8600ec970c9dd1bb4e152b890c97ddbc0f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "aec2895d2b8c1408b7fbb07658e0cdbbecb5b9ec6d40447cf2d08e2d730c329e"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.20.tar.gz"
+  sha256 "ff9defd5db50ffce01cbc8aa6308ff26e2343813c5c9156e7cb50d127435831a"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v5.13.20](https://github.com/PurpleBooth/git-mit/compare/...v5.13.20) (2024-08-18)

### Deps

#### Fix

- Update rust crate which to v6.0.3 ([`06d1484`](https://github.com/PurpleBooth/git-mit/commit/06d1484602212a477589ac51457b50c99ad4aecf))


### Version

#### Chore

- V5.13.20 ([`a8e692c`](https://github.com/PurpleBooth/git-mit/commit/a8e692cfd530b32836eab42d15c3c8b451663be5))


