### PR TITLE
fix: Update whatismyip to v0.11.6

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.11.5.tar.gz"
-  sha256 "7ba750311bbf63f7caba66edf5e5e0ddce17516bd71f91cedad0558acdb70bed"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.11.5"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "be66e55f2bb9eba22fa31cb58451fbc7cdd45ece1b6e429b3c732d2d4665eab4"
-    sha256 cellar: :any_skip_relocation, ventura:      "dd6daa69617bcffcad0c21065247a5371017cb96c29d38167faa0b19bbb9fbd6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b789683400e09fdb55bbd63da1993207ebb910074a4521d7ce2f969ba170d93f"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.11.6.tar.gz"
+  sha256 "fe3a2bacdcd27ce53661ec99d16ef8237d1e929f240e78f4d7f13dc4d943a5c6"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.11.6](https://github.com/PurpleBooth/whatismyip/compare/...v0.11.6) (2024-08-19)

### Deps

#### Fix

- Update rust crate tokio to v1.39.3 ([`9822dc2`](https://github.com/PurpleBooth/whatismyip/commit/9822dc2efaa5369858c2120371356e6ebf21ecda))


### Version

#### Chore

- V0.11.6 ([`ef8d63d`](https://github.com/PurpleBooth/whatismyip/commit/ef8d63de39899ee5b5089e30893d3cd9531c0f9f))


