### PR TITLE
fix: Update git-moves-together to v2.5.71

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,15 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.70.tar.gz"
-  sha256 "b0fc1a4e2db7eefca607f0462e946483a1e31527899a64984719fd59af57f9ea"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.5.70"
-    sha256 cellar: :any,                 arm64_sonoma: "88f634f191640fe4d449f694fc43205fff25092c24402223c9f45012409e6977"
-    sha256 cellar: :any,                 ventura:      "51ae2d695dbdc3437f283b6c8ec0e5786e9de792826fa48efae3fa1e85645672"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "b22c12a077d992ecf29f02ff1e8ff472e65c7c3fec552eda67f9e4fec19460ce"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.5.71.tar.gz"
+  sha256 "2ded86f53122b88bc97fd41b9a816e903dbc6c9f39a3e1edc1492017648d3387"
 
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v2.5.71](https://github.com/PurpleBooth/git-moves-together/compare/...v2.5.71) (2024-08-19)

### Deps

#### Fix

- Bump tokio from 1.39.2 to 1.39.3 ([`946d4ac`](https://github.com/PurpleBooth/git-moves-together/commit/946d4ac034a53ba5ecc8e252ac141999853043ac))


### Version

#### Chore

- V2.5.71 ([`74c4682`](https://github.com/PurpleBooth/git-moves-together/commit/74c468239dfbfafc579bedd0ed150a8d0934277e))


