### PR TITLE
fix: Update readable-name-generator to v2.101.4

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.101.3.tar.gz"
-  sha256 "1c4b75a653817c5cfbab56c1d2817382448dd74429c68d5bb490cb448573e047"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.101.3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "ac49d32632e2fd153f35570f67b7a19e533816c886f5f1a1123445cde9e0bff3"
-    sha256 cellar: :any_skip_relocation, ventura:      "0249b9b399873832b397f3e498546edbf96b99ebf6c674978b835ab60de5b632"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0bfdf9b104cc2503bb22d72f00832048d4376991541730fc9fdf93b99ef66443"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.101.4.tar.gz"
+  sha256 "849056a32a97bfa001b3a1f777942690f324c6ff978675cbaf68d8d5aa421d9e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v2.101.4](https://github.com/PurpleBooth/readable-name-generator/compare/...v2.101.4) (2024-08-19)

### Deps

#### Chore

- Pin softprops/action-gh-release action to c062e08 ([`44bc8e2`](https://github.com/PurpleBooth/readable-name-generator/commit/44bc8e2063d1c14e254463546c1541b3350feba1))

#### Fix

- Update rust crate clap_complete to v4.5.18 ([`260f144`](https://github.com/PurpleBooth/readable-name-generator/commit/260f14422bbac8b156adb8589fc157cbb438e89a))
- Bump clap_complete from 4.5.17 to 4.5.19 ([`a905fe6`](https://github.com/PurpleBooth/readable-name-generator/commit/a905fe699397fff8391e852775cb70c93515152e))


### Version

#### Chore

- V2.101.4 ([`682ae6d`](https://github.com/PurpleBooth/readable-name-generator/commit/682ae6d69e5fd74130ae234400e9823b56e3599e))


