### PR TITLE
fix: Update readable-name-generator to v3.0.0

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v2.101.4.tar.gz"
-  sha256 "849056a32a97bfa001b3a1f777942690f324c6ff978675cbaf68d8d5aa421d9e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-2.101.4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "82fb9c21091fd1140a0b1cb7eb267b2c34fe7cf85862eb5ab24de91874066d7b"
-    sha256 cellar: :any_skip_relocation, ventura:      "ec97db44cc35b28bd8d6c492e64b5062e2cf43131c1ea1ca9ef8b663efbcf9c6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "fa2d21f6fe12c2d62bdafb441385183ac3ed35418cf22a0700fa4f0776514de3"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v3.0.0.tar.gz"
+  sha256 "0ed448d1e38c23dd892ade397087260ae42a1c1af6483eed5407f34699c9b7d9"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v3.0.0](https://github.com/PurpleBooth/readable-name-generator/compare/...v3.0.0) (2024-08-19)

### FastConventional

#### Build

- Add fast conventional ([`4b18b23`](https://github.com/PurpleBooth/readable-name-generator/commit/4b18b23dcb7dc3950f66a4d1d0315ed4c8ff1289))


### Homebrew

#### Fix

- Fix urls in template ([`27bbafb`](https://github.com/PurpleBooth/readable-name-generator/commit/27bbafb38bf4c42068a9cad14e9bf2f17af41b7f))


### Mergify

#### Ci

- Configuration update ([`9c68c6a`](https://github.com/PurpleBooth/readable-name-generator/commit/9c68c6af30b47d175eb81973842f5702e4a9a651))
- Configuration update ([`cc58db1`](https://github.com/PurpleBooth/readable-name-generator/commit/cc58db1c6c88a0e5ea4a1aaf181b484debc89de7))


### Changelog

#### Ci

- Use centralised changelog ([`fe3c497`](https://github.com/PurpleBooth/readable-name-generator/commit/fe3c49711b2e5fff32b857d6ad3e1540fb53bb17))


### Dependabot

#### Build

- Add scope for dependencies ([`da51b58`](https://github.com/PurpleBooth/readable-name-generator/commit/da51b58e3374f309f13c0ead59d1c873e3cbc9df))


### Deploy

#### Build

- Versio update versions ([`2f999e2`](https://github.com/PurpleBooth/readable-name-generator/commit/2f999e210cf98697b64730d4bd6cf92ad20318d3))
- Versio update versions ([`eafa24d`](https://github.com/PurpleBooth/readable-name-generator/commit/eafa24df36140d70fdf8bcd63180e502cb45f7d8))
- Versio update versions ([`e639bcc`](https://github.com/PurpleBooth/readable-name-generator/commit/e639bccbad988d050c9ec37ae2b5dce0ddfe29df))
- Versio update versions ([`0345225`](https://github.com/PurpleBooth/readable-name-generator/commit/0345225166fd143af7faea4ecf0c80814c43c2c2))
- Versio update versions ([`f4c2be5`](https://github.com/PurpleBooth/readable-name-generator/commit/f4c2be5205e85426bc058eb8541942c836e393e2))
- Versio update versions ([`23ba401`](https://github.com/PurpleBooth/readable-name-generator/commit/23ba401aac5fd3cd518839140ddf2799ca28d56a))
- Versio update versions ([`5881a04`](https://github.com/PurpleBooth/readable-name-generator/commit/5881a0403fc3ee0d03e03a9bd7eb5214d7a480cc))
- Versio update versions ([`211b1b6`](https://github.com/PurpleBooth/readable-name-generator/commit/211b1b6d5bb2d7e55ad43be26ff9fd4275c4a86f))
- Versio update versions ([`2cca7e7`](https://github.com/PurpleBooth/readable-name-generator/commit/2cca7e7dcbbb5d1d407f89ba680e1f359e5d2792))
- Versio update versions ([`b7ce797`](https://github.com/PurpleBooth/readable-name-generator/commit/b7ce797e2157570a4f98b4c1edde2c147f6c11d4))
- Versio update versions ([`c18caf5`](https://github.com/PurpleBooth/readable-name-generator/commit/c18caf59fcb928b465b5cff0b93f51f346b22512))
- Versio update versions ([`1bb2788`](https://github.com/PurpleBooth/readable-name-generator/commit/1bb278893742467d385631a6d32f29013aa0b58e))
- Versio update versions ([`c94fa58`](https://github.com/PurpleBooth/readable-name-generator/commit/c94fa586f10e04742b884551b2099d335e5cab20))
- Versio update versions ([`0ef1049`](https://github.com/PurpleBooth/readable-name-generator/commit/0ef1049994e31fd0ed08d78430ff8017ef5a161a))
- Versio update versions ([`8b9bda2`](https://github.com/PurpleBooth/readable-name-generator/commit/8b9bda29d4a13378fef92d38195a4b15a4b05fb7))
- Versio update versions ([`a1c7465`](https://github.com/PurpleBooth/readable-name-generator/commit/a1c7465c4b9f716a6040ae9d4c73a74f781264bd))
- Versio update versions ([`3fd72fb`](https://github.com/PurpleBooth/readable-name-generator/commit/3fd72fb911bc1ac00c5608bcb03c77a752a312e6))
- Versio update versions ([`dabff31`](https://github.com/PurpleBooth/readable-name-generator/commit/dabff31d6ba62f1e12630c12ddb031dbd17c5c8e))
- Versio update versions ([`3933ee1`](https://github.com/PurpleBooth/readable-name-generator/commit/3933ee169953728d9414979163f0c5f5f4523626))
- Versio update versions ([`4c599a2`](https://github.com/PurpleBooth/readable-name-generator/commit/4c599a2c65ce464bd9579c29d763dcf46facae34))
- Versio update versions ([`f9489ba`](https://github.com/PurpleBooth/readable-name-generator/commit/f9489ba457ad47a67a27f9ec77752c1944e00585))
- Versio update versions ([`e77f46d`](https://github.com/PurpleBooth/readable-name-generator/commit/e77f46d4dff565245ab2cc8d5f55c22772ee0a70))
- Versio update versions ([`8bc33b0`](https://github.com/PurpleBooth/readable-name-generator/commit/8bc33b0a4729a5b0d2522e359cc1b970e2fb8e45))
- Versio update versions ([`c9be0b6`](https://github.com/PurpleBooth/readable-name-generator/commit/c9be0b608a21321027d17eaaa218924984698fa7))
- Versio update versions ([`0b84d34`](https://github.com/PurpleBooth/readable-name-generator/commit/0b84d34350c7f1e111400dd32aa265350e9a134b))
- Versio update versions ([`03d14fc`](https://github.com/PurpleBooth/readable-name-generator/commit/03d14fc0fc33e2fb0afbdacbee6349801411119d))
- Versio update versions ([`2ec1e2b`](https://github.com/PurpleBooth/readable-name-generator/commit/2ec1e2b484d541338b9b3427f2e5149f476a9416))
- Versio update versions ([`3b94b8d`](https://github.com/PurpleBooth/readable-name-generator/commit/3b94b8dad4adef3466920188854a3398fcc0706d))
- Versio update versions ([`4ec6159`](https://github.com/PurpleBooth/readable-name-generator/commit/4ec6159761a5014f48d93d2eabd2b0e3ff332b94))
- Versio update versions ([`5ad908b`](https://github.com/PurpleBooth/readable-name-generator/commit/5ad908bf0ef48e192fd83d827614770b33bdabcf))
- Versio update versions ([`4d9b932`](https://github.com/PurpleBooth/readable-name-generator/commit/4d9b932f0e23b60347104ae2c0c602315470fb43))
- Versio update versions ([`17e848f`](https://github.com/PurpleBooth/readable-name-generator/commit/17e848f3558ee1834d7f41622168aa4e4167f93d))
- Versio update versions ([`4f9a417`](https://github.com/PurpleBooth/readable-name-generator/commit/4f9a417a8dd6a444fe71a716767423c1d6e55e9f))
- Versio update versions ([`8a4d709`](https://github.com/PurpleBooth/readable-name-generator/commit/8a4d709b7139928bdc7f89af38f0d838640cc862))
- Versio update versions ([`e6103cb`](https://github.com/PurpleBooth/readable-name-generator/commit/e6103cbeb96c22369f371ee95dfdb4f656acaae8))
- Versio update versions ([`ace768c`](https://github.com/PurpleBooth/readable-name-generator/commit/ace768c401f96fb99c9ee2dd5c5f0517179443cf))
- Versio update versions ([`460b72a`](https://github.com/PurpleBooth/readable-name-generator/commit/460b72a97ce40c8c7c4898fb8a7ec758f97a161c))
- Versio update versions ([`a8037ab`](https://github.com/PurpleBooth/readable-name-generator/commit/a8037ab73839ca65ece9cfc562e7b3ae7c3fbffc))
- Versio update versions ([`4028444`](https://github.com/PurpleBooth/readable-name-generator/commit/4028444f5c0310ad35ee53dda17b7d886ea6c20a))
- Versio update versions ([`359cb8f`](https://github.com/PurpleBooth/readable-name-generator/commit/359cb8f41df10c71198050b4b34a40ff31df1fa7))
- Versio update versions ([`76c9b8a`](https://github.com/PurpleBooth/readable-name-generator/commit/76c9b8a78f10966dc67a9874427ad2cde054aa5a))
- Versio update versions ([`06a1eb6`](https://github.com/PurpleBooth/readable-name-generator/commit/06a1eb6804ca09e7ce966b1748c5315a9d0e734f))
- Versio update versions ([`a50380b`](https://github.com/PurpleBooth/readable-name-generator/commit/a50380ba568204175458fb1fb60aeaa6978cfee1))
- Versio update versions ([`42070d5`](https://github.com/PurpleBooth/readable-name-generator/commit/42070d55dfaa35724481a6024d92a4a96ab4a77f))
- Versio update versions ([`460d424`](https://github.com/PurpleBooth/readable-name-generator/commit/460d424062a816b1bb7078e099d7dd04ab8155d2))
- Versio update versions ([`df4fcc3`](https://github.com/PurpleBooth/readable-name-generator/commit/df4fcc3fc9128cd01ca41d798536f6ad7ceb1c3b))
- Versio update versions ([`9f94ee2`](https://github.com/PurpleBooth/readable-name-generator/commit/9f94ee212a816588ce6009efa7e5c6b5e4662743))


### Deps

#### Build

- Bump golang from 1.13.4-alpine to 1.13.5-alpineBumps golang from 1.13.4-alpine to 1.13.5-alpine.Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([`2940f43`](https://github.com/PurpleBooth/readable-name-generator/commit/2940f432c076dbf05c904610fd486f67c6f483e4))
- Bump golang from 1.13.5-alpine to 1.13.6-alpineBumps golang from 1.13.5-alpine to 1.13.6-alpine.Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([`dd6de29`](https://github.com/PurpleBooth/readable-name-generator/commit/dd6de29b02bb527aaff50237aded95dc1422aad1))
- Bump golang from 1.13.6-alpine to 1.13.7-alpineBumps golang from 1.13.6-alpine to 1.13.7-alpine.Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([`fa3d020`](https://github.com/PurpleBooth/readable-name-generator/commit/fa3d02018da31ee2aeec424268fe6fd65acb6c1d))
- Bump golang from 1.13.7-alpine to 1.13.8-alpineBumps golang from 1.13.7-alpine to 1.13.8-alpine.Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([`229287b`](https://github.com/PurpleBooth/readable-name-generator/commit/229287bc8e7702ab523ce6b517c90bb96663ccab))
- Bump golang from 1.13.8-alpine to 1.14.0-alpineBumps golang from 1.13.8-alpine to 1.14.0-alpine.Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([`2926857`](https://github.com/PurpleBooth/readable-name-generator/commit/2926857d0c1d2b1f10e7ac1b645734e564aacd69))

#### Chore

- Upgrade clap ([`03c82df`](https://github.com/PurpleBooth/readable-name-generator/commit/03c82dfcc11abe11c3b760a3e7af7eae5e8b9b40))
- Pin rust docker tag to fcbb950 ([`824cd30`](https://github.com/PurpleBooth/readable-name-generator/commit/824cd30cec52f558928335237512c2d2fbafd775))
- Update rust:latest docker digest to 536c1a4 ([`352ef1c`](https://github.com/PurpleBooth/readable-name-generator/commit/352ef1c7c49b0795b8c097647477dc6c11dee87c))
- Update rust:latest docker digest to 29fe437 ([`c63fc2d`](https://github.com/PurpleBooth/readable-name-generator/commit/c63fc2d21e5d75d9ea46f0c571c655c1f5a22449))
- Pin dependencies ([`4978c33`](https://github.com/PurpleBooth/readable-name-generator/commit/4978c33966c87db9da0b0a97b8e958bb67a2f462))
- Pin softprops/action-gh-release action to c062e08 ([`ab7a5a5`](https://github.com/PurpleBooth/readable-name-generator/commit/ab7a5a5d130b57758f5caac776485f9b204775aa))

#### Ci

- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`72c7428`](https://github.com/PurpleBooth/readable-name-generator/commit/72c7428f1d71145fdf1dd9d13334ca6adb3e6fc3))
- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`508d023`](https://github.com/PurpleBooth/readable-name-generator/commit/508d02340116b4ccc75cd2fd22d781c6fc55d450))
- Bump PurpleBooth/versio-release-action from 0.1.9 to 0.1.10 ([`3ad5c9a`](https://github.com/PurpleBooth/readable-name-generator/commit/3ad5c9a23bb0ffa4796d405cb8142357166f02cb))
- Bump PurpleBooth/versio-release-action from 0.1.10 to 0.1.11 ([`cee52bd`](https://github.com/PurpleBooth/readable-name-generator/commit/cee52bd5d333f793cc904cbfb23ffabe150cdacf))
- Bump PurpleBooth/versio-release-action from 0.1.11 to 0.1.12 ([`b85e6bf`](https://github.com/PurpleBooth/readable-name-generator/commit/b85e6bf2a13de3b1a163430021b97bd25e99ae51))
- Bump PurpleBooth/versio-release-action from 0.1.12 to 0.1.13 ([`d2bedf1`](https://github.com/PurpleBooth/readable-name-generator/commit/d2bedf1716fb420ef4179bf8777433c2deee55b2))
- Bump PurpleBooth/versio-release-action from 0.1.13 to 0.1.15 ([`357db65`](https://github.com/PurpleBooth/readable-name-generator/commit/357db658ca9f4271538b1bfb241362f52c518c40))
- Bump PurpleBooth/versio-release-action from 0.1.15 to 0.1.16 ([`85333e8`](https://github.com/PurpleBooth/readable-name-generator/commit/85333e8b360c61b68bd8512c192e5320bca81ccb))
- Bump PurpleBooth/versio-release-action from 0.1.16 to 0.1.17 ([`789b142`](https://github.com/PurpleBooth/readable-name-generator/commit/789b14210f24435832eeb8664980311d7fae5e99))
- Bump PurpleBooth/common-pipelines from 0.4.5 to 0.6.50 ([`16f2cf5`](https://github.com/PurpleBooth/readable-name-generator/commit/16f2cf5dedd665f0104714f00feae9d14ba90041))
- Bump PurpleBooth/common-pipelines from 0.6.50 to 0.6.51 ([`668b6ce`](https://github.com/PurpleBooth/readable-name-generator/commit/668b6ce7105f30521fe82dbc2d313541c53a0064))
- Bump PurpleBooth/common-pipelines from 0.6.51 to 0.6.52 ([`c8a39ab`](https://github.com/PurpleBooth/readable-name-generator/commit/c8a39ab03382ce89cd7654c1b863db1d6af6dd52))

#### Fix

- Bump miette from 4.0.1 to 4.2.0 ([`c9b3bc0`](https://github.com/PurpleBooth/readable-name-generator/commit/c9b3bc0942de272c809f5f544d88d96dcbf70cc6))
- Bump clap from 3.1.1 to 3.1.2 ([`578d023`](https://github.com/PurpleBooth/readable-name-generator/commit/578d0234d0b9ab9b336dc279c28d320a5220f904))
- Bump rust from 1.58.1 to 1.59.0 ([`82d3d67`](https://github.com/PurpleBooth/readable-name-generator/commit/82d3d67dd21bc7024a3d40ab283f6e9da44df384))
- Bump miette from 4.2.0 to 4.2.1 ([`f298d3b`](https://github.com/PurpleBooth/readable-name-generator/commit/f298d3b9c9059ea6c7faa7d863f1383f8b649173))
- Bump clap from 3.1.2 to 3.1.3 ([`bc180d0`](https://github.com/PurpleBooth/readable-name-generator/commit/bc180d02bdd35af7a54b63fb0dabb46d589af1b5))
- Bump clap from 3.1.3 to 3.1.5 ([`cb6801d`](https://github.com/PurpleBooth/readable-name-generator/commit/cb6801d8b6c8128df51646df183d5c8df366ad39))
- Bump clap_complete from 3.1.0 to 3.1.1 ([`f4f10ce`](https://github.com/PurpleBooth/readable-name-generator/commit/f4f10ce5687eda565d058c88561fd1c13a8ce03b))
- Bump clap from 3.1.5 to 3.1.6 ([`fa5cf60`](https://github.com/PurpleBooth/readable-name-generator/commit/fa5cf60a5e0b29cca9aab33e959d4bdd2c0e04ae))
- Bump miette from 4.2.1 to 4.3.0 ([`5149d46`](https://github.com/PurpleBooth/readable-name-generator/commit/5149d46c0abc9593af8c8342e86c97ed707ee314))
- Bump clap from 3.1.6 to 3.1.7 ([`eac9546`](https://github.com/PurpleBooth/readable-name-generator/commit/eac95461d995be9bc7a9142e2c18fc729182b949))
- Bump clap from 3.1.7 to 3.1.8 ([`4b85e37`](https://github.com/PurpleBooth/readable-name-generator/commit/4b85e370c2652ec39e8578e91388e66423866136))
- Bump rust from 1.59.0 to 1.60.0 ([`33c3ab6`](https://github.com/PurpleBooth/readable-name-generator/commit/33c3ab63297bba8f76ba4c7407cd4284b39b0631))
- Bump miette from 4.3.0 to 4.4.0 ([`d6e624f`](https://github.com/PurpleBooth/readable-name-generator/commit/d6e624f6877a57a4360b9413e1fa5bd3b1065220))
- Bump miette from 4.4.0 to 4.5.0 ([`e517c01`](https://github.com/PurpleBooth/readable-name-generator/commit/e517c011a2ab07b7540a0008aa788e17caac994a))
- Bump clap from 3.1.8 to 3.1.9 ([`7630465`](https://github.com/PurpleBooth/readable-name-generator/commit/7630465e43938c6d25b308fdef3ac30eedbe72da))
- Bump clap from 3.1.9 to 3.1.10 ([`30f7e62`](https://github.com/PurpleBooth/readable-name-generator/commit/30f7e62133bfca9a66d0aeb6a31fc61faee009f9))
- Bump clap_complete from 3.1.1 to 3.1.2 ([`5b89439`](https://github.com/PurpleBooth/readable-name-generator/commit/5b89439ef832838123b497485dab6db4ad775e21))
- Bump clap from 3.1.10 to 3.1.12 ([`4fde2e1`](https://github.com/PurpleBooth/readable-name-generator/commit/4fde2e11ff6212cd45b9b1b1bcdd21420417eda3))
- Bump miette from 4.5.0 to 4.6.0 ([`78b5cb5`](https://github.com/PurpleBooth/readable-name-generator/commit/78b5cb5d31d0bddac711e3d78592f25330e78127))
- Bump clap from 3.1.12 to 3.1.15 ([`82c5d20`](https://github.com/PurpleBooth/readable-name-generator/commit/82c5d2024cc4311679cb61b060e27450ff4a6394))
- Bump thiserror from 1.0.30 to 1.0.31 ([`9e0da89`](https://github.com/PurpleBooth/readable-name-generator/commit/9e0da89a33766bc9f1ef1ccf1e4cccb334c678d9))
- Bump clap_complete from 3.1.2 to 3.1.3 ([`e5084ab`](https://github.com/PurpleBooth/readable-name-generator/commit/e5084abfac19cd3c7966b8cfcf0d28bc3f3863e4))
- Bump clap from 3.1.15 to 3.1.17 ([`5ca3a91`](https://github.com/PurpleBooth/readable-name-generator/commit/5ca3a9192a2bc00dfe961782c62c8dfe53634ea5))
- Bump clap_complete from 3.1.3 to 3.1.4 ([`1d0b34e`](https://github.com/PurpleBooth/readable-name-generator/commit/1d0b34e1c40a7db79f85086b10927723d07d2a51))
- Bump miette from 4.6.0 to 4.7.0 ([`a5af57d`](https://github.com/PurpleBooth/readable-name-generator/commit/a5af57d328f8486f0e645baf71b02f3f58fd5f75))
- Bump clap from 3.1.17 to 3.1.18 ([`c577464`](https://github.com/PurpleBooth/readable-name-generator/commit/c577464af61e444d2543d1cfcb428dec6409a63d))
- Bump miette from 4.7.0 to 4.7.1 ([`7a32cf1`](https://github.com/PurpleBooth/readable-name-generator/commit/7a32cf1fab80f90adc09bff7ced6959080ce0ad2))
- Bump rust from 1.60.0 to 1.61.0 ([`ee54758`](https://github.com/PurpleBooth/readable-name-generator/commit/ee54758639da59a1cab6318349222e1cf4f8f080))
- Bump regex from 1.5.4 to 1.5.6 ([`e040def`](https://github.com/PurpleBooth/readable-name-generator/commit/e040def391b8446a50360e3ae54208f5bf58563e))
- Bump clap_complete from 3.1.4 to 3.2.1 ([`ba3c012`](https://github.com/PurpleBooth/readable-name-generator/commit/ba3c0123d9395b4c4b1b0cd2972af0bd6090047a))
- Bump clap from 3.2.3 to 3.2.5 ([`effb811`](https://github.com/PurpleBooth/readable-name-generator/commit/effb8113a27c658a270150c61adb86fda291be59))
- Bump clap_complete from 3.2.1 to 3.2.2 ([`337cc93`](https://github.com/PurpleBooth/readable-name-generator/commit/337cc93b1ff40c2fdae227fb089a50951fc3baa5))
- Bump clap from 3.2.5 to 3.2.6 ([`c47a36f`](https://github.com/PurpleBooth/readable-name-generator/commit/c47a36f449c6528b5b01523ed6aae74ef6df237b))
- Bump miette from 4.7.1 to 5.1.0 ([`f196c6a`](https://github.com/PurpleBooth/readable-name-generator/commit/f196c6a26096f945396c1be27b88ce8106aec15c))
- Bump clap_complete from 3.2.2 to 3.2.3 ([`45f0bac`](https://github.com/PurpleBooth/readable-name-generator/commit/45f0bac25eb8947e02192f473200b0bc0f0e2bcc))
- Bump clap from 3.2.6 to 3.2.7 ([`eeebc46`](https://github.com/PurpleBooth/readable-name-generator/commit/eeebc46786deadd95573515161bcc51ce663b7a4))
- Bump clap from 3.2.7 to 3.2.8 ([`6e7d10e`](https://github.com/PurpleBooth/readable-name-generator/commit/6e7d10efc18d468c14571bea8b1e2a26a0cadaa1))
- Bump rust from 1.61.0 to 1.62.0 ([`bf399e9`](https://github.com/PurpleBooth/readable-name-generator/commit/bf399e935678eb842c399178139b3c81f761174c))
- Bump miette from 5.1.0 to 5.1.1 ([`ac9fc0e`](https://github.com/PurpleBooth/readable-name-generator/commit/ac9fc0e9ba556d701395b7ad569c5579f568d383))
- Bump clap from 3.2.8 to 3.2.12 ([`1ba67c1`](https://github.com/PurpleBooth/readable-name-generator/commit/1ba67c1fa75a0da952ea5507d62cb8867d9cb36b))
- Bump rust from 1.62.0 to 1.62.1 ([`3e82c4b`](https://github.com/PurpleBooth/readable-name-generator/commit/3e82c4bed0afb9c7945f5bf077e2b8a796a44712))
- Bump clap from 3.2.12 to 3.2.13 ([`b386715`](https://github.com/PurpleBooth/readable-name-generator/commit/b38671522dddf221c2a7558372e35227a2b33025))
- Bump clap from 3.2.13 to 3.2.14 ([`a0e3b14`](https://github.com/PurpleBooth/readable-name-generator/commit/a0e3b146c8c3f1c192d1e976aa15a59e41835b1b))
- Bump clap from 3.2.14 to 3.2.15 ([`8a968c7`](https://github.com/PurpleBooth/readable-name-generator/commit/8a968c7865c34c305866e286814e84712f9c161a))
- Bump miette from 5.1.1 to 5.2.0 ([`90ed296`](https://github.com/PurpleBooth/readable-name-generator/commit/90ed29619a8fcead3108f4bb5960faead40d6c4c))
- Bump clap from 3.2.15 to 3.2.16 ([`56be37d`](https://github.com/PurpleBooth/readable-name-generator/commit/56be37d3c00c2f39903ff9b185c5857d5817b470))
- Bump thiserror from 1.0.31 to 1.0.32 ([`5054a24`](https://github.com/PurpleBooth/readable-name-generator/commit/5054a24422f88564b7a0ce8b9b57b33929a88826))
- Bump thiserror from 1.0.32 to 1.0.37 ([`0be5d15`](https://github.com/PurpleBooth/readable-name-generator/commit/0be5d15e15a08a242906b867560b2b8685147c8e))
- Bump rust from 1.62.1 to 1.64.0 ([`d2cf1e3`](https://github.com/PurpleBooth/readable-name-generator/commit/d2cf1e3be31c316e012f815169e4ccaf9df74d70))
- Bump clap from 3.2.16 to 3.2.21 ([`fd928d0`](https://github.com/PurpleBooth/readable-name-generator/commit/fd928d00e4cd821cda355b727be33f0450b17845))
- Bump miette from 5.2.0 to 5.3.0 ([`d8a5930`](https://github.com/PurpleBooth/readable-name-generator/commit/d8a593077d3e9dce2d537ea434f937676d037c3a))
- Bump miette from 5.3.0 to 5.4.1 ([`8aec65c`](https://github.com/PurpleBooth/readable-name-generator/commit/8aec65cc6d263009c22c11b6587ce7ac94419cfd))
- Bump rust from 1.64.0 to 1.65.0 ([`ed6ac11`](https://github.com/PurpleBooth/readable-name-generator/commit/ed6ac119575f17f0a3bf2e9717dccd21e117eb92))
- Bump miette from 5.4.1 to 5.5.0 ([`3b17cf5`](https://github.com/PurpleBooth/readable-name-generator/commit/3b17cf56c4e4b3fe563dea6c1c0a0d670be51936))
- Bump rust from 1.65.0 to 1.66.0 ([`d57e7e4`](https://github.com/PurpleBooth/readable-name-generator/commit/d57e7e409c93c7021aba564ac11f75c120fae5f5))
- Bump thiserror from 1.0.37 to 1.0.38 ([`7133815`](https://github.com/PurpleBooth/readable-name-generator/commit/713381579ced269df0d4bfea1310ab93594c87df))
- Bump rust from 1.66.0 to 1.66.1 ([`9a3281d`](https://github.com/PurpleBooth/readable-name-generator/commit/9a3281d5983fe6b93dd6796e13594439565dc2b0))
- Bump rust from 1.66.1 to 1.67.0 ([`aadea07`](https://github.com/PurpleBooth/readable-name-generator/commit/aadea07547d499afaca93b56190e99366f8f0a02))
- Bump rust from 1.67.0 to 1.67.1 ([`5600ea9`](https://github.com/PurpleBooth/readable-name-generator/commit/5600ea941538e8ee5f3f7c47a5d06adc1d3025fc))
- Bump thiserror from 1.0.38 to 1.0.39 ([`458618e`](https://github.com/PurpleBooth/readable-name-generator/commit/458618e0455a5a85fe8713f8a4f9bfdb95bb29f5))
- Bump rust from 1.67.1 to 1.68.0 ([`ab34859`](https://github.com/PurpleBooth/readable-name-generator/commit/ab34859ce06abe1b8b2db5e6eb2e313eb6a7bee5))
- Bump versions ([`bc0f449`](https://github.com/PurpleBooth/readable-name-generator/commit/bc0f449ca8f26f5ef27839c4e3dc1b0c26a3067b))
- Bump clap from 4.4.18 to 4.5.13 ([`408d355`](https://github.com/PurpleBooth/readable-name-generator/commit/408d3551ec30298064f2d16ba322006e8cc7aa9c))
- Bump miette from 5.10.0 to 7.2.0 ([`b2cb3ad`](https://github.com/PurpleBooth/readable-name-generator/commit/b2cb3adf2903088ac86f254865c2ef18f529d8ec))
- Bump thiserror from 1.0.56 to 1.0.63 ([`1fdb303`](https://github.com/PurpleBooth/readable-name-generator/commit/1fdb3039e4731189bd41d299f68f40ef8bc496b6))
- Bump clap_complete from 4.4.9 to 4.5.12 ([`e314447`](https://github.com/PurpleBooth/readable-name-generator/commit/e314447980798b01db77386666495d0b3a80f268))
- Bump clap from 4.5.13 to 4.5.14 ([`2b423c7`](https://github.com/PurpleBooth/readable-name-generator/commit/2b423c7100c2add5e8576fe254eecc95461b2dc1))
- Bump clap_complete from 4.5.12 to 4.5.13 ([`403df74`](https://github.com/PurpleBooth/readable-name-generator/commit/403df743cf39c73f382ddef111e17a49dfcc7e7c))
- Bump rust from `fcbb950` to `606b76f` ([`5e87bfe`](https://github.com/PurpleBooth/readable-name-generator/commit/5e87bfe4fb159f23b6b179201f8cbaeaa74df891))
- Update rust crate clap to v4.5.15 ([`d9a74fd`](https://github.com/PurpleBooth/readable-name-generator/commit/d9a74fd3b91df80f6951e5915f9a85357befce70))
- Update rust crate clap_complete to v4.5.16 ([`e3944f1`](https://github.com/PurpleBooth/readable-name-generator/commit/e3944f1bed3c324a6737758d058bd6e5f33c517b))
- Update rust crate anarchist-readable-name-generator-lib to v0.1.2 ([`b214a56`](https://github.com/PurpleBooth/readable-name-generator/commit/b214a56abe00d4b5bd81ae6954e3608e68c105c3))
- Update rust crate clap to v4.5.16 ([`50e1111`](https://github.com/PurpleBooth/readable-name-generator/commit/50e11112633049248c3ed013658b64ee0659c438))
- Bump clap_complete from 4.5.16 to 4.5.17 ([`8298679`](https://github.com/PurpleBooth/readable-name-generator/commit/82986793dc93d885997f9efdacb92e3846897f02))
- Update rust crate clap_complete to v4.5.18 ([`b59badc`](https://github.com/PurpleBooth/readable-name-generator/commit/b59badc5e128feae2d2c0ae4b09158a531adae28))
- Bump clap_complete from 4.5.17 to 4.5.19 ([`d56f44b`](https://github.com/PurpleBooth/readable-name-generator/commit/d56f44b1e14cffa9563c0c6b79fc2ccf09f930dd))


### Src

#### Docs

- Formatting ([`66c8139`](https://github.com/PurpleBooth/readable-name-generator/commit/66c813938b099ed81298f091e93c0fe166539d8a))

#### Refactor

- Follow clippy advice ([`97b41bc`](https://github.com/PurpleBooth/readable-name-generator/commit/97b41bc4b8952a95c1313155e7af2b70a5f8fc77))


### Version

#### Chore

- V2.100.53  ([`02c3b3b`](https://github.com/PurpleBooth/readable-name-generator/commit/02c3b3b6f368815d3b47b47f08a63c6c2a761328))
- V2.100.54 ([`6a867f7`](https://github.com/PurpleBooth/readable-name-generator/commit/6a867f7964ea14ed704e97fde699e3a5b6db84f8))
- V2.100.55 ([`a1e8291`](https://github.com/PurpleBooth/readable-name-generator/commit/a1e82914c59191a75fd0a5b19ac0126458ce2ef3))
- V2.100.56 ([`db21491`](https://github.com/PurpleBooth/readable-name-generator/commit/db21491498bfbe5d4bda35d1dab204cdc2129a6f))
- V2.100.57 ([`109b3dc`](https://github.com/PurpleBooth/readable-name-generator/commit/109b3dcb5cbcc8563a6800f1cc8e968917975ace))
- V2.100.58 ([`1c5504f`](https://github.com/PurpleBooth/readable-name-generator/commit/1c5504f2b8489214278a3ea9749cf4f3e7c057cd))
- V2.100.59 ([`5de0111`](https://github.com/PurpleBooth/readable-name-generator/commit/5de01112adb5209c7316b0de7b98013f4a7492dc))
- V2.100.60 ([`730826e`](https://github.com/PurpleBooth/readable-name-generator/commit/730826ea76f10d6c37c74bfad995cba6d02a18f7))
- V2.100.61 ([`3c2c9eb`](https://github.com/PurpleBooth/readable-name-generator/commit/3c2c9ebb1d54fad3451cb51bf1822a5c60fe344b))
- V2.101.0 ([`25bd9aa`](https://github.com/PurpleBooth/readable-name-generator/commit/25bd9aada63da8ecdd0fbb3bf42440b5c0876ebd))
- V2.101.1 ([`b498b57`](https://github.com/PurpleBooth/readable-name-generator/commit/b498b578e400b7d2944eb8ff682614f7b369369f))
- V2.101.2 ([`f21c426`](https://github.com/PurpleBooth/readable-name-generator/commit/f21c426eedcc14f8040e716dd648b7f402db5e69))
- V2.101.3 ([`afc3854`](https://github.com/PurpleBooth/readable-name-generator/commit/afc385498c9e43f69ba2f3b49ccb81360418fb5b))
- V2.101.4 ([`60fb908`](https://github.com/PurpleBooth/readable-name-generator/commit/60fb908f4329b8fc5b66e9bc92cda12e02b24328))
- V3.0.0 ([`2a4cabe`](https://github.com/PurpleBooth/readable-name-generator/commit/2a4cabeec56d66a036bee5e8e8a11864ca9ae20d))


