### PR TITLE
fix: Update readable-name-generator to v4.0.0

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v3.0.0.tar.gz"
-  sha256 "0ed448d1e38c23dd892ade397087260ae42a1c1af6483eed5407f34699c9b7d9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-3.0.0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "e1674e324437e7f98b7734e9d2dea6b3c4c47e5f128f1ccdcc16e2d8be95773a"
-    sha256 cellar: :any_skip_relocation, ventura:      "99da0f8d0407d0a249a90e23a15bd3890c7f46ce9aedec9996e7cef91004ef7d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "d8c5e7ec8a4fe7370c0c8bcb6d5b8cf97ae9105375513a42b5a4089e82f414dd"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.0.tar.gz"
+  sha256 "5c2ec0192f0b99d710510f5b93c78a3dc469aed3c486d1cb4144394588c63946"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.0.0](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.0.0) (2024-08-20)

### FastConventional

#### Build

- Add fast conventional ([`c6b41e9`](https://github.com/PurpleBooth/readable-name-generator/commit/c6b41e9c2085f0f3fb031ef0e67a2a2ee823c0e3))


### Homebrew

#### Fix

- Fix urls in template ([`5a2a991`](https://github.com/PurpleBooth/readable-name-generator/commit/5a2a9912088bba4d0d27a3eb6b2137de0fe47fb0))


### Mergify

#### Ci

- Configuration update ([`0e55aae`](https://github.com/PurpleBooth/readable-name-generator/commit/0e55aae43341b9cf748d13b46be306c5c6597bd1))
- Configuration update ([`7be2c74`](https://github.com/PurpleBooth/readable-name-generator/commit/7be2c74f424641b49b2e507df4812e95964e7c7c))


### Changelog

#### Ci

- Use centralised changelog ([`f468ea0`](https://github.com/PurpleBooth/readable-name-generator/commit/f468ea0a5c029393325c638d267ef489619e754d))


### Dependabot

#### Build

- Add scope for dependencies ([`52a20d7`](https://github.com/PurpleBooth/readable-name-generator/commit/52a20d789ac2d0d49b11a10cae2e1ee7c5115c95))


### Deploy

#### Build

- Versio update versions ([`91a8685`](https://github.com/PurpleBooth/readable-name-generator/commit/91a868546347807aeee97b1d33db9134b2f4799b))
- Versio update versions ([`c6d3bdd`](https://github.com/PurpleBooth/readable-name-generator/commit/c6d3bddb52eb63844ed73b1b91886b56ebf9f970))
- Versio update versions ([`b1a3913`](https://github.com/PurpleBooth/readable-name-generator/commit/b1a3913c285d2798ee66628cbdc56b97413aae24))
- Versio update versions ([`7545053`](https://github.com/PurpleBooth/readable-name-generator/commit/7545053cd948de152bf22401b69d2e1b5d1165c4))
- Versio update versions ([`f2a3431`](https://github.com/PurpleBooth/readable-name-generator/commit/f2a3431139b4618a1dd2d080cddeb166ca69a2fd))
- Versio update versions ([`a383003`](https://github.com/PurpleBooth/readable-name-generator/commit/a383003547f7e27d2057b1bb4d53ffc643ffa772))
- Versio update versions ([`531880b`](https://github.com/PurpleBooth/readable-name-generator/commit/531880b4dd8d7d035585b7fa8615d81bec630707))
- Versio update versions ([`660815e`](https://github.com/PurpleBooth/readable-name-generator/commit/660815eca54fa921006c06ac6d0075ad6c41adc6))
- Versio update versions ([`f421260`](https://github.com/PurpleBooth/readable-name-generator/commit/f421260220ed82542b2999478b50b3c8ab943cd7))
- Versio update versions ([`04a680a`](https://github.com/PurpleBooth/readable-name-generator/commit/04a680acfcea82fbd3f911635d949802a9204350))
- Versio update versions ([`a4b077f`](https://github.com/PurpleBooth/readable-name-generator/commit/a4b077f7c94de41ab1d07d2775eb159947b47d41))
- Versio update versions ([`55dfc61`](https://github.com/PurpleBooth/readable-name-generator/commit/55dfc610710b060b852b76cd85f403cc5ed80eea))
- Versio update versions ([`349163b`](https://github.com/PurpleBooth/readable-name-generator/commit/349163b14bea162e1314d5cdefa83147f3d91cbe))
- Versio update versions ([`0df73ea`](https://github.com/PurpleBooth/readable-name-generator/commit/0df73ea8262a9d59d34fa9494aa3cb24a88b001f))
- Versio update versions ([`4c97e5d`](https://github.com/PurpleBooth/readable-name-generator/commit/4c97e5d113d35af2f8448f3c08445aa95280bb16))
- Versio update versions ([`11b2544`](https://github.com/PurpleBooth/readable-name-generator/commit/11b25441aeaab89c62256983d8274e6f29c1fc88))
- Versio update versions ([`34409b4`](https://github.com/PurpleBooth/readable-name-generator/commit/34409b4b9f15c930d3df085ab810f039284baeea))
- Versio update versions ([`9c12961`](https://github.com/PurpleBooth/readable-name-generator/commit/9c12961a615029a46d3d67a7b9e6ab2d0ff48071))
- Versio update versions ([`472bdee`](https://github.com/PurpleBooth/readable-name-generator/commit/472bdee5f36d2b37db590097dc5f8298b04a67a6))
- Versio update versions ([`055b675`](https://github.com/PurpleBooth/readable-name-generator/commit/055b6752aabfa9cb6889ca559c6f8ae306165c14))
- Versio update versions ([`e1e985d`](https://github.com/PurpleBooth/readable-name-generator/commit/e1e985deefba776c3cdba0f29955e60f11b8b3bd))
- Versio update versions ([`ea0553a`](https://github.com/PurpleBooth/readable-name-generator/commit/ea0553a06c29ed43ec9172f0d7cf573e321782be))
- Versio update versions ([`036e6a9`](https://github.com/PurpleBooth/readable-name-generator/commit/036e6a9e75578b745e862bef534b6b3adf323283))
- Versio update versions ([`235c619`](https://github.com/PurpleBooth/readable-name-generator/commit/235c619c76834690efdd984a56115c084a3d88d7))
- Versio update versions ([`7755e0a`](https://github.com/PurpleBooth/readable-name-generator/commit/7755e0a912e18b558c3764c75b7bad4bedefac16))
- Versio update versions ([`f1e5536`](https://github.com/PurpleBooth/readable-name-generator/commit/f1e55361f3b365633d07723231f822be988c1607))
- Versio update versions ([`012475a`](https://github.com/PurpleBooth/readable-name-generator/commit/012475aad76a8a2f87ec522d6e3f2ab181549884))
- Versio update versions ([`7dfd8f0`](https://github.com/PurpleBooth/readable-name-generator/commit/7dfd8f020dfcd38fe73a7d9a0830027cfd2d0c0a))
- Versio update versions ([`6c29aec`](https://github.com/PurpleBooth/readable-name-generator/commit/6c29aeccdff4056f80d4ebbd304c7611fbd2c671))
- Versio update versions ([`53bf301`](https://github.com/PurpleBooth/readable-name-generator/commit/53bf301fa90b87edc1738f2269226f09052b8af9))
- Versio update versions ([`7f939c6`](https://github.com/PurpleBooth/readable-name-generator/commit/7f939c6770e1c5b12b4fdabd113f6ccc86d32bae))
- Versio update versions ([`10c4eda`](https://github.com/PurpleBooth/readable-name-generator/commit/10c4eda422bd227ce565e45147b57d5d0d0f85d3))
- Versio update versions ([`6aff54c`](https://github.com/PurpleBooth/readable-name-generator/commit/6aff54c28cf107765f30eb8d5559601de988dd42))
- Versio update versions ([`20722fe`](https://github.com/PurpleBooth/readable-name-generator/commit/20722fe168a7ba96771e41c1c5310942e5dd879d))
- Versio update versions ([`998f2a3`](https://github.com/PurpleBooth/readable-name-generator/commit/998f2a301c8dfee307976f8b88b13be8782f2933))
- Versio update versions ([`bd1bbe3`](https://github.com/PurpleBooth/readable-name-generator/commit/bd1bbe30083293064dea2bad46b34290831e603f))
- Versio update versions ([`b89990b`](https://github.com/PurpleBooth/readable-name-generator/commit/b89990bd90e9749b4e323cb09593ec5b4fea56ef))
- Versio update versions ([`da1cc49`](https://github.com/PurpleBooth/readable-name-generator/commit/da1cc49f56f587ccac4eb827f2b9787036dd4bc5))
- Versio update versions ([`c0795ea`](https://github.com/PurpleBooth/readable-name-generator/commit/c0795ea4c2c8de56331671c7b6112396815a0449))
- Versio update versions ([`f25fd63`](https://github.com/PurpleBooth/readable-name-generator/commit/f25fd633e4b4146776d4cf9453261dc46b62f28f))
- Versio update versions ([`71619fb`](https://github.com/PurpleBooth/readable-name-generator/commit/71619fb59ab8e0af0f937d29b38295fb0faabe3e))
- Versio update versions ([`cb4891a`](https://github.com/PurpleBooth/readable-name-generator/commit/cb4891a0f45498c80b81892c3a1fe1a7135aac0d))
- Versio update versions ([`4ab6d6d`](https://github.com/PurpleBooth/readable-name-generator/commit/4ab6d6dcb110f0e61ded26faa2f53718f8c047c7))
- Versio update versions ([`87863d7`](https://github.com/PurpleBooth/readable-name-generator/commit/87863d7511177e1f67a7d3847e70ac93c7e36425))
- Versio update versions ([`d84b4b6`](https://github.com/PurpleBooth/readable-name-generator/commit/d84b4b6db33d3e5fe64fe4e6c77f102fe961f5a7))
- Versio update versions ([`70fdce6`](https://github.com/PurpleBooth/readable-name-generator/commit/70fdce6903e0d19dc6db457294d4d9adf0d3304c))
- Versio update versions ([`3453f28`](https://github.com/PurpleBooth/readable-name-generator/commit/3453f28ed24792063a11a4917965524e10b5a0ca))


### Deps

#### Build

- Bump golang from 1.13.4-alpine to 1.13.5-alpineBumps golang from 1.13.4-alpine to 1.13.5-alpine.Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([`fff4252`](https://github.com/PurpleBooth/readable-name-generator/commit/fff42521cd14b87f69fb1f213ef94ace31a4db93))
- Bump golang from 1.13.5-alpine to 1.13.6-alpineBumps golang from 1.13.5-alpine to 1.13.6-alpine.Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([`6cb883f`](https://github.com/PurpleBooth/readable-name-generator/commit/6cb883f2f52d33c6dd950bba8b354a64cdc356b1))
- Bump golang from 1.13.6-alpine to 1.13.7-alpineBumps golang from 1.13.6-alpine to 1.13.7-alpine.Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([`2937560`](https://github.com/PurpleBooth/readable-name-generator/commit/2937560161d0e2a587159ce60fa77b1813346f62))
- Bump golang from 1.13.7-alpine to 1.13.8-alpineBumps golang from 1.13.7-alpine to 1.13.8-alpine.Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([`8537cf5`](https://github.com/PurpleBooth/readable-name-generator/commit/8537cf570bbb93b31ffd3370e5980023a5a760a3))
- Bump golang from 1.13.8-alpine to 1.14.0-alpineBumps golang from 1.13.8-alpine to 1.14.0-alpine.Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([`c379c3e`](https://github.com/PurpleBooth/readable-name-generator/commit/c379c3e70c7b0ecf9fac9433caba9cd428b57ab4))

#### Chore

- Upgrade clap ([`5539d0a`](https://github.com/PurpleBooth/readable-name-generator/commit/5539d0aeadae236190547b5a543611cbae7edbf0))
- Pin rust docker tag to fcbb950 ([`69c0233`](https://github.com/PurpleBooth/readable-name-generator/commit/69c02333b701d084236dc03516e9e69b56bfaab4))
- Update rust:latest docker digest to 536c1a4 ([`96d1a79`](https://github.com/PurpleBooth/readable-name-generator/commit/96d1a79465a9cb45d5a2cd5db36ec572c75dc24c))
- Update rust:latest docker digest to 29fe437 ([`6e3f37b`](https://github.com/PurpleBooth/readable-name-generator/commit/6e3f37ba638a182b037f925205d28e975a77de9f))
- Pin dependencies ([`941c23d`](https://github.com/PurpleBooth/readable-name-generator/commit/941c23df9ef55b81b1dfb3d71fd9f07e03a6a7fe))
- Pin softprops/action-gh-release action to c062e08 ([`e2aad38`](https://github.com/PurpleBooth/readable-name-generator/commit/e2aad38eaeb7491e19b54c7590ccf68ca5d13b9c))
- Pin bilelmoussaoui/flatpak-github-actions docker tag to d0713c3 ([`ed97fb9`](https://github.com/PurpleBooth/readable-name-generator/commit/ed97fb91ce2b57f5a7280181a3d8cc9517b15484))

#### Ci

- Bump PurpleBooth/versio-release-action from 0.1.7 to 0.1.8 ([`ed30598`](https://github.com/PurpleBooth/readable-name-generator/commit/ed3059806e64921369617e3539aa645b8a30eaec))
- Bump PurpleBooth/versio-release-action from 0.1.8 to 0.1.9 ([`d4738fa`](https://github.com/PurpleBooth/readable-name-generator/commit/d4738fa0f74aa9b639bc4fde0d218727a3fc7d2d))
- Bump PurpleBooth/versio-release-action from 0.1.9 to 0.1.10 ([`ab876fd`](https://github.com/PurpleBooth/readable-name-generator/commit/ab876fd77538639b8b3be8578c79e0a0e67e696d))
- Bump PurpleBooth/versio-release-action from 0.1.10 to 0.1.11 ([`ada3553`](https://github.com/PurpleBooth/readable-name-generator/commit/ada3553df698dc784827a903b88f2a619f2e97e3))
- Bump PurpleBooth/versio-release-action from 0.1.11 to 0.1.12 ([`fed0171`](https://github.com/PurpleBooth/readable-name-generator/commit/fed017121c04e1b06046dd90bb9a0bce5de65140))
- Bump PurpleBooth/versio-release-action from 0.1.12 to 0.1.13 ([`7f8d85e`](https://github.com/PurpleBooth/readable-name-generator/commit/7f8d85eb821f8090cae71eca8820e91482c5655c))
- Bump PurpleBooth/versio-release-action from 0.1.13 to 0.1.15 ([`f9abd67`](https://github.com/PurpleBooth/readable-name-generator/commit/f9abd6736f8dcc2f84156c902199b4dfaf596e4d))
- Bump PurpleBooth/versio-release-action from 0.1.15 to 0.1.16 ([`be90c27`](https://github.com/PurpleBooth/readable-name-generator/commit/be90c27bccc8851a552a68a4e342a514d4bc5575))
- Bump PurpleBooth/versio-release-action from 0.1.16 to 0.1.17 ([`7e2495f`](https://github.com/PurpleBooth/readable-name-generator/commit/7e2495f0e5e6230ef15a42842e375dabef944dde))
- Bump PurpleBooth/common-pipelines from 0.4.5 to 0.6.50 ([`31815a7`](https://github.com/PurpleBooth/readable-name-generator/commit/31815a7a4ab1dc630bc283316447a252ea5dbf62))
- Bump PurpleBooth/common-pipelines from 0.6.50 to 0.6.51 ([`a2d9f8c`](https://github.com/PurpleBooth/readable-name-generator/commit/a2d9f8cbd25535c2e2d190107597c21d2fcb6712))
- Bump PurpleBooth/common-pipelines from 0.6.51 to 0.6.52 ([`f18d163`](https://github.com/PurpleBooth/readable-name-generator/commit/f18d163ed0fb36ab4fb9fbff98e3f860edf01c24))

#### Fix

- Bump miette from 4.0.1 to 4.2.0 ([`3fdbf48`](https://github.com/PurpleBooth/readable-name-generator/commit/3fdbf481bffee0b0c359287f04809c846f2ce69e))
- Bump clap from 3.1.1 to 3.1.2 ([`7b0c107`](https://github.com/PurpleBooth/readable-name-generator/commit/7b0c1075a3c199dfa7d242bcdfca5e34e38056f5))
- Bump rust from 1.58.1 to 1.59.0 ([`0b73516`](https://github.com/PurpleBooth/readable-name-generator/commit/0b73516780900bf56b9b1de02dfdf777004ab100))
- Bump miette from 4.2.0 to 4.2.1 ([`bf7584a`](https://github.com/PurpleBooth/readable-name-generator/commit/bf7584ae9c4d83c18821b8a3026824121a24fd98))
- Bump clap from 3.1.2 to 3.1.3 ([`cebd9b7`](https://github.com/PurpleBooth/readable-name-generator/commit/cebd9b7626fae642b4a0f246cf6f919180636424))
- Bump clap from 3.1.3 to 3.1.5 ([`0fd7780`](https://github.com/PurpleBooth/readable-name-generator/commit/0fd77808387ea304586f475c0cab760071247974))
- Bump clap_complete from 3.1.0 to 3.1.1 ([`3266a63`](https://github.com/PurpleBooth/readable-name-generator/commit/3266a63862cff8bf9b77852b226b0bcd140369fd))
- Bump clap from 3.1.5 to 3.1.6 ([`4fa531c`](https://github.com/PurpleBooth/readable-name-generator/commit/4fa531c8a3e8723cedf64f74b1f9a3ef2239d507))
- Bump miette from 4.2.1 to 4.3.0 ([`7ff6023`](https://github.com/PurpleBooth/readable-name-generator/commit/7ff6023e7752eb3cfcbabb89f738aa495f70990a))
- Bump clap from 3.1.6 to 3.1.7 ([`173353a`](https://github.com/PurpleBooth/readable-name-generator/commit/173353a99a3bc0d4694c54b5855e505c9e05db26))
- Bump clap from 3.1.7 to 3.1.8 ([`98b2184`](https://github.com/PurpleBooth/readable-name-generator/commit/98b2184f166c5d65b8b3d3ec318f0220ce5dfe22))
- Bump rust from 1.59.0 to 1.60.0 ([`11ff9e4`](https://github.com/PurpleBooth/readable-name-generator/commit/11ff9e491a9cace21ffc83bf8922cca987ff4708))
- Bump miette from 4.3.0 to 4.4.0 ([`53a586a`](https://github.com/PurpleBooth/readable-name-generator/commit/53a586a54bba358d1fbcadebb4a5398478200268))
- Bump miette from 4.4.0 to 4.5.0 ([`8f679de`](https://github.com/PurpleBooth/readable-name-generator/commit/8f679de4cf15ee489a670b78dcc7226e0d96a127))
- Bump clap from 3.1.8 to 3.1.9 ([`68181b8`](https://github.com/PurpleBooth/readable-name-generator/commit/68181b81c8bb5801f5907f6bd0b66d9c3f462ed6))
- Bump clap from 3.1.9 to 3.1.10 ([`accc281`](https://github.com/PurpleBooth/readable-name-generator/commit/accc28146be6ca946ef79416614d04cb7a563206))
- Bump clap_complete from 3.1.1 to 3.1.2 ([`377c6a3`](https://github.com/PurpleBooth/readable-name-generator/commit/377c6a3bf410daf004b6b497c399a622fccca21b))
- Bump clap from 3.1.10 to 3.1.12 ([`77f8436`](https://github.com/PurpleBooth/readable-name-generator/commit/77f84362b3bad42011dab994199802a1d4805277))
- Bump miette from 4.5.0 to 4.6.0 ([`53cd493`](https://github.com/PurpleBooth/readable-name-generator/commit/53cd493711c6a9bbadb0d8de9a79bdc346729ff5))
- Bump clap from 3.1.12 to 3.1.15 ([`01943fb`](https://github.com/PurpleBooth/readable-name-generator/commit/01943fb0e6449438e66c811bdfda45505adb9f3f))
- Bump thiserror from 1.0.30 to 1.0.31 ([`7c38ea4`](https://github.com/PurpleBooth/readable-name-generator/commit/7c38ea447c922317e566a9bfd15c8fe34d680ef1))
- Bump clap_complete from 3.1.2 to 3.1.3 ([`ec44570`](https://github.com/PurpleBooth/readable-name-generator/commit/ec445708751b99c8cd080b5ec878981ecbdb5c6e))
- Bump clap from 3.1.15 to 3.1.17 ([`1429745`](https://github.com/PurpleBooth/readable-name-generator/commit/1429745d2b0ad064b8d1b64486fafdf5babeddc9))
- Bump clap_complete from 3.1.3 to 3.1.4 ([`692adf6`](https://github.com/PurpleBooth/readable-name-generator/commit/692adf639e3343822f61fe4da176f202b646e589))
- Bump miette from 4.6.0 to 4.7.0 ([`7ca3052`](https://github.com/PurpleBooth/readable-name-generator/commit/7ca3052a356f8c76b0252de9b13741ffa4f871ec))
- Bump clap from 3.1.17 to 3.1.18 ([`7bb3855`](https://github.com/PurpleBooth/readable-name-generator/commit/7bb38552c2ed719f628f269c943f818366fe5780))
- Bump miette from 4.7.0 to 4.7.1 ([`dd99a76`](https://github.com/PurpleBooth/readable-name-generator/commit/dd99a765a3346451a21f66970dbe1e594427c6b3))
- Bump rust from 1.60.0 to 1.61.0 ([`f9964e7`](https://github.com/PurpleBooth/readable-name-generator/commit/f9964e7ec7ed3a92b8299734b17a7d28dca82616))
- Bump regex from 1.5.4 to 1.5.6 ([`141a896`](https://github.com/PurpleBooth/readable-name-generator/commit/141a896aceb93b552bf3fd747db648c3155314e9))
- Bump clap_complete from 3.1.4 to 3.2.1 ([`0828593`](https://github.com/PurpleBooth/readable-name-generator/commit/0828593e0cb3fdfb18c2aaabbdbdc6f02f58c220))
- Bump clap from 3.2.3 to 3.2.5 ([`c714686`](https://github.com/PurpleBooth/readable-name-generator/commit/c714686384b1727010fa68dd99ffb9d3fd276570))
- Bump clap_complete from 3.2.1 to 3.2.2 ([`17f72d6`](https://github.com/PurpleBooth/readable-name-generator/commit/17f72d6fea9d174b6005631c0d539c7ebb525fe1))
- Bump clap from 3.2.5 to 3.2.6 ([`e1733e6`](https://github.com/PurpleBooth/readable-name-generator/commit/e1733e61604661125d50354d9135b5f30fc4bcf8))
- Bump miette from 4.7.1 to 5.1.0 ([`780a15e`](https://github.com/PurpleBooth/readable-name-generator/commit/780a15e4722da6d25490dbca2dcd7cf39f86d467))
- Bump clap_complete from 3.2.2 to 3.2.3 ([`19c1792`](https://github.com/PurpleBooth/readable-name-generator/commit/19c1792ae6daa9461b0e39d3735dc05fcead0bb0))
- Bump clap from 3.2.6 to 3.2.7 ([`4d33902`](https://github.com/PurpleBooth/readable-name-generator/commit/4d33902ccea8a7ba2d30eb0ba98776fa269235ac))
- Bump clap from 3.2.7 to 3.2.8 ([`b556849`](https://github.com/PurpleBooth/readable-name-generator/commit/b5568493f93cab42910adf639886289f8bed0d31))
- Bump rust from 1.61.0 to 1.62.0 ([`91ad163`](https://github.com/PurpleBooth/readable-name-generator/commit/91ad1635b963951ec19f50ba7ee75f6489f1afc9))
- Bump miette from 5.1.0 to 5.1.1 ([`49aa2db`](https://github.com/PurpleBooth/readable-name-generator/commit/49aa2dbcd042f92732947d3c773655e6e0189dc3))
- Bump clap from 3.2.8 to 3.2.12 ([`9e29dd4`](https://github.com/PurpleBooth/readable-name-generator/commit/9e29dd48ab9fee03f4410ce80d9a3457a27fb0e2))
- Bump rust from 1.62.0 to 1.62.1 ([`8289638`](https://github.com/PurpleBooth/readable-name-generator/commit/8289638ae4d7029cd9a20e74d1513c1a5d31a49d))
- Bump clap from 3.2.12 to 3.2.13 ([`83fa25e`](https://github.com/PurpleBooth/readable-name-generator/commit/83fa25e4c7e17721b78ccd6599e06c839a359468))
- Bump clap from 3.2.13 to 3.2.14 ([`dbfcd89`](https://github.com/PurpleBooth/readable-name-generator/commit/dbfcd896e513bc6ff876d928eb189a409028b96d))
- Bump clap from 3.2.14 to 3.2.15 ([`8e8d35e`](https://github.com/PurpleBooth/readable-name-generator/commit/8e8d35efb7de210c2671d6340e4e770921fcb775))
- Bump miette from 5.1.1 to 5.2.0 ([`5a3a89b`](https://github.com/PurpleBooth/readable-name-generator/commit/5a3a89b056de2d92b441cd19ceed10efe4452d22))
- Bump clap from 3.2.15 to 3.2.16 ([`b478087`](https://github.com/PurpleBooth/readable-name-generator/commit/b47808726e702f10efbb18ecc98877d67e78d04e))
- Bump thiserror from 1.0.31 to 1.0.32 ([`d18d426`](https://github.com/PurpleBooth/readable-name-generator/commit/d18d4269f886baaae6986974fc8c9b7d6d562007))
- Bump thiserror from 1.0.32 to 1.0.37 ([`b5750f1`](https://github.com/PurpleBooth/readable-name-generator/commit/b5750f1f9977cabbf236e7ee391576aa48ba9f18))
- Bump rust from 1.62.1 to 1.64.0 ([`470b783`](https://github.com/PurpleBooth/readable-name-generator/commit/470b78385764819bf6e4a7c7a70880269cedbf5c))
- Bump clap from 3.2.16 to 3.2.21 ([`e6e5010`](https://github.com/PurpleBooth/readable-name-generator/commit/e6e5010f62793bad7ef3af6be5f829aa6ef21921))
- Bump miette from 5.2.0 to 5.3.0 ([`c507409`](https://github.com/PurpleBooth/readable-name-generator/commit/c50740979f593c2c28ad0f3d91f3964973491857))
- Bump miette from 5.3.0 to 5.4.1 ([`9b4255e`](https://github.com/PurpleBooth/readable-name-generator/commit/9b4255efcc8f38306f7a65249e85754f4e4be7d4))
- Bump rust from 1.64.0 to 1.65.0 ([`1a8a4b7`](https://github.com/PurpleBooth/readable-name-generator/commit/1a8a4b75249874ac497dea724f39772fa74d4e3d))
- Bump miette from 5.4.1 to 5.5.0 ([`45267a2`](https://github.com/PurpleBooth/readable-name-generator/commit/45267a2f14ad59ef44cb0edce06fdf196a2799e0))
- Bump rust from 1.65.0 to 1.66.0 ([`06a3a88`](https://github.com/PurpleBooth/readable-name-generator/commit/06a3a889d957da0663b1364f3ab9253c934ca2be))
- Bump thiserror from 1.0.37 to 1.0.38 ([`59af852`](https://github.com/PurpleBooth/readable-name-generator/commit/59af85269aba1402c66c875c5c71359ab6b577bf))
- Bump rust from 1.66.0 to 1.66.1 ([`b24d477`](https://github.com/PurpleBooth/readable-name-generator/commit/b24d4779c6a21cbac468ca5d7a08e121ec6ba952))
- Bump rust from 1.66.1 to 1.67.0 ([`dfb1635`](https://github.com/PurpleBooth/readable-name-generator/commit/dfb163524c44207045f0a3bca7efb2883baaa485))
- Bump rust from 1.67.0 to 1.67.1 ([`71f4a5e`](https://github.com/PurpleBooth/readable-name-generator/commit/71f4a5e876f1452e78f3b2a08fcef97a659994d8))
- Bump thiserror from 1.0.38 to 1.0.39 ([`3923567`](https://github.com/PurpleBooth/readable-name-generator/commit/3923567a852b86a812f4860f8bee91f72f03acb8))
- Bump rust from 1.67.1 to 1.68.0 ([`1ff132d`](https://github.com/PurpleBooth/readable-name-generator/commit/1ff132de6d920fcbb87fef33d97197592252894e))
- Bump versions ([`40a9133`](https://github.com/PurpleBooth/readable-name-generator/commit/40a9133b4424b6471f9299029ac21b8fafc8033d))
- Bump clap from 4.4.18 to 4.5.13 ([`3d5f543`](https://github.com/PurpleBooth/readable-name-generator/commit/3d5f543bb9e16d64fc994385eb3971bb1d4ff69d))
- Bump miette from 5.10.0 to 7.2.0 ([`c85a9a6`](https://github.com/PurpleBooth/readable-name-generator/commit/c85a9a67026c143b9447405ec341d9886478f34e))
- Bump thiserror from 1.0.56 to 1.0.63 ([`9767270`](https://github.com/PurpleBooth/readable-name-generator/commit/97672706d2a0ff78d8e41b8e0c2e40afea90bacc))
- Bump clap_complete from 4.4.9 to 4.5.12 ([`48f38d7`](https://github.com/PurpleBooth/readable-name-generator/commit/48f38d7098162a52faf52cd5e120ce5e75c189fd))
- Bump clap from 4.5.13 to 4.5.14 ([`c4d3425`](https://github.com/PurpleBooth/readable-name-generator/commit/c4d3425f1ce3f5ee386a3e2f64b86de5c6e41544))
- Bump clap_complete from 4.5.12 to 4.5.13 ([`b37004c`](https://github.com/PurpleBooth/readable-name-generator/commit/b37004cf08906b939a28d25e13134c8dfe995ac3))
- Bump rust from `fcbb950` to `606b76f` ([`12b9332`](https://github.com/PurpleBooth/readable-name-generator/commit/12b9332a87a648dbad58eb28b2b79ffc1f922d8b))
- Update rust crate clap to v4.5.15 ([`61d1137`](https://github.com/PurpleBooth/readable-name-generator/commit/61d11376f89e5d8c19d4379f946342e033b96950))
- Update rust crate clap_complete to v4.5.16 ([`d35f191`](https://github.com/PurpleBooth/readable-name-generator/commit/d35f1910463918c71ecdab4fa10e4d3c395ec2b9))
- Update rust crate anarchist-readable-name-generator-lib to v0.1.2 ([`e6528d9`](https://github.com/PurpleBooth/readable-name-generator/commit/e6528d9dd963c6962fbe478b037277393c25d851))
- Update rust crate clap to v4.5.16 ([`0e897b0`](https://github.com/PurpleBooth/readable-name-generator/commit/0e897b06cbd8b67307d0853d3bcdcd0c92c25f42))
- Bump clap_complete from 4.5.16 to 4.5.17 ([`9309f3b`](https://github.com/PurpleBooth/readable-name-generator/commit/9309f3b5a63145167ba14de89de0619c9091c538))
- Update rust crate clap_complete to v4.5.18 ([`7335328`](https://github.com/PurpleBooth/readable-name-generator/commit/7335328697cd762806715f7fcdad0936dc9b86fe))
- Bump clap_complete from 4.5.17 to 4.5.19 ([`71b4537`](https://github.com/PurpleBooth/readable-name-generator/commit/71b4537fb34ec3bc3ccc4c43e43e6be895960c87))


### Src

#### Docs

- Formatting ([`ff4c76d`](https://github.com/PurpleBooth/readable-name-generator/commit/ff4c76d9dba9c325669d85be6e502074820262c6))

#### Refactor

- Follow clippy advice ([`623931d`](https://github.com/PurpleBooth/readable-name-generator/commit/623931d13c8956117fd82f36f924d99a82d5b7b4))


### Version

#### Chore

- V2.100.53  ([`2ddf5c1`](https://github.com/PurpleBooth/readable-name-generator/commit/2ddf5c1e7dd085a622f4e94aac21cfff29e43454))
- V2.100.54 ([`90f2319`](https://github.com/PurpleBooth/readable-name-generator/commit/90f2319be02d4047a8c8fff5972debf54a195667))
- V2.100.55 ([`88a5cdc`](https://github.com/PurpleBooth/readable-name-generator/commit/88a5cdc5fd868513d6390ce8a1e939c141106da7))
- V2.100.56 ([`5d7d645`](https://github.com/PurpleBooth/readable-name-generator/commit/5d7d645e9197b1dd625cfb321880c03a1cab5a1e))
- V2.100.57 ([`2f7a86c`](https://github.com/PurpleBooth/readable-name-generator/commit/2f7a86c75584d9309f69574b80174ebdf6038721))
- V2.100.58 ([`9efc149`](https://github.com/PurpleBooth/readable-name-generator/commit/9efc149b11d6ea67126377ac28c31f678f5ffb02))
- V2.100.59 ([`facbd61`](https://github.com/PurpleBooth/readable-name-generator/commit/facbd61f0a9619c81347957186b136d5c82bcf9e))
- V2.100.60 ([`df255a2`](https://github.com/PurpleBooth/readable-name-generator/commit/df255a2e05b375ef9b810f4f14efc994f85d9436))
- V2.100.61 ([`9efb177`](https://github.com/PurpleBooth/readable-name-generator/commit/9efb177c9a00d72e80ed453b1d51a4dad47cc9c4))
- V2.101.0 ([`9d3fd51`](https://github.com/PurpleBooth/readable-name-generator/commit/9d3fd5171cc75ddd3ca3bb27d2b6c018fef26210))
- V2.101.1 ([`e9f3532`](https://github.com/PurpleBooth/readable-name-generator/commit/e9f3532839247754e70b73b3b5e1a0d88ae837ef))
- V2.101.2 ([`a089bde`](https://github.com/PurpleBooth/readable-name-generator/commit/a089bdead7ffb77e8bae723447fb9dccd3b159ec))
- V2.101.3 ([`3321d1f`](https://github.com/PurpleBooth/readable-name-generator/commit/3321d1f3188fa7308151c96e11adeb4b77bade1b))
- V2.101.4 ([`f9f7626`](https://github.com/PurpleBooth/readable-name-generator/commit/f9f762633cee2f3ebffe219dc09449d3396c3a2c))
- V3.0.0 ([`f35ea79`](https://github.com/PurpleBooth/readable-name-generator/commit/f35ea79037c5492f4c122540bb5ab8788d2fbfd6))
- V4.0.0 ([`feef12d`](https://github.com/PurpleBooth/readable-name-generator/commit/feef12df1fff5eadebb7582f1adedd2f11e67794))


