### PR TITLE
fix: Update git-mit to v5.13.21

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.20.tar.gz"
-  sha256 "ff9defd5db50ffce01cbc8aa6308ff26e2343813c5c9156e7cb50d127435831a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.20"
-    sha256 cellar: :any,                 arm64_sonoma: "889728c6c2a11d6a5a8d8abc30d44611b993ca8fa849e6f24146b32062282866"
-    sha256 cellar: :any,                 ventura:      "6e789ab5de74a6d187a19772ed667ae13738a982ca85a3ef54a3decc93a594dd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "743e919e01ec294e7760398b5d3c251443f1e85fe47fa9cfee0162a0e79893bc"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.21.tar.gz"
+  sha256 "1b2d348d06d25da47e8647ae7740106a8de8fd15c38b14ff0508c577faaec38c"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v5.13.21](https://github.com/PurpleBooth/git-mit/compare/...v5.13.21) (2024-08-20)

### Deps

#### Fix

- Update rust crate clap_complete to v4.5.19 ([`774ffe7`](https://github.com/PurpleBooth/git-mit/commit/774ffe7e8dcfb8e4e88b43a60841265b70424193))


### Version

#### Chore

- V5.13.21 ([`663a821`](https://github.com/PurpleBooth/git-mit/commit/663a8219d0b97a1178724d0b068e278224b3a676))


