### PR TITLE
fix: Update readable-name-generator to v4.0.1

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.0.tar.gz"
-  sha256 "5c2ec0192f0b99d710510f5b93c78a3dc469aed3c486d1cb4144394588c63946"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.0.0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "ccd5339884f7488dfb224047d0660f8741b7faa39256d33cd956c659a901839f"
-    sha256 cellar: :any_skip_relocation, ventura:      "244b65305a7ed4ee6d9bb983b49210c97e266b9b850ed9b6a24df6907aa37c32"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "37443bf8d95d25380f4f5ec3a8361c6c0b161ebbd5c075cf7fa6f04beda93180"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.1.tar.gz"
+  sha256 "97af575636db15c1d8a03175bfc57c6b2e5a39956b65bb686388bddf1a440519"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.0.1](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.0.1) (2024-08-21)

### Deps

#### Fix

- Update rust crate clap_complete to v4.5.20 ([`a9b23bb`](https://github.com/PurpleBooth/readable-name-generator/commit/a9b23bb00e20722d60b2f749a063bc623a86528f))


### Version

#### Chore

- V4.0.1 ([`86a859a`](https://github.com/PurpleBooth/readable-name-generator/commit/86a859a5d8a69d1a929d0d65687deba388c7a23d))


