### PR TITLE
fix: Update readable-name-generator to v4.0.2

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.0.tar.gz"
-  sha256 "5c2ec0192f0b99d710510f5b93c78a3dc469aed3c486d1cb4144394588c63946"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.0.0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "ccd5339884f7488dfb224047d0660f8741b7faa39256d33cd956c659a901839f"
-    sha256 cellar: :any_skip_relocation, ventura:      "244b65305a7ed4ee6d9bb983b49210c97e266b9b850ed9b6a24df6907aa37c32"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "37443bf8d95d25380f4f5ec3a8361c6c0b161ebbd5c075cf7fa6f04beda93180"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.2.tar.gz"
+  sha256 "0c6108735806ab6fe16b92175d483816a4b133f93040763144560945fedd657a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.0.2](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.0.2) (2024-08-22)

### Deps

#### Fix

- Update rust crate clap_complete to v4.5.22 ([`404c7bf`](https://github.com/PurpleBooth/readable-name-generator/commit/404c7bf3146b765dcdfa329181a8c0b6ebdfa394))


### Version

#### Chore

- V4.0.2 ([`ed53de9`](https://github.com/PurpleBooth/readable-name-generator/commit/ed53de94157517b47f10d6b62e111994d9661ba5))


