### PR TITLE
fix: Update readable-name-generator to v4.0.3

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.2.tar.gz"
-  sha256 "0c6108735806ab6fe16b92175d483816a4b133f93040763144560945fedd657a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.0.2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "11a4319ffcec6837eee26bd7111f2978615dd1291266a2205bfa9eaf9ddac097"
-    sha256 cellar: :any_skip_relocation, ventura:      "dbfd74357cb1696f65c05b54aeb2cc53c7c444afd25b92048fef105556c61903"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "56864a9656a1ad6998a44bf469c0062edef9531c2b8b3b4a8b7a3c16f2e8aea7"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.3.tar.gz"
+  sha256 "91c6d3e451f7e28ae02edb3f20bb68dffe4fd5c663dfe8721b0aecaeb6ea7dc3"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.0.3](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.0.3) (2024-08-22)

### Deps

#### Chore

- Update softprops/action-gh-release action to v2.0.8 ([`b19d818`](https://github.com/PurpleBooth/readable-name-generator/commit/b19d8187c9ef01b5bccaee466e64aa19aeb64124))

#### Fix

- Update rust crate anarchist-readable-name-generator-lib to 0.1.2 ([`ad96218`](https://github.com/PurpleBooth/readable-name-generator/commit/ad96218fcd43f2f6426cc70319a61115a9c5c663))


### Version

#### Chore

- V4.0.3 ([`613b105`](https://github.com/PurpleBooth/readable-name-generator/commit/613b105014bdcdf0ad14f5511b9a1c9f3d1cc346))


