### PR TITLE
fix: Update readable-name-generator to v4.0.4

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.3.tar.gz"
-  sha256 "91c6d3e451f7e28ae02edb3f20bb68dffe4fd5c663dfe8721b0aecaeb6ea7dc3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.0.3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "356115e0aa07f533710fccac28945edd7bd580cbeefa053ac25133dc9acec804"
-    sha256 cellar: :any_skip_relocation, ventura:      "833f9d5ea289a28b85a10fe5e0473fa3db644f87dca745f476fdfad10c4918e1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9ba17224b692208a108067c923d53d3ff265ce8f8f43d6bc746646c404aedd31"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.4.tar.gz"
+  sha256 "9ca6afec44652c2ad8dd4185a08d39327f0037028fe98665b447af9f97c914ca"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.0.4](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.0.4) (2024-08-22)

### Deps

#### Fix

- Update rust crate clap to 4.5.16 ([`9d6c769`](https://github.com/PurpleBooth/readable-name-generator/commit/9d6c76987523347ff6714718c2cca89ac6e938d7))


### Version

#### Chore

- V4.0.4 ([`cdce63f`](https://github.com/PurpleBooth/readable-name-generator/commit/cdce63f45b785ebeb1008133f669316984c2d11a))


