### PR TITLE
fix: Update readable-name-generator to v4.0.5

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.4.tar.gz"
-  sha256 "9ca6afec44652c2ad8dd4185a08d39327f0037028fe98665b447af9f97c914ca"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.0.4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "f65a804c41ab1c2ad49d4da34fb1e5314d6d7cd9b74800dbcf9282b6afb6324d"
-    sha256 cellar: :any_skip_relocation, ventura:      "0f85f65f02ab222189e2938714d204bbf6dfb2c1264d2ad37fb6c44c18b6ca4c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8b5fe93657c08148bd73d0506762c08d69dbafebb159ec61ff4235e0c8235eb0"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.5.tar.gz"
+  sha256 "a55cdbaf897012ad7f2b0dc708ec0bad475cd61491bbff28c5f138c8d5af62ab"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.0.5](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.0.5) (2024-08-22)

### Deps

#### Fix

- Update rust crate clap_complete to 4.5.22 ([`88f6c3c`](https://github.com/PurpleBooth/readable-name-generator/commit/88f6c3c8807cb8c6d2be830ffff36930ea9e31ba))


### Version

#### Chore

- V4.0.5 ([`1d559f0`](https://github.com/PurpleBooth/readable-name-generator/commit/1d559f0e3398819266a71120af18e490f950cd77))


