### PR TITLE
fix: Update whatismyip to v0.12.1

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.12.0.tar.gz"
-  sha256 "29811ca4568c23653d3da23d67d1115748161f76859a464dccaea36ba491c6a2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.12.0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "b6cf1ff4455a2ca708acbbe0911ad26b3b8edac8fb26fff7a86dc47ea7157c87"
-    sha256 cellar: :any_skip_relocation, ventura:      "92e6c515744ec5eb74fb587c70ef9bcac51b30e5b42875bd4d90696a215e194e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "70125c0b061d3a5ac0eae7d19d43c23620b3e8821c9425e7a0e6a834b1779a43"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.12.1.tar.gz"
+  sha256 "c2c13e0b1c4e14944423b572d29cd21288a51b2b2f32396c72683cd61e2e5c2e"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.12.1](https://github.com/PurpleBooth/whatismyip/compare/...v0.12.1) (2024-08-24)

### Deps

#### Chore

- Pin rust docker tag to 29fe437 ([`eb0f6cf`](https://github.com/PurpleBooth/whatismyip/commit/eb0f6cf48f2fa7601b7222c8a8bf7c7e92973d97))

#### Fix

- Update rust crate clap to 4.5.16 ([`eb3ef8d`](https://github.com/PurpleBooth/whatismyip/commit/eb3ef8de982b0b422dc712e120d1c6f639419695))


### Version

#### Chore

- V0.12.1 ([`37e3f4d`](https://github.com/PurpleBooth/whatismyip/commit/37e3f4deed1b374acacd35ae80bf87bd078901f1))


