### PR TITLE
fix: Update git-mit to v5.13.24

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.23.tar.gz"
-  sha256 "b165cc5728831df7bbf42200f797a211fcfcbf5e32e60db2df67d5911f1f8b87"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.23"
-    sha256 cellar: :any,                 arm64_sonoma: "8e817bf7bc66ec9f5d7dfc88cb1b1a93efa7835dace3a84df07bc0535ff92c9c"
-    sha256 cellar: :any,                 ventura:      "df14ed6a32cfbc03b1d9b0c0e24be97de617fb1c53c9417c0471778c2f3230c7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e73bc43e9ff898adcd39d76b4f3418b99c926d53f9991e6f61c9d95b31cf35c3"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.24.tar.gz"
+  sha256 "d11f567408bac30ebc820a13d4f13c7e7e3fbf365ec26f22b8fb1c3ed894a6e1"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v5.13.24](https://github.com/PurpleBooth/git-mit/compare/...v5.13.24) (2024-08-25)

### Deps

#### Fix

- Update rust crate tokio to 1.39.3 ([`caf9930`](https://github.com/PurpleBooth/git-mit/commit/caf993045777cc4a77a0569b67301da9f4af068b))


### Version

#### Chore

- V5.13.24 ([`bf02f0e`](https://github.com/PurpleBooth/git-mit/commit/bf02f0e7b7ae2d2807ce30da4aa39f18863fa454))


