### PR TITLE
fix: Update git-mit to v5.13.25

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.24.tar.gz"
-  sha256 "d11f567408bac30ebc820a13d4f13c7e7e3fbf365ec26f22b8fb1c3ed894a6e1"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.24"
-    sha256 cellar: :any,                 arm64_sonoma: "066838962e9735958a3c1129777ce3ee2b38e9281b0421c5e2d3b315c0f192d7"
-    sha256 cellar: :any,                 ventura:      "d233ae90015157bf3bc2308a45d3f9060c24700b4b7ef6da66d0c1e011858895"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "370a65c944260c48a058cc1e6561b063e656785db6c25ced5e58f3e05c7673fb"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.25.tar.gz"
+  sha256 "896c7725016e44dc18588097e3f10b60b6bd1f70804416c146c32532030621b4"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v5.13.25](https://github.com/PurpleBooth/git-mit/compare/...v5.13.25) (2024-08-25)

### Deps

#### Fix

- Update rust crate which to 6.0.3 ([`e8646b8`](https://github.com/PurpleBooth/git-mit/commit/e8646b8dc62f122af60a72a61d71b826c872c4b0))


### Version

#### Chore

- V5.13.25 ([`7e35283`](https://github.com/PurpleBooth/git-mit/commit/7e3528354c5fb98feb6b5e521a7c52e087dc4f11))


