### PR TITLE
fix: Update whatismyip to v0.12.2

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.12.1.tar.gz"
-  sha256 "c2c13e0b1c4e14944423b572d29cd21288a51b2b2f32396c72683cd61e2e5c2e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.12.1"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "fa1893ed8477990fbe6a06b83fafecbbeee851fd28eea2b0cf3f884ef4778abe"
-    sha256 cellar: :any_skip_relocation, ventura:      "f794d9ae39d48227ad8c6561b91cd7071ce5ff8e38a234495750fe96510b0c8f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f82d46e33f29b9f56ca235f87d6f2268d32bc47d8c0448aeb6a72f805d8ba3c"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.12.2.tar.gz"
+  sha256 "0244c4970a6fd7e0d4df1d4db064012f32e15508fee16a7eeb8bc129002463b8"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.12.2](https://github.com/PurpleBooth/whatismyip/compare/...v0.12.2) (2024-08-25)

### Deps

#### Fix

- Update rust crate tokio to 1.39.3 ([`aeb27d5`](https://github.com/PurpleBooth/whatismyip/commit/aeb27d5d9ceb39b241880bd51057e7e10c03e4d7))


### Version

#### Chore

- V0.12.2 ([`cc2c4dd`](https://github.com/PurpleBooth/whatismyip/commit/cc2c4dd24d465a52bfd6f18de1570a61c6c27d94))


