### PR TITLE
fix: Update git-mit to v5.13.26

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.25.tar.gz"
-  sha256 "896c7725016e44dc18588097e3f10b60b6bd1f70804416c146c32532030621b4"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.25"
-    sha256 cellar: :any,                 arm64_sonoma: "451fae52b39fc46151df8c86942cd08abf58bf4eff687a2d239c5249c66d5bd2"
-    sha256 cellar: :any,                 ventura:      "8809ac99da3ae5c082c2a0cb7f084bc60b0f765db95deddad4e1d933ca179150"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "12039573c50975cbabd9318cad9262b3c5352b36983b577e8c4d4cab4d679112"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.26.tar.gz"
+  sha256 "cdc8c97350ea89b87e6d66aa98c9242946309369f02b11ecd2cb72f538c82209"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v5.13.26](https://github.com/PurpleBooth/git-mit/compare/...v5.13.26) (2024-08-26)

### Deps

#### Fix

- Update rust crate clap_complete to 4.5.23 ([`b231f8b`](https://github.com/PurpleBooth/git-mit/commit/b231f8bc7e214cffba9bec5d57793eb0198b15c3))


### Version

#### Chore

- V5.13.26 ([`593f9a6`](https://github.com/PurpleBooth/git-mit/commit/593f9a6006596ccaa6b7f10874b50c8c8e7d5a0c))


