### PR TITLE
fix: Update git-mit to v5.13.27

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.26.tar.gz"
-  sha256 "cdc8c97350ea89b87e6d66aa98c9242946309369f02b11ecd2cb72f538c82209"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.26"
-    sha256 cellar: :any,                 arm64_sonoma: "5bdc54c36be15b80deeef0ad36c9ca1144288c99e235c32c3980f39cbced8b13"
-    sha256 cellar: :any,                 ventura:      "1edbdecda4772b8779b0253d30b4796a77dc02ca80feadc0f779dd6654ca31f5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "70c6406402629f965e20002696a9f6f4a6f16ada2de1d35ac270545250fef86c"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.27.tar.gz"
+  sha256 "6d4adf44ecaba63fe1240eed8d9c91fbfa30b7b663dc2c08823818306d4a5f15"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v5.13.27](https://github.com/PurpleBooth/git-mit/compare/...v5.13.27) (2024-08-26)

### Deps

#### Fix

- Update serde monorepo to 1.0.208 ([`9c0d438`](https://github.com/PurpleBooth/git-mit/commit/9c0d43815a5b19f0ec2ecc86f43ffeda4ce9c76d))


### Version

#### Chore

- V5.13.27 ([`3df6e68`](https://github.com/PurpleBooth/git-mit/commit/3df6e6893558462bf6a4906ed15ebf14a1749bca))


