### PR TITLE
fix: Update readable-name-generator to v4.0.7

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.6.tar.gz"
-  sha256 "83b5356b06568449c3e881c8ebf235ba1817cd853f386324f60ca4836953d68d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.0.6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "e2dc4d0ae869c92c35fd180d424457bf002331b1e6a95f79f912c870083fab54"
-    sha256 cellar: :any_skip_relocation, ventura:      "b1022af865ee2401ef276d4a222e62f1ae6473b9a7582a758173fcbe582e067d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e46723033155544173f36b9774726baa581ccfff3aa99dc49eae5fa2db310148"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.7.tar.gz"
+  sha256 "175eb3de4c50a67370e4e791abeca545fa6c060d9bf2d595fa53a8c3cc7f5304"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.0.7](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.0.7) (2024-08-29)

### Deps

#### Chore

- Pin rust docker tag to 29fe437 ([`4531e05`](https://github.com/PurpleBooth/readable-name-generator/commit/4531e05eea1de5d14fe7343ff174ad7bf32dac0e))
- Update actions/attest-build-provenance digest to 6149ea5 ([`001883a`](https://github.com/PurpleBooth/readable-name-generator/commit/001883a7cc225002f78e8b88044a64e1da55d0d6))
- Update bilelmoussaoui/flatpak-github-actions:freedesktop-23.08 docker digest to 006121b ([`2ed964e`](https://github.com/PurpleBooth/readable-name-generator/commit/2ed964e466183ea3ed54358ad49dcb3a7821dd7a))


### Version

#### Chore

- V4.0.7 ([`e7956c4`](https://github.com/PurpleBooth/readable-name-generator/commit/e7956c499a792a54a3a15db0a635b9edf8a155a5))


