### PR TITLE
fix: Update readable-name-generator to v4.0.8

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.6.tar.gz"
-  sha256 "83b5356b06568449c3e881c8ebf235ba1817cd853f386324f60ca4836953d68d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.0.6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "e2dc4d0ae869c92c35fd180d424457bf002331b1e6a95f79f912c870083fab54"
-    sha256 cellar: :any_skip_relocation, ventura:      "b1022af865ee2401ef276d4a222e62f1ae6473b9a7582a758173fcbe582e067d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e46723033155544173f36b9774726baa581ccfff3aa99dc49eae5fa2db310148"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.8.tar.gz"
+  sha256 "e8dae2e69b0947022732c481e2048ef9a5d96b28333064c1f9f7272a2ac3cc1c"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.0.8](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.0.8) (2024-08-29)

### Version

#### Chore

- V4.0.8 ([`418c121`](https://github.com/PurpleBooth/readable-name-generator/commit/418c121a51aaaa1123052ae8d4d1f9f4c982f664))


