### PR TITLE
fix: Update readable-name-generator to v4.0.9

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.7.tar.gz"
-  sha256 "175eb3de4c50a67370e4e791abeca545fa6c060d9bf2d595fa53a8c3cc7f5304"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.0.7"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "6baf33c08ff5d9e2b8a3cd8c655f62df1e39e942d1545dcbee4db017a42a28e7"
-    sha256 cellar: :any_skip_relocation, ventura:      "112284a24bc0d583dc80171ee40822fe5a1cde64a08f0d58e7debe64448d00a1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "092c5a5ff3a6861fe7441a34387db2666dc440e72796bbc194ee73d2248bbf61"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.9.tar.gz"
+  sha256 "57696c769c3f52082b130bbf299b2f571400150fc86dae0c400cc816e079ee29"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.0.9](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.0.9) (2024-08-29)

### Deps

#### Chore

- Pin dependencies ([`60acde6`](https://github.com/PurpleBooth/readable-name-generator/commit/60acde6fb6c65ff82ef5e38507fbad69d3e37cf6))


### Version

#### Chore

- V4.0.9 ([`7fbdaf6`](https://github.com/PurpleBooth/readable-name-generator/commit/7fbdaf6587f606b0dd4307da8e6e01c1ddf1d699))


