### PR TITLE
fix: Update readable-name-generator to v4.1.0

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.0.9.tar.gz"
-  sha256 "57696c769c3f52082b130bbf299b2f571400150fc86dae0c400cc816e079ee29"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.0.9"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "1c6035d4546b89e4cfb1a33b27dcffdef26fb7ebb798401c613cb1bcf7bbc6af"
-    sha256 cellar: :any_skip_relocation, ventura:      "5c880eba37057080ae2d309a0364e40f4694b0c742e7e0ca44a1f92caea7a970"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "15d7ecbb521be156a70a41e9698c35e31292d53ecc3e04b1fe31f7834cdfbea6"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.0.tar.gz"
+  sha256 "ee48c9e29cd90639b4ea45420c1ee49fc0a9448189637d408d87179b0c07ee0b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.0](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.0) (2024-08-29)

### Version

#### Chore

- V4.1.0 ([`c4948a8`](https://github.com/PurpleBooth/readable-name-generator/commit/c4948a89149ed0267f73ac660aaf6aaf318c2599))


