### PR TITLE
fix: Update readable-name-generator to v4.1.2

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.1.tar.gz"
-  sha256 "e16bc619cd2324569ca4edb532e22df86954d9ba6a2e06c1b40d74b26ffc59c2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.1"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "c1b60d1d2af6083d8723811f8f63a0888512d49f776fc9b74f3a31f9469ddd0c"
-    sha256 cellar: :any_skip_relocation, ventura:      "6c344ff15108dcd1238caecf31d7327d4b977bd46f5019dc894d334c6334932b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "a782fb69d8cd23ba41551625248fdd3db0bebd3f4642a3ca9a7686ee71e6cf12"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.2.tar.gz"
+  sha256 "73f8f4a0c17e495eae6ac90d4f1963f15cda5ae1888b154db27b0ee6a372ef61"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.2](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.2) (2024-08-29)

### Version

#### Chore

- V4.1.2 ([`f889c00`](https://github.com/PurpleBooth/readable-name-generator/commit/f889c003a5a49a93d8923213a0b4a6dfa5bfbb53))


