### PR TITLE
fix: Update whatismyip to v0.13.0

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.12.2.tar.gz"
-  sha256 "0244c4970a6fd7e0d4df1d4db064012f32e15508fee16a7eeb8bc129002463b8"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.12.2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "ca111018a020c40a706c891e6990b4bd222fcd2362e9ab52253841d4ab691775"
-    sha256 cellar: :any_skip_relocation, ventura:      "b1cc1cbbbd0fffdf5e50afde7aa32f7d798b68f0863e1bc11335f453bfad146a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f248d9e47d889579b693005a47ef103f698ba00e0947492d23b637a0d086a7ad"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.13.0.tar.gz"
+  sha256 "bc76c8ba4904a34175d2ab7d5c2800a58ebfe654625af0aba489b6a5f282091a"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.13.0](https://github.com/PurpleBooth/whatismyip/compare/...v0.13.0) (2024-08-29)

### Version

#### Chore

- V0.13.0 ([`33f6047`](https://github.com/PurpleBooth/whatismyip/commit/33f6047227c741c0d8ad65a349d87ba9153b1a0f))


