### PR TITLE
fix: Update git-moves-together to v2.6.2

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,15 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.6.1.tar.gz"
-  sha256 "9ead77d3cbe39f57416f4366fca8fa5664920b2a90b631ae8fdb32775dca2cd7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.6.1"
-    sha256 cellar: :any,                 arm64_sonoma: "f8529b390132c98e933fd03635c639390805be0fd30a51666d4b08c1f43b6e4d"
-    sha256 cellar: :any,                 ventura:      "cbc3732e9301a0a5258482cb1b3010f9e209f257bde8aa934a356e6ba38e3db7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "8c0ef07ca997ee4bbd40a7e333e73f55296cc1bd7b78e9d17e35c04b85fda7cf"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.6.2.tar.gz"
+  sha256 "ed14e31a0cab914e755f1e384d1d98704edbca27999472619654679f1fde7f0a"
 
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v2.6.2](https://github.com/PurpleBooth/git-moves-together/compare/...v2.6.2) (2024-08-30)

### Version

#### Chore

- V2.6.2 ([`74e3e99`](https://github.com/PurpleBooth/git-moves-together/commit/74e3e99303c05ea69528472962406dd96524f5f7))


