### PR TITLE
fix: Update whatismyip to v0.13.3

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.13.2.tar.gz"
-  sha256 "05ec977bc3e24a4e5f8bb762d0356074e29770d747e53f2000cdf8a4ee0ac345"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.13.2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "8f0b573ec8964216ed668a9b96d21129de0c99916cd0057c3e5e186e63b77c6e"
-    sha256 cellar: :any_skip_relocation, ventura:      "fbcaf5a11c0713565fd815f8f05661af9c8567bf17da2212249349ab37f17cc2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "65f502fd49d13ebed3a14e9bb0ce1b7a59872cef6ca79180712eece40dc5e940"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.13.3.tar.gz"
+  sha256 "ad16f6f43d53a95e57cd705927d3d65869a1b5aedcd222a9a28093e4c2d7ebc9"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.13.3](https://github.com/PurpleBooth/whatismyip/compare/...v0.13.3) (2024-08-31)

### Deps

#### Chore

- Pin dependencies ([`b36f9db`](https://github.com/PurpleBooth/whatismyip/commit/b36f9db6185fe982422d375687592996a5ecc8fe))

#### Fix

- Update rust crate tokio to 1.40.0 ([`d36ddbf`](https://github.com/PurpleBooth/whatismyip/commit/d36ddbfe2f9c0a36410eed9b3a13019fdd19ca6b))


### Version

#### Chore

- V0.13.3 ([`85e1c98`](https://github.com/PurpleBooth/whatismyip/commit/85e1c98e4c8d2a9fa6b81c27c71249ec5b5a4a67))


