### PR TITLE
fix: Update readable-name-generator to v4.1.4

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.3.tar.gz"
-  sha256 "a35e4fc4f290947652b548a01029d100d20d64a7a2fda8bdd209a6e7fe36a293"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "310cbbaf0d3fbd3bce1a2ba569b2b7ff0d207db78ba5ed95be03527986dd0cb3"
-    sha256 cellar: :any_skip_relocation, ventura:      "56b28b7959b2abe95fa80e8ba3b907295ec46831732e9198c4d48f428656d601"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "258580956b0478018b93454abd7a6b1c710442628635f8868f8c17945f73e625"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.4.tar.gz"
+  sha256 "eda6a7cbc67b24af2e9a32f6feea35267eaf8feeb96dbb6030839d667991a346"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.4](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.4) (2024-08-31)

### Deps

#### Chore

- Pin dependencies ([`ea1ff52`](https://github.com/PurpleBooth/readable-name-generator/commit/ea1ff52898d79244bbea1c7bd86c9335b830c6fd))


### Version

#### Chore

- V4.1.4 ([`8ff626c`](https://github.com/PurpleBooth/readable-name-generator/commit/8ff626c86fbcf0ee5775efdaff330f79cbd4f9ae))


