### PR TITLE
fix: Update git-moves-together to v2.6.3

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,15 +1,8 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.6.2.tar.gz"
-  sha256 "ed14e31a0cab914e755f1e384d1d98704edbca27999472619654679f1fde7f0a"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.6.2"
-    sha256 cellar: :any,                 arm64_sonoma: "cfe76efa6540faa78a18c42d856122cc78b19ad7a44766f1df9b67947898d1d0"
-    sha256 cellar: :any,                 ventura:      "be70597eb83e0140925febac58fe61091b5a3f9a6e9354fa8723aa41dd955ad1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "09bfeed5d3e94eb108f76e1e6c60c3edfe5605690e338528a36f7cfbcdb54244"
-  end
+  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.6.3.tar.gz"
+  sha256 "98880f26ebd8380289afd2d543c53c2c9b300bba979561c825f5235a503394ae"
 
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v2.6.3](https://github.com/PurpleBooth/git-moves-together/compare/...v2.6.3) (2024-08-31)

### Deps

#### Chore

- Pin dependencies ([`4adc75a`](https://github.com/PurpleBooth/git-moves-together/commit/4adc75a5873808130ec156fdcc472a254ca45bf8))

#### Fix

- Update rust crate tokio to 1.40.0 ([`4539f57`](https://github.com/PurpleBooth/git-moves-together/commit/4539f570f876fcb8f3ddb4658d96856075865068))


### Version

#### Chore

- V2.6.3 ([`81b9640`](https://github.com/PurpleBooth/git-moves-together/commit/81b96409050a75fa4a3d49c627f3372aed029ec9))


