### PR TITLE
fix: Update readable-name-generator to v4.1.5

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.4.tar.gz"
-  sha256 "eda6a7cbc67b24af2e9a32f6feea35267eaf8feeb96dbb6030839d667991a346"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "cd65b605e717d181f3ad6cc12eaa442994de4516b1e24c1fedfa531babd62fcc"
-    sha256 cellar: :any_skip_relocation, ventura:      "ae096c28291d5312fe5c9c17492ff94f878c6856a2e79a1fc9e709db2d7d5192"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4a94cb9aa7ff88eceab4e0e7f6d8d4654379893c204c51fa3f4d9e98a41d7438"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.5.tar.gz"
+  sha256 "8e016bd3281b2adf0f3cbbc1de598182dc3c676b6a45e72322b9a64e32ae6727"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.5](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.5) (2024-09-03)

### Version

#### Chore

- V4.1.5 ([`db31dd2`](https://github.com/PurpleBooth/readable-name-generator/commit/db31dd2c063aefdc1086e14aa388aa65fff389ee))


