### PR TITLE
fix: Update readable-name-generator to v4.1.7

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.6.tar.gz"
-  sha256 "165860058b6c83b1d9340eeda0b275feab923f8d62ddc834efe40b7c5d57eddf"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "d782d383c5958e850e47423469085ee1f76290aaffa8eb59a8a3a52a6db66c48"
-    sha256 cellar: :any_skip_relocation, ventura:      "f0fd530cd858571896bd01a5d45710120aa6906f76b17fc90cab93c5bf4631b1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1cbd594e3b21b4d133eb4d9dd1ddcb98f4b0ae0388ec9b84cec0e755ef68f265"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.7.tar.gz"
+  sha256 "95b098e1981df7904d7c2df1158c410c62ef05512101bbb5ffb0cf81700bda33"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.7](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.7) (2024-09-03)

### Version

#### Chore

- V4.1.7 ([`511e64f`](https://github.com/PurpleBooth/readable-name-generator/commit/511e64f5fcaffbe8e150ef6d0dab9fd5470d89d6))


