### PR TITLE
fix: Update readable-name-generator to v4.1.9

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.7.tar.gz"
-  sha256 "95b098e1981df7904d7c2df1158c410c62ef05512101bbb5ffb0cf81700bda33"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.7"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "3fb4f5842f085eba09e742816f150bfbef1e37a6cb9320a6d620ed4408b823e4"
-    sha256 cellar: :any_skip_relocation, ventura:      "94b188bc50d45dd53e1a323c1b27d629b9c085789305bbd0fe66310c3e891d97"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5b3ee09d4839b0efe6c8919a24ad9f851d3a81925340e7440cadb84c1b929345"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.9.tar.gz"
+  sha256 "6f8e7709f7437ab5e969d570d4acf540a728694e6951249f0ab92d9f0cad1825"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.9](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.9) (2024-09-03)

### Version

#### Chore

- V4.1.9 ([`45412ca`](https://github.com/PurpleBooth/readable-name-generator/commit/45412cac251a1ae1401bece45db755d8ee49a81b))


