### PR TITLE
fix: Update readable-name-generator to v4.1.10

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.7.tar.gz"
-  sha256 "95b098e1981df7904d7c2df1158c410c62ef05512101bbb5ffb0cf81700bda33"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.7"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "3fb4f5842f085eba09e742816f150bfbef1e37a6cb9320a6d620ed4408b823e4"
-    sha256 cellar: :any_skip_relocation, ventura:      "94b188bc50d45dd53e1a323c1b27d629b9c085789305bbd0fe66310c3e891d97"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5b3ee09d4839b0efe6c8919a24ad9f851d3a81925340e7440cadb84c1b929345"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.10.tar.gz"
+  sha256 "b116f8904bba81b5c98dae76bdb9530829b42a5b24fca5971a4c16fdf696bcce"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.10](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.10) (2024-09-03)

### Version

#### Chore

- V4.1.10 ([`1b477f1`](https://github.com/PurpleBooth/readable-name-generator/commit/1b477f124a9246e705242a5cf84690c6723d8f81))


