### PR TITLE
fix: Update readable-name-generator to v4.1.11

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.9.tar.gz"
-  sha256 "6f8e7709f7437ab5e969d570d4acf540a728694e6951249f0ab92d9f0cad1825"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.9"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "151001e727537d11406cc424894965275b3012b11008fbbbc9b80b643779db91"
-    sha256 cellar: :any_skip_relocation, ventura:      "245a3e24d785ff10d48b02780e7496fa9ff4c581fbf0aa90c37bfce783659591"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9fbad9ed9214b27f96be29646650d2b5128eac5ea770a188790290ebf1ec0068"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.11.tar.gz"
+  sha256 "345238535a45e5134aeeb937f5a66fbdf13a212340d02672cad68473405b57fa"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.11](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.11) (2024-09-03)

### Version

#### Chore

- V4.1.11 ([`619a2ab`](https://github.com/PurpleBooth/readable-name-generator/commit/619a2ab1303960b45a0027c22b243542b143718d))


