### PR TITLE
fix: Update readable-name-generator to v4.1.12

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.11.tar.gz"
-  sha256 "345238535a45e5134aeeb937f5a66fbdf13a212340d02672cad68473405b57fa"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.11"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "abd57dbd8b4fecef8a6887ed21ffd0544b863527b923c699220f71639191ebb8"
-    sha256 cellar: :any_skip_relocation, ventura:      "b68a21bcf71f628525df21fef556e1cdda47746eff0f8c738dd7bdc4d67a68a0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "55159efdb46a8743fb33b83da2daae3b29c43936b50ec283f4c1f55eb6de7757"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.12.tar.gz"
+  sha256 "108983a79e33e729bd983d75603102309358aeeb4051c14e9bc38ebf82416588"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.12](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.12) (2024-09-03)

### Version

#### Chore

- V4.1.12 ([`8c0b127`](https://github.com/PurpleBooth/readable-name-generator/commit/8c0b12768b9c31bcb0f5e0b52561c84737920ec2))


