### PR TITLE
fix: Update readable-name-generator to v4.1.14

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.12.tar.gz"
-  sha256 "108983a79e33e729bd983d75603102309358aeeb4051c14e9bc38ebf82416588"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.12"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "067c1bb9d6d45876154205f0956ee4cc2baf7268e182e3f380e7b112de5edc4a"
-    sha256 cellar: :any_skip_relocation, ventura:      "9734ad5d3b836888b73b7b7215b60617e6efa6d2d7a06a684ce32422d5fae1af"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "0fc7daf583ae41f6aa1cd79741c3b2f9488fa7dffcd568a7842755dacb7d3c4f"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.14.tar.gz"
+  sha256 "f715ae6ded885ec6d45cd606ae78e8bc74d08e8d3800f7b0c795b62ef322f8a0"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.14](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.14) (2024-09-03)

### Version

#### Chore

- V4.1.14 ([`548bd61`](https://github.com/PurpleBooth/readable-name-generator/commit/548bd613c0c92e3b83863c846652269f5de523de))


