### PR TITLE
fix: Update game-of-life to v1.53.79

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,0 +1,18 @@
+class GameOfLife < Formula
+  desc "PurpleBooth's implementation of Conway's Game of life"
+  homepage "https://github.com/PurpleBooth/game-of-life"
+  url "https://github.com/PurpleBooth/game-of-life/archive/v1.53.79.tar.gz"
+  sha256 "7a1a7d6e7c54e65c1a433f5b28514833a230f10f4594d43ba64ef42065c88e72"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+  end
+
+  test do
+    system "#{bin}/game-of-life", "-h"
+    system "#{bin}/game-of-life", "-V"
+    system "#{bin}/game-of-life", "-s", "1"
+  end
+end


### PR DESCRIPTION
## Changelog
### [v1.53.79](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.79) (2024-09-19)

### Deps

#### Fix

- Update rust crate clap to 4.5.17 ([`198e7a9`](https://github.com/PurpleBooth/game-of-life/commit/198e7a95f977b05f64a1123daeeeb75b6f8797c9))


### Version

#### Chore

- V1.53.79 ([`b0be187`](https://github.com/PurpleBooth/game-of-life/commit/b0be187fdade94cd3f40e6d0bee2d3e776498490))


