### PR TITLE
fix: Update git-mit to v5.13.30

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.29.tar.gz"
-  sha256 "cbfa2f4b679307495b2d7218802901e877ffcab2cb99e7547bae90cfc7a0426e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.13.29"
-    sha256 cellar: :any,                 arm64_sonoma: "8da405c3482da14044f78ee7dda72cad2e1b0d7fdd3f8fba47d2d0f1f95eec6f"
-    sha256 cellar: :any,                 ventura:      "9d6682c277c39870c70d43e05a9a82d1702787c31402ce6ad0615415a4181623"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "01c92682b5c23075fec287be127030ff7c182387de2a8bff9cf6bbc17d33168f"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.13.30.tar.gz"
+  sha256 "516918d36a076f0aa902bba9488be1bc225b1511bc2479784705aa4a3b521630"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v5.13.30](https://github.com/PurpleBooth/git-mit/compare/...v5.13.30) (2024-10-23)

### Deps

#### Chore

- Update rust docker tag to v1.81.0 ([`21d3f27`](https://github.com/PurpleBooth/git-mit/commit/21d3f276b0e4b7315cf299194952be60cf4df378))
- Update rust:1.81.0 docker digest to 7b7f7ae ([`8bb529a`](https://github.com/PurpleBooth/git-mit/commit/8bb529a5bebc19d8594a21484fe8f721f3c8ab3f))
- Update actions/cache action to v4.1.2 ([`e8ae1c8`](https://github.com/PurpleBooth/git-mit/commit/e8ae1c8788a8d9cc21362d1519d1108a4ca5e8f6))
- Update rust docker tag to v1.82.0 ([`f150921`](https://github.com/PurpleBooth/git-mit/commit/f150921ef505bbdee93edd5695d480901dd90573))

#### Fix

- Update rust crate regex to 1.11.0 ([`198a62c`](https://github.com/PurpleBooth/git-mit/commit/198a62c8933d586e386970d707225245ecbfab61))


### Src

#### Chore

- Formatting ([`1ef8ab5`](https://github.com/PurpleBooth/git-mit/commit/1ef8ab53755b6dd19d6155b1b91dad08bbc925e9))


### Version

#### Chore

- V5.13.30 ([`230a140`](https://github.com/PurpleBooth/git-mit/commit/230a140b1a832f281242a465d7b989eb1f8b6396))


