### PR TITLE
fix: Update readable-name-generator to v4.1.19

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.13.tar.gz"
-  sha256 "cd85e45fbf6baf2b9123672a53d43fd64e828506f47d985ca18d41701d8e53b9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.13"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "f0e90ee3177aa9e559abb550bc647c383042bf3f8d1e90b4ced7f7adca417b5d"
-    sha256 cellar: :any_skip_relocation, ventura:      "c05ed9f6a4f3d2b980b9ffdded4911bda4c20a11c07c829f1a1b7a9de254c6b2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f1fde462b78acc56e4f6fb03384c5c72cee596c183187176a4b872ffc16f5796"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.19.tar.gz"
+  sha256 "39771a3cbc16d5ed53b8ff7b196edbaa331d369ed1dfcecb5dadf3dee4d6a8fa"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.19](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.19) (2024-11-02)

### Version

#### Chore

- V4.1.19 ([`807e34d`](https://github.com/PurpleBooth/readable-name-generator/commit/807e34d62a748a1d73e6a96e3e34eef9e0622402))


