### PR TITLE
fix: Update whatismyip to v0.13.8

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.13.7.tar.gz"
-  sha256 "8efa716aaabf462535d2f7af0a8d8a103df71bb2bbfbe6e64273c8675fd4884f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.13.7"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0f40e1f47b3f68a505041ad7eafc34949533fbe369934de4bfdee59204b09ced"
-    sha256 cellar: :any_skip_relocation, ventura:       "1f3f37ccca49254faf5ba7e6350a86a2a3d7f69a0615f4a62c56dd8af15dc5f4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a47c86b7c2ff02f440863c214a7c91318eaa6da38988561ae15548b8951feea0"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.13.8.tar.gz"
+  sha256 "ef69fcf6bcd579811fb2c41e88e03edba7f21947c4ce7cdf216cdbbd9600b2e0"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.13.8](https://github.com/PurpleBooth/whatismyip/compare/...v0.13.8) (2024-12-04)

### Deps

#### Chore

- Update rust:alpine docker digest to 00c2107 ([`d30a773`](https://github.com/PurpleBooth/whatismyip/commit/d30a773a1a675fcf2341c21a88b70b8e1d68b8f3))
- Update rust:alpine docker digest to 2f42ce0 ([`30595b0`](https://github.com/PurpleBooth/whatismyip/commit/30595b00d181bac62f6a20f7b97d6efbc78eddc7))
- Update goreleaser/nfpm docker digest to ae35b40 ([`85c6198`](https://github.com/PurpleBooth/whatismyip/commit/85c6198e94897fe994ec61c4c49ad61a399aab9f))
- Update rust:alpine docker digest to 838d384 ([`74d8d68`](https://github.com/PurpleBooth/whatismyip/commit/74d8d68b5415f5ab8f73e9c462dd8d1539d624ea))

#### Fix

- Update rust crate clap to v4.5.22 (#230) ([`1ecb127`](https://github.com/PurpleBooth/whatismyip/commit/1ecb127b90aa317b415fcdfd8f8e91e6c784d562))


### Version

#### Chore

- V0.13.8 ([`607e689`](https://github.com/PurpleBooth/whatismyip/commit/607e6895f9fef9f79f5675b7966cc15fb3a1615d))


