### PR TITLE
fix: Update readable-name-generator to v4.1.20

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,8 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.19.tar.gz"
-  sha256 "39771a3cbc16d5ed53b8ff7b196edbaa331d369ed1dfcecb5dadf3dee4d6a8fa"
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.20.tar.gz"
+  sha256 "5adf0bcd72a5fa6fe6e926f5d4643fa24b589b7dbd41d0a7d0424a39ede3cb59"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.20](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.20) (2024-12-04)

### Deps

#### Chore

- Update rust:alpine docker digest to 00c2107 ([`7de6c6c`](https://github.com/PurpleBooth/readable-name-generator/commit/7de6c6ca4446c9341400bbb84783b707ba5e4dab))
- Update rust:alpine docker digest to 2f42ce0 ([`fbc35a1`](https://github.com/PurpleBooth/readable-name-generator/commit/fbc35a1f6511ccb9b1b512ae4b5d48661b72a7cf))
- Update goreleaser/nfpm docker digest to ae35b40 ([`36fcc15`](https://github.com/PurpleBooth/readable-name-generator/commit/36fcc157495afa58360d36089baf345f506f1c0a))
- Update rust:alpine docker digest to 838d384 ([`7798a39`](https://github.com/PurpleBooth/readable-name-generator/commit/7798a39af9c5c4d79155172ae6a2c451e7450f52))

#### Fix

- Update rust crate clap to v4.5.22 (#317) ([`1ec594f`](https://github.com/PurpleBooth/readable-name-generator/commit/1ec594f88fd99f2e424cc573f2931bee7b23dfff))
- Update rust crate clap_complete to v4.5.38 (#318) ([`c6bce43`](https://github.com/PurpleBooth/readable-name-generator/commit/c6bce43b755278451ee5b853e4a5a7cf87f10c37))


### Version

#### Chore

- V4.1.20 ([`30e0fe1`](https://github.com/PurpleBooth/readable-name-generator/commit/30e0fe175f0be9f4db8691fc536352b211bbe069))


