### PR TITLE
fix: Update game-of-life to v1.53.80

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,0 +1,18 @@
+class GameOfLife < Formula
+  desc "PurpleBooth's implementation of Conway's Game of life"
+  homepage "https://github.com/PurpleBooth/game-of-life"
+  url "https://github.com/PurpleBooth/game-of-life/archive/refs/tags/v1.53.80.tar.gz"
+  sha256 "00ccf2a34353c56722336d34211031f6373f86e02e3d3d0ab2e38667c305940f"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+  end
+
+  test do
+    system "#{bin}/game-of-life", "-h"
+    system "#{bin}/game-of-life", "-V"
+    system "#{bin}/game-of-life", "-s", "1"
+  end
+end


### PR DESCRIPTION
## Changelog
### [v1.53.80](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.80) (2024-12-04)

### Deps

#### Chore

- Update rust:alpine docker digest to 466dc99 ([`7bf386c`](https://github.com/PurpleBooth/game-of-life/commit/7bf386ce2adbf59629cc038c749af23f387b6b9b))
- Update goreleaser/nfpm docker digest to bf713f8 ([`a4bcc10`](https://github.com/PurpleBooth/game-of-life/commit/a4bcc1007d93825c48b36d9c7328456948b2093d))
- Update rust:alpine docker digest to 00c2107 ([`faed085`](https://github.com/PurpleBooth/game-of-life/commit/faed08550622a55a222192b20551124349b19976))
- Update rust:alpine docker digest to 2f42ce0 ([`06da53a`](https://github.com/PurpleBooth/game-of-life/commit/06da53ae5f0adcd5a1c18c98127ef4f98ec40be4))
- Update goreleaser/nfpm docker digest to ae35b40 ([`fac4ba5`](https://github.com/PurpleBooth/game-of-life/commit/fac4ba5a0af4236c85ea88c7750473584a5291e1))
- Update rust:alpine docker digest to 838d384 ([`10eac42`](https://github.com/PurpleBooth/game-of-life/commit/10eac42afa0cb91c8108b6024e6d7676de90feed))

#### Fix

- Update rust crate clap to v4.5.22 (#238) ([`fcdaafb`](https://github.com/PurpleBooth/game-of-life/commit/fcdaafba16adfc9064c4d72ee4e8d9b121edfdc3))


### Version

#### Chore

- V1.53.80 ([`b0b1c43`](https://github.com/PurpleBooth/game-of-life/commit/b0b1c430af93860b976009bdfc5cbe131e419642))


