### PR TITLE
fix: Update whatismyip to v0.13.10

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.13.9.tar.gz"
-  sha256 "2201f4a4df64b70fc88973077821ad7e51b83a0fe05822e35b4acdccc1fb27fc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.13.9"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f07be9f4d3a1e464a29dd0f755fc565018acc31f4f2beee05b7055b8d98c0c75"
-    sha256 cellar: :any_skip_relocation, ventura:       "248089a520ff029e21df6162314e70c87b96bd2c1c7cd76b58b3105ab96a5655"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7a8afa241454e6a47af0fba947c474876d0e5c1d46388d9aa5ef0d018837ca6c"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.13.10.tar.gz"
+  sha256 "157a2d315fa407142a4eb851c4fe7e4ee71f3b177e12e4513047cca400d87f81"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.13.10](https://github.com/PurpleBooth/whatismyip/compare/...v0.13.10) (2024-12-04)

### Deps

#### Fix

- Update rust crate local-ip-address to v0.6.3 ([`e9ad1cc`](https://github.com/PurpleBooth/whatismyip/commit/e9ad1cc4867ea08cc08f4a5bd7c4c5d81f9c89f7))
- Update rust crate tokio to v1.42.0 ([`fed28e9`](https://github.com/PurpleBooth/whatismyip/commit/fed28e9c9af53d5672f9b9a77059f0acbdf9070c))
- Update rust crate miette to v7.4.0 ([`a57e95f`](https://github.com/PurpleBooth/whatismyip/commit/a57e95fd3cd3b289cab5045cbbc3403d7643eedd))


### Version

#### Chore

- V0.13.10 ([`8cb8a53`](https://github.com/PurpleBooth/whatismyip/commit/8cb8a5357de96f18a9a29047d89b4adeaa53793a))


