### PR TITLE
fix: Update readable-name-generator to v4.1.21

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.20.tar.gz"
-  sha256 "5adf0bcd72a5fa6fe6e926f5d4643fa24b589b7dbd41d0a7d0424a39ede3cb59"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.20"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7f163836c42ca75a57f984351168b2e1ea0a18ccdc520ea1a06ebb8eff35707e"
-    sha256 cellar: :any_skip_relocation, ventura:       "4e1bc1d214a4533496628fa4122916995b9f1fedac88ac7cd1cf143200c42d05"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "83bfaf05e9dd6595fe29cb12b520ee04c4a29094946dd7d595fd7afff6adfaee"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.21.tar.gz"
+  sha256 "d8a567a33d79464afa5f1eb757a59407f65964c82cb8c3671f0c2b9bf5966f01"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.21](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.21) (2024-12-04)

### Deps

#### Fix

- Update rust crate thiserror to v1.0.69 (#319) ([`e5ce17a`](https://github.com/PurpleBooth/readable-name-generator/commit/e5ce17ab9db6d74a5e4ed7534c4c255d947797ec))


### Version

#### Chore

- V4.1.21 ([`ad7d65f`](https://github.com/PurpleBooth/readable-name-generator/commit/ad7d65f76c4a3098d18f64253f717f5337c311ef))


