### PR TITLE
fix: Update readable-name-generator to v4.1.22

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.20.tar.gz"
-  sha256 "5adf0bcd72a5fa6fe6e926f5d4643fa24b589b7dbd41d0a7d0424a39ede3cb59"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.20"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7f163836c42ca75a57f984351168b2e1ea0a18ccdc520ea1a06ebb8eff35707e"
-    sha256 cellar: :any_skip_relocation, ventura:       "4e1bc1d214a4533496628fa4122916995b9f1fedac88ac7cd1cf143200c42d05"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "83bfaf05e9dd6595fe29cb12b520ee04c4a29094946dd7d595fd7afff6adfaee"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.22.tar.gz"
+  sha256 "8e7f57dfc5a807bccc0a626a8f8f53f5cb5470e48ba49b220f0b2cbfc28f0014"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.22](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.22) (2024-12-04)

### Deps

#### Fix

- Update rust crate miette to v7.4.0 (#320) ([`6d7f155`](https://github.com/PurpleBooth/readable-name-generator/commit/6d7f1554e599ad3db2fe61f256753e7112c12380))


### Version

#### Chore

- V4.1.22 ([`677ea04`](https://github.com/PurpleBooth/readable-name-generator/commit/677ea04f5470599c8d0181bc630e4358d60fa465))


