### PR TITLE
fix: Update whatismyip to v0.13.11

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,15 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.13.10.tar.gz"
-  sha256 "157a2d315fa407142a4eb851c4fe7e4ee71f3b177e12e4513047cca400d87f81"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.13.10"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "11c51cf3af1bae461cb136084045651b12d34c34ed679243b8c956a7c97cd2b3"
-    sha256 cellar: :any_skip_relocation, ventura:       "2f09a837b3b66cd4c03670d8c4a5872f911e3f7f855ade0b5acce07ef960c42a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4c77b445cde8291a3e9a00043070ef96086752914b5b64db9459f971726d6dde"
-  end
+  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.13.11.tar.gz"
+  sha256 "c749b8260160629c51af572d8ffbaa054302124b2f23ae59260016e5d51c89c9"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v0.13.11](https://github.com/PurpleBooth/whatismyip/compare/...v0.13.11) (2024-12-06)

### Deps

#### Fix

- Update rust crate clap to v4.5.23 (#235) ([`7178d9f`](https://github.com/PurpleBooth/whatismyip/commit/7178d9f25499a119c216949630e6e6f78f42b9a0))


### Version

#### Chore

- V0.13.11 ([`aaac584`](https://github.com/PurpleBooth/whatismyip/commit/aaac5847757698c1964f291b7cbd89daf5eac92c))


