### PR TITLE
fix: Update game-of-life to v1.53.81

### DIFF
--- a/Formula/game-of-life.rb
+++ b/Formula/game-of-life.rb
@@ -1,0 +1,18 @@
+class GameOfLife < Formula
+  desc "PurpleBooth's implementation of Conway's Game of life"
+  homepage "https://github.com/PurpleBooth/game-of-life"
+  url "https://github.com/PurpleBooth/game-of-life/archive/refs/tags/v1.53.81.tar.gz"
+  sha256 "abe7de8ebc064b48dc9806b6c303a895ccfa7eb536b54f044e0e3cff073a14af"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+  end
+
+  test do
+    system "#{bin}/game-of-life", "-h"
+    system "#{bin}/game-of-life", "-V"
+    system "#{bin}/game-of-life", "-s", "1"
+  end
+end


### PR DESCRIPTION
## Changelog
### [v1.53.81](https://github.com/PurpleBooth/game-of-life/compare/...v1.53.81) (2024-12-06)

### Deps

#### Fix

- Update rust crate clap to v4.5.23 (#239) ([`6dddd64`](https://github.com/PurpleBooth/game-of-life/commit/6dddd643181a6832f1bc6897f5478a4260b30fe4))


### Version

#### Chore

- V1.53.81 ([`e0f673e`](https://github.com/PurpleBooth/game-of-life/commit/e0f673ebba6765d4cb52d9c1d94e3b7cd46035b3))


