### PR TITLE
fix: Update readable-name-generator to v4.1.23

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.21.tar.gz"
-  sha256 "d8a567a33d79464afa5f1eb757a59407f65964c82cb8c3671f0c2b9bf5966f01"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.21"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "690f93c51a7967544099c0b2391bd4739e939b2e6451b334b15875f343a85cf1"
-    sha256 cellar: :any_skip_relocation, ventura:       "4ed75440179d3c9e9585f5105ffd3c70aa2b60896443bb1fe0edcbb149ff339e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cb0bc12084bc8f331ddf2536016175a2acc1ecb81478bfd9c5483b464ee1ad62"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.23.tar.gz"
+  sha256 "7554640a4fd34ac559b226764d7ac3c833b7c34eabcc9f49c5b29c67c8b38c4d"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.23](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.23) (2024-12-06)

### Deps

#### Fix

- Update rust crate clap to v4.5.23 (#321) ([`f682629`](https://github.com/PurpleBooth/readable-name-generator/commit/f6826298fdb7049f13e7bfc3731da15562e9ba7c))


### Version

#### Chore

- V4.1.23 ([`5b9a890`](https://github.com/PurpleBooth/readable-name-generator/commit/5b9a8903a8b57ad68079f1d906b147c02e587633))


