### PR TITLE
fix: Update readable-name-generator to v4.1.24

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.23.tar.gz"
-  sha256 "7554640a4fd34ac559b226764d7ac3c833b7c34eabcc9f49c5b29c67c8b38c4d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.23"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "94c9599b9301f9e953ed6c0445c6f35f4edc89ef107916a5429db15ec7df339e"
-    sha256 cellar: :any_skip_relocation, ventura:       "93b60d01832178c855ea021be1ac9fce503bad58d4168edf507ad766f2b20bd4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b52ada7ce06ab06c147aa31ddafc0805cbfbe35b63699fcbd678e2c7e3ebee2c"
-  end
+  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.24.tar.gz"
+  sha256 "d935b69c4ac7a958d6cc68dc3cff734b159d6f22a2a6b77e477401601c5dc5c4"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## Changelog
### [v4.1.24](https://github.com/PurpleBooth/readable-name-generator/compare/...v4.1.24) (2024-12-23)

### Deps

#### Chore

- Update rust:alpine docker digest to 9ab8f4e (#322) ([`9df6210`](https://github.com/PurpleBooth/readable-name-generator/commit/9df62109f8c2880d8e1d3788e3c2a76708d1c63e))
- Update tonistiigi/xx docker digest to 923441d (#323) ([`37a2401`](https://github.com/PurpleBooth/readable-name-generator/commit/37a24013d48bab22ee9272cc8412c9afa1d9b1a2))

#### Fix

- Update rust crate clap_complete to v4.5.40 (#324) ([`7e51740`](https://github.com/PurpleBooth/readable-name-generator/commit/7e517400899395080460693cdf300ddb3b2ae64d))


### Version

#### Chore

- V4.1.24 ([`d908527`](https://github.com/PurpleBooth/readable-name-generator/commit/d90852737e39b6299362026228a7c03952a25af5))


