### PR TITLE
fix: upgrade fast-conventional to 2.3.67

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,8 +1,9 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
-  homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/refs/tags/v2.3.6.tar.gz"
-  sha256 "9501c226e9e20d9704197c54dc14afe3a0757e20b3a066f0e7b1fd96f87062fb"
+  homepage "https://codeberg.org/PurpleBooth/fast-conventional"
+  url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
+  version "2.3.67"
+  sha256 "c0602ae7624ee40fe4c75993e6144d86c5ec8aa3a55cacd86beb5f721c78354a"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.67](https://codeberg.org/PurpleBooth/git-mit/compare/b32792959ad49b846a1aea8b0d68cbff1837c2b7..v2.3.67) - 2025-01-07
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.41 - ([aac596b](https://codeberg.org/PurpleBooth/git-mit/commit/aac596beef1d325a33dad307449186abcdbf3f88)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update rust:alpine docker digest to ede82b1 - ([b327929](https://codeberg.org/PurpleBooth/git-mit/commit/b32792959ad49b846a1aea8b0d68cbff1837c2b7)) - Solace System Renovate Fox
- **(version)** v2.3.67 [skip ci] - ([bf10ce6](https://codeberg.org/PurpleBooth/git-mit/commit/bf10ce635955ceecbbb6372e12e3c50a096cc0dd)) - SolaceRenovateFox

