### PR TITLE
fix: upgrade fast-conventional to 2.3.68

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,8 +1,9 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
-  homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/refs/tags/v2.3.6.tar.gz"
-  sha256 "9501c226e9e20d9704197c54dc14afe3a0757e20b3a066f0e7b1fd96f87062fb"
+  homepage "https://codeberg.org/PurpleBooth/fast-conventional"
+  url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
+  version "2.3.68"
+  sha256 "cb4b5a215ea32bdd8235ffc9273f7a916383866c8390ac4ed2086c2e2eda6aa4"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.68](https://codeberg.org/PurpleBooth/git-mit/compare/6c0b825572f5cade57f064105a430d5a92dc899f..v2.3.68) - 2025-01-08
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.24 - ([37e6f73](https://codeberg.org/PurpleBooth/git-mit/commit/37e6f73093f9e8254a77a6b73d1119e0315021f6)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update rust:alpine docker digest to 38b1c0e - ([6c0b825](https://codeberg.org/PurpleBooth/git-mit/commit/6c0b825572f5cade57f064105a430d5a92dc899f)) - Solace System Renovate Fox
- **(version)** v2.3.68 [skip ci] - ([ad337cf](https://codeberg.org/PurpleBooth/git-mit/commit/ad337cf8aec6882089908476b509f05079dff2f3)) - SolaceRenovateFox

