### PR TITLE
fix: upgrade fast-conventional to 2.3.69

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,8 +1,9 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
-  homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/refs/tags/v2.3.6.tar.gz"
-  sha256 "9501c226e9e20d9704197c54dc14afe3a0757e20b3a066f0e7b1fd96f87062fb"
+  homepage "https://codeberg.org/PurpleBooth/fast-conventional"
+  url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
+  version "2.3.69"
+  sha256 "33e1f1436d938d1ca71eca4dd00db83dc5fa5ff8a285f2cd3e19800be1b6b887"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.69](https://codeberg.org/PurpleBooth/git-mit/compare/c4d8b3827f3d2e24fc28b9b4c078c0e375fd5c4e..v2.3.69) - 2025-01-08
#### Bug Fixes
- **(deps)** update rust crate thiserror to v2.0.10 - ([c4d8b38](https://codeberg.org/PurpleBooth/git-mit/commit/c4d8b3827f3d2e24fc28b9b4c078c0e375fd5c4e)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.69 [skip ci] - ([46ff734](https://codeberg.org/PurpleBooth/git-mit/commit/46ff7342af9213709a73f7ed8de19408d40c1b00)) - SolaceRenovateFox

