### PR TITLE
fix: upgrade fast-conventional to 2.3.71

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,8 +1,9 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
-  homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/refs/tags/v2.3.6.tar.gz"
-  sha256 "9501c226e9e20d9704197c54dc14afe3a0757e20b3a066f0e7b1fd96f87062fb"
+  homepage "https://codeberg.org/PurpleBooth/fast-conventional"
+  url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
+  version "2.3.71"
+  sha256 "df655512cb60e728c4a29ac579add584c4a0f29a816072370400c6ef844de4b0"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.71](https://codeberg.org/PurpleBooth/git-mit/compare/09c8986895c596b8f981534b9f61390be7d02f15..v2.3.71) - 2025-01-09
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.26 - ([09c8986](https://codeberg.org/PurpleBooth/git-mit/commit/09c8986895c596b8f981534b9f61390be7d02f15)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.71 [skip ci] - ([bf84b8c](https://codeberg.org/PurpleBooth/git-mit/commit/bf84b8cec39b4cceaa3271de849c134e7bcdfdd2)) - SolaceRenovateFox

