### PR TITLE
fix: upgrade fast-conventional to 2.3.72

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,8 +1,9 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
-  homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/refs/tags/v2.3.6.tar.gz"
-  sha256 "9501c226e9e20d9704197c54dc14afe3a0757e20b3a066f0e7b1fd96f87062fb"
+  homepage "https://codeberg.org/PurpleBooth/fast-conventional"
+  url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
+  version "2.3.72"
+  sha256 "4ee7edb785e1a3ba4c67376381f04e21dd85dcd8082ba94866c85332f751e029"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.72](https://codeberg.org/PurpleBooth/git-mit/compare/52d68fe00e5e6ca1b59ab533707a7c761a632b6b..v2.3.72) - 2025-01-10
#### Bug Fixes
- **(deps)** update rust crate thiserror to v2.0.11 - ([02041ad](https://codeberg.org/PurpleBooth/git-mit/commit/02041ad4cde248750765272a44694c41be6d30f1)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update rust:alpine docker digest to 0cfc78e - ([8e2c942](https://codeberg.org/PurpleBooth/git-mit/commit/8e2c942a3b3436b2378d6e6fbfb4cde13c234e79)) - Solace System Renovate Fox
- **(deps)** update rust:alpine docker digest to 6706207 - ([52d68fe](https://codeberg.org/PurpleBooth/git-mit/commit/52d68fe00e5e6ca1b59ab533707a7c761a632b6b)) - Solace System Renovate Fox
- **(version)** v2.3.72 [skip ci] - ([91aac2f](https://codeberg.org/PurpleBooth/git-mit/commit/91aac2f76e575efa03c1e04685809f31f806ed45)) - SolaceRenovateFox

