### PR TITLE
fix: upgrade fast-conventional to 2.3.73

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -1,13 +1,15 @@
 class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
-  homepage "https://github.com/PurpleBooth/fast-conventional"
-  url "https://github.com/PurpleBooth/fast-conventional/archive/refs/tags/v2.3.6.tar.gz"
-  sha256 "9501c226e9e20d9704197c54dc14afe3a0757e20b3a066f0e7b1fd96f87062fb"
+  homepage "https://codeberg.org/PurpleBooth/fast-conventional"
+  url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
+  version "2.3.73"
+  sha256 "ee139ee37854a0d396309bac300b6508491d811c202555607594b2cc5d21252b"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "socat" => :test
   depends_on "specdown/repo/specdown" => :test
+  depends_on "openssl@3"
 
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."


### PR DESCRIPTION
## [v2.3.73](https://codeberg.org/PurpleBooth/git-mit/compare/eaa9870370b35600809585a0e9ea6879f39bf336..v2.3.73) - 2025-01-20
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.27 - ([7ace1b6](https://codeberg.org/PurpleBooth/git-mit/commit/7ace1b607476d3800e99553ade658c8b9f0886d8)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update goreleaser/nfpm docker digest to b842811 - ([eaa9870](https://codeberg.org/PurpleBooth/git-mit/commit/eaa9870370b35600809585a0e9ea6879f39bf336)) - Solace System Renovate Fox
- **(version)** v2.3.73 [skip ci] - ([376f539](https://codeberg.org/PurpleBooth/git-mit/commit/376f5394afd3eb6dbd7f9c6529e8ba0708f1ae93)) - SolaceRenovateFox
- add ssl dep - ([b290716](https://codeberg.org/PurpleBooth/git-mit/commit/b290716ffe971b95217bcf84b36bfd8086a44d62)) - PurpleBooth

