### PR TITLE
fix: upgrade fast-conventional to 2.3.74

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,13 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.73"
-  sha256 "ee139ee37854a0d396309bac300b6508491d811c202555607594b2cc5d21252b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.73"
-    sha256 cellar: :any, ventura: "c1380db2e4ccaa66bbed8a2e45e7951c9886d55747286129b7610273e70eca5b"
-  end
+  version "2.3.74"
+  sha256 "ef2669b833238d9d630674e9e62ae19ba936e546f9146b74304736c9645fef3d"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.74](https://codeberg.org/PurpleBooth/git-mit/compare/55495e1fe4bbb1e3f5b6918c37a876a882032eb8..v2.3.74) - 2025-01-28
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.43 - ([da87f88](https://codeberg.org/PurpleBooth/git-mit/commit/da87f88b6ae3e351a27b315dee782c0f83d82038)) - Solace System Renovate Fox
- **(deps)** update rust crate nom to v8 - ([945f966](https://codeberg.org/PurpleBooth/git-mit/commit/945f966e65cef0a432998dd2f4aae6f2ca21fb92)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action action to v6 - ([1e79df5](https://codeberg.org/PurpleBooth/git-mit/commit/1e79df5e3cd1fe83872f47e76e25696001a39e9c)) - Solace System Renovate Fox
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to aefd381 - ([55495e1](https://codeberg.org/PurpleBooth/git-mit/commit/55495e1fe4bbb1e3f5b6918c37a876a882032eb8)) - Solace System Renovate Fox
- **(version)** v2.3.74 [skip ci] - ([f6e9cf4](https://codeberg.org/PurpleBooth/git-mit/commit/f6e9cf4de40e4a527da04cf5e21806de18155aac)) - PurpleBooth
- revert "chore(deps): update https://code.forgejo.org/docker/bake-action digest to aefd381" - ([d2f2655](https://codeberg.org/PurpleBooth/git-mit/commit/d2f26550b9a5b83b58c8a6b65ad0007258c282be)) - Billie Thompson
#### Refactoring
- make work with new tuple type - ([c1224c4](https://codeberg.org/PurpleBooth/git-mit/commit/c1224c41eda58f016d1ad22b748b99c8104d69f6)) - Billie Thompson

