### PR TITLE
fix: upgrade fast-conventional to 2.3.75

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,13 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.74"
-  sha256 "ef2669b833238d9d630674e9e62ae19ba936e546f9146b74304736c9645fef3d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.74"
-    sha256 cellar: :any, ventura: "0e780a6c03b118f2acb2de2aa93a3158fed3551b4f744fad37ce08c81ac639a3"
-  end
+  version "2.3.75"
+  sha256 "2aa68df64ff5799ec2f11f08311807bd3d7132d2a134af46016a6da141bf5a16"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.75](https://codeberg.org/PurpleBooth/git-mit/compare/3aa1da07fa08692c609c57a9ce6fa3481524b8ae..v2.3.75) - 2025-01-29
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.44 - ([7886dab](https://codeberg.org/PurpleBooth/git-mit/commit/7886dab1ac5fbb32812570d445dd505f0a848836)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update rust crate tempfile to v3.16.0 - ([533be9a](https://codeberg.org/PurpleBooth/git-mit/commit/533be9afa763aa37b068ce292ae50c8abed42e89)) - Solace System Renovate Fox
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to aefd381 - ([3aa1da0](https://codeberg.org/PurpleBooth/git-mit/commit/3aa1da07fa08692c609c57a9ce6fa3481524b8ae)) - Solace System Renovate Fox
- **(version)** v2.3.75 [skip ci] - ([8e37a5c](https://codeberg.org/PurpleBooth/git-mit/commit/8e37a5c302d10a977fba51db262e10d3907bcdeb)) - SolaceRenovateFox

