### PR TITLE
fix: upgrade fast-conventional to 2.3.77

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,13 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.76"
-  sha256 "756e8b837874286f7301707c5c662df35dcc48c7c8b013da4832313b5dccfbf0"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.76"
-    sha256 cellar: :any, ventura: "135656a8ecae21bc41d35ca729adf22ad29580d71687baa4a1662d583cffdc14"
-  end
+  version "2.3.77"
+  sha256 "d5ec7729130d1f592e7331764d20c9902fa5ff3faa65f033e3811e111c32b427"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.77](https://codeberg.org/PurpleBooth/git-mit/compare/cc5c70e0cebd57b64aa30431d9891844705ad425..v2.3.77) - 2025-02-05
#### Bug Fixes
- **(deps)** update rust crate miette to v7.5.0 - ([19f0872](https://codeberg.org/PurpleBooth/git-mit/commit/19f08729a660fa897fecc9cc97addbc28343cdde)) - Solace System Renovate Fox
#### Continuous Integration
- correct quotes - ([16b8ba7](https://codeberg.org/PurpleBooth/git-mit/commit/16b8ba73133f62288c309d0c28c30e37df21fb85)) - Billie Thompson
- correct repository normalisation - ([cc5c70e](https://codeberg.org/PurpleBooth/git-mit/commit/cc5c70e0cebd57b64aa30431d9891844705ad425)) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v2.3.77 [skip ci] - ([abc09fc](https://codeberg.org/PurpleBooth/git-mit/commit/abc09fcc66d3ee63304e370c1d5954256dead74f)) - PurpleBooth
#### Tests
- new miette formatting - ([f889226](https://codeberg.org/PurpleBooth/git-mit/commit/f889226a1f45e85cf110273371569639bdd8a176)) - Billie Thompson

