### PR TITLE
fix: upgrade fast-conventional to 2.3.78

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,13 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.77"
-  sha256 "d5ec7729130d1f592e7331764d20c9902fa5ff3faa65f033e3811e111c32b427"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.77"
-    sha256 cellar: :any, ventura: "ae0de2a34cfa3f0c06df0f09f7e5f23724617687292629c014adc991994c87e3"
-  end
+  version "2.3.78"
+  sha256 "521d14acc9bce7c7dfe393d59bac68d69b48c4a73df505333e6e4910450bc011"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.78](https://codeberg.org/PurpleBooth/git-mit/compare/4f789bd63d6ff0190dfad12e27fe0faea991ea25..v2.3.78) - 2025-02-06
#### Bug Fixes
- unpin versions - ([c7c2fe2](https://codeberg.org/PurpleBooth/git-mit/commit/c7c2fe2a7b2c08f31f1d25f7862c30a0e6dbf1c7)) - Billie Thompson
#### Build system
- **(Dockerfile)** specify Cargo.toml and Cargo.lock during copy - ([4a4f0a2](https://codeberg.org/PurpleBooth/git-mit/commit/4a4f0a29ced597610dae6ac64316a923075a7433)) - Billie Thompson
#### Continuous Integration
- use an inline cache - ([d6aecf0](https://codeberg.org/PurpleBooth/git-mit/commit/d6aecf0aa2eab6fe510abdc21d4395a8acf1bd8a)) - Billie Thompson
- correct file paths in pipeline workflow - ([4f789bd](https://codeberg.org/PurpleBooth/git-mit/commit/4f789bd63d6ff0190dfad12e27fe0faea991ea25)) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v2.3.78 [skip ci] - ([8452115](https://codeberg.org/PurpleBooth/git-mit/commit/8452115030c2747112285c5fa82a9bf7fb3ae1cc)) - PurpleBooth

