### PR TITLE
fix: upgrade readable-name-generator to 4.1.27

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,15 +1,9 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
-  homepage "https://github.com/PurpleBooth/readable-name-generator"
-  url "https://github.com/PurpleBooth/readable-name-generator/archive/refs/tags/v4.1.24.tar.gz"
-  sha256 "d935b69c4ac7a958d6cc68dc3cff734b159d6f22a2a6b77e477401601c5dc5c4"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.24"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7c3ca83d80091e8699544e34b3e81cc893bed72a7c256955d004418ba5f93658"
-    sha256 cellar: :any_skip_relocation, ventura:       "4106de6d583e80f23c1d7fdba7ea7aecdc102e929c848091ac440cc3131fadb4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "36b7d3508e97f69e9246783a735d2dde388a0c7ed2ad2c0d34553c056f3d9969"
-  end
+  homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
+  version "4.1.27"
+  sha256 "2a9474431059ab8d84ace10036d45e6b2ab4d78a210543042dca2fb16fadac87"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.27](https://codeberg.org/PurpleBooth/readable-name-generator/compare/c99ca36d997186552e1e6ff803b839f5da27bc9e..v4.1.27) - 2025-02-09
#### Bug Fixes
- test release - ([d6d0938](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d6d09382064ba936044aa20f69aacc093acd98de)) - Billie Thompson
#### Continuous Integration
- correct runs on - ([3ea3487](https://codeberg.org/PurpleBooth/readable-name-generator/commit/3ea3487aa0da7d8218f31f728895d010ddb52274)) - Billie Thompson
- Adjust cargo-publish workflow to use version - ([9d76b7f](https://codeberg.org/PurpleBooth/readable-name-generator/commit/9d76b7fe07b844e98fd46ce454200ae57dc7afb7)) - Billie Thompson
- add some different names for the jobs - ([1ecdc9b](https://codeberg.org/PurpleBooth/readable-name-generator/commit/1ecdc9b84afbee0fcdf93edc6e24233102cf46b7)) - Billie Thompson
- remove redundant Socat installation steps - ([f651159](https://codeberg.org/PurpleBooth/readable-name-generator/commit/f6511593ae1089901841b7951b3875a6b98ce2bd)) - Billie Thompson
- add cargo publish - ([3aed52b](https://codeberg.org/PurpleBooth/readable-name-generator/commit/3aed52b1f09a3a42dded1ea902bbaebea030002e)) - Billie Thompson
#### Documentation
- Update README with package availability - ([b43d657](https://codeberg.org/PurpleBooth/readable-name-generator/commit/b43d657424ba119695036b324d2c5fd9330561fa)) - Billie Thompson
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/setup-buildx-action digest to f7ce87c - ([a20ea80](https://codeberg.org/PurpleBooth/readable-name-generator/commit/a20ea80f53e9b25af3cc8058fec21565f4cac4a4)) - Solace System Renovate Fox
- **(deps)** pin dependencies - ([c25db1d](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c25db1deafa7c130e2876566c347253861f30d95)) - Solace System Renovate Fox
- **(version)** v4.1.27 [skip ci] - ([6d43f33](https://codeberg.org/PurpleBooth/readable-name-generator/commit/6d43f33adb8f3436644a061dd06e952e45d00cf9)) - PurpleBooth
- unused file - ([36d54f4](https://codeberg.org/PurpleBooth/readable-name-generator/commit/36d54f4fd978a0eefb98896db1caf717404fa6f6)) - PurpleBooth
- move to codeberg - ([c99ca36](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c99ca36d997186552e1e6ff803b839f5da27bc9e)) - Billie Thompson

