### PR TITLE
fix: upgrade readable-name-generator to 4.1.28

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.27"
-  sha256 "2a9474431059ab8d84ace10036d45e6b2ab4d78a210543042dca2fb16fadac87"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.27"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cbe8955e4dc78fac7ba41eba66211c056a4f0669de84b166e51d7c1644aea04f"
-    sha256 cellar: :any_skip_relocation, ventura:       "1a3c834ddd71c0e6edb747acc5cb20a1775d9d1bb2dd60552069eb84f13b66ad"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e990216dc6aeaedac2d72f248eebbbfac9c7defa5b95ee41fa4d9bf39bbea049"
-  end
+  version "4.1.28"
+  sha256 "bdca1807610f705a16b9fe585f3f49bcc00e7140efe3d973638a46131c194702"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.28](https://codeberg.org/PurpleBooth/readable-name-generator/compare/e388d50c22b7044f3c77a1eb5be4735e15811231..v4.1.28) - 2025-02-09
#### Bug Fixes
- Remove unused configs and update dependencies - ([6f5c96a](https://codeberg.org/PurpleBooth/readable-name-generator/commit/6f5c96a6933cc65d1b0076b1600d79388ed448d0)) - Billie Thompson
#### Continuous Integration
- install rust before trying to release - ([e388d50](https://codeberg.org/PurpleBooth/readable-name-generator/commit/e388d50c22b7044f3c77a1eb5be4735e15811231)) - Billie Thompson
#### Documentation
- Update placeholder name examples in README.md - ([4e1fd39](https://codeberg.org/PurpleBooth/readable-name-generator/commit/4e1fd39eaf117727444024575d6950e20b861475)) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v4.1.28 [skip ci] - ([0a2635e](https://codeberg.org/PurpleBooth/readable-name-generator/commit/0a2635e44a0a058c8a59b71f65ab5c23d4664be3)) - PurpleBooth
- unused file - ([d353abd](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d353abdde3acd3f1ad87a62f28cb4f6ef145c45b)) - PurpleBooth

