### PR TITLE
fix: upgrade readable-name-generator to 4.1.29

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.27"
-  sha256 "2a9474431059ab8d84ace10036d45e6b2ab4d78a210543042dca2fb16fadac87"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.27"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cbe8955e4dc78fac7ba41eba66211c056a4f0669de84b166e51d7c1644aea04f"
-    sha256 cellar: :any_skip_relocation, ventura:       "1a3c834ddd71c0e6edb747acc5cb20a1775d9d1bb2dd60552069eb84f13b66ad"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e990216dc6aeaedac2d72f248eebbbfac9c7defa5b95ee41fa4d9bf39bbea049"
-  end
+  version "4.1.29"
+  sha256 "978157d435b243d36d73057d0aa2874631614e4c96f6b3f6534a9e1a10e31813"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.29](https://codeberg.org/PurpleBooth/readable-name-generator/compare/e2b03da75c2b68312d3ff1efb06d49534d25ba2e..v4.1.29) - 2025-02-10
#### Bug Fixes
- **(deps)** update rust crate anarchist-readable-name-generator-lib to v0.1.4 - ([c62d1cf](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c62d1cf3319ee8b93dfee3ff26ee183b9ea5eeed)) - Solace System Renovate Fox
#### Documentation
- Update the docker tag - ([e2b03da](https://codeberg.org/PurpleBooth/readable-name-generator/commit/e2b03da75c2b68312d3ff1efb06d49534d25ba2e)) - PurpleBooth
#### Miscellaneous Chores
- **(version)** v4.1.29 [skip ci] - ([fa070ce](https://codeberg.org/PurpleBooth/readable-name-generator/commit/fa070ce4ba86131037d5f593aaccf221f2897229)) - PurpleBooth

