### PR TITLE
fix: upgrade whatismyip to 0.13.12

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,16 +1,9 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
-  homepage "https://github.com/PurpleBooth/whatismyip"
-  url "https://github.com/PurpleBooth/whatismyip/archive/refs/tags/v0.13.11.tar.gz"
-  sha256 "c749b8260160629c51af572d8ffbaa054302124b2f23ae59260016e5d51c89c9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.13.11"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b68a22d5b6a177d1bd7b7736b2133d1d06343664371d97057090eac39c8731a2"
-    sha256 cellar: :any_skip_relocation, ventura:       "d8347acb690345f506512b6a11f1165c9945f3d9d15014bd51b25947ab18dbe2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "95497f4e95da76c7b26f31fd52e1677be83282bf3d92236b7e861953238d6d07"
-  end
-
+  homepage "https://codeberg.org/PurpleBooth/whatismyip"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/main.tar.gz"
+  version "0.13.12"
+  sha256 "402c0f5fd5fb278e133f1f779c8125b22f7bead25e5a17d04fe63c2144ef0fdd"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.13.12 - 2025-02-11
#### Bug Fixes
- rename project to "whatismyip" in Dockerfile - (7a79532) - Billie Thompson
- Update dependencies to latest versions - (98e8750) - Billie Thompson
- migrate to codeberg - (4b1b612) - Billie Thompson
#### Miscellaneous Chores
- **(deps)** update rust:alpine docker digest to 9ab8f4e (#236) - (a74f819) - renovate[bot]
- **(version)** v0.13.12 [skip ci] - (1932f2c) - PurpleBooth
- remove yamlfmt command from Justfile - (74acb4e) - Billie Thompson
#### Refactoring
- simplify and adjust linting configuration - (0d099e3) - Billie Thompson

