### PR TITLE
fix: upgrade fast-conventional to 2.3.79

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,19 +2,18 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.78"
-  sha256 "521d14acc9bce7c7dfe393d59bac68d69b48c4a73df505333e6e4910450bc011"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.78"
-    sha256 cellar: :any, ventura: "bb4054cce9cd7114babd71d5dfe879ce418af354dd1e971d1666ed764f678ef8"
-  end
+  version "2.3.79"
+  sha256 "7cab16a4b3baabab998b560e6ec010d7191ddc85f7b7c99db420486e562a54ee"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build
   depends_on "socat" => :test
   depends_on "specdown/repo/specdown" => :test
   depends_on "openssl@3"
+
+  on_linux do
+    depends_on "zlib"
+  end
 
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."


### PR DESCRIPTION
## [v2.3.79](https://codeberg.org/PurpleBooth/git-mit/compare/e40dd3b6851b113a335c8e9726de77148c2f9901..v2.3.79) - 2025-02-14
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.29 - ([6228884](https://codeberg.org/PurpleBooth/git-mit/commit/62288844eb6204400d14dad5f7c0367e93246562)) - Solace System Renovate Fox
#### Build system
- add zlib dependency for Linux builds - ([69e5115](https://codeberg.org/PurpleBooth/git-mit/commit/69e5115b3e0906e26146c72f34bc8f9472c10093)) - Billie Thompson
#### Continuous Integration
- Add Socat installation to pipeline - ([8503284](https://codeberg.org/PurpleBooth/git-mit/commit/8503284663774d26a3ad27376a4117e6219f2f15)) - Billie Thompson
- Add Socat installation step to pipeline - ([80b95a5](https://codeberg.org/PurpleBooth/git-mit/commit/80b95a5e7c2ddc37e449f0db586293c35edd6a14)) - Billie Thompson
- clean up workflow formatting and add cargo publish - ([36453db](https://codeberg.org/PurpleBooth/git-mit/commit/36453dbc0298b02bb4253926b75b7973085a0e5c)) - Billie Thompson
#### Miscellaneous Chores
- **(deps)** update rust crate tempfile to v3.16.0 - ([97a9ae5](https://codeberg.org/PurpleBooth/git-mit/commit/97a9ae5f586c643734539b1f968d396dc587dfe1)) - Solace System Renovate Fox
- **(deps)** pin dependencies - ([3b19eaa](https://codeberg.org/PurpleBooth/git-mit/commit/3b19eaaaae37f96eeeac73cbf12259a8d3e3c547)) - Solace System Renovate Fox
- **(deps)** update https://code.forgejo.org/docker/setup-buildx-action digest to f7ce87c - ([972622a](https://codeberg.org/PurpleBooth/git-mit/commit/972622a2ca49d7564e65e2130fe076fcfc7c27f1)) - Solace System Renovate Fox
- **(deps)** pin dependencies - ([e40dd3b](https://codeberg.org/PurpleBooth/git-mit/commit/e40dd3b6851b113a335c8e9726de77148c2f9901)) - Solace System Renovate Fox
- **(version)** v2.3.79 [skip ci] - ([6bf244a](https://codeberg.org/PurpleBooth/git-mit/commit/6bf244aa4d648eb5efb18f995ede4354efe00531)) - PurpleBooth

