### PR TITLE
fix: upgrade readable-name-generator to 4.1.31

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.30"
-  sha256 "a9dc00f63e5a0613dc3acca7a960430cf4f5015c6e30592c8fe627d2e59e92e3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.30"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "045f77f990c661d9cef80924dab70c04db37cee59acfbb0144e72de50fd506a3"
-    sha256 cellar: :any_skip_relocation, ventura:       "ba38bbf393714c07db3bc8cc88ee074a0b7fde8521b5be12b2dd1964bc5a9271"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e1700cb95205b0e0a2c1f1e40d23049f36acfc6e21640790f1da39583daf749d"
-  end
+  version "4.1.31"
+  sha256 "6009c3abe2e0aaff64c8724b15af40a614c2f61d8f8996fa06b312ee08265f02"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.31](https://codeberg.org/PurpleBooth/readable-name-generator/compare/c807bf1a386799079a72dd640d6e4655d5462ba6..v4.1.31) - 2025-02-14
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 12360d0 - ([c807bf1](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c807bf1a386799079a72dd640d6e4655d5462ba6)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.31 [skip ci] - ([a6b5af6](https://codeberg.org/PurpleBooth/readable-name-generator/commit/a6b5af65d77d27e9100f3c5f9755c61978d0e7f2)) - SolaceRenovateFox

