### PR TITLE
fix: upgrade readable-name-generator to 4.1.32

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.31"
-  sha256 "6009c3abe2e0aaff64c8724b15af40a614c2f61d8f8996fa06b312ee08265f02"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.31"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2d863c20cf6424db058f40e78a1ed0cd6dbf576be1b055e562abd86558578aa4"
-    sha256 cellar: :any_skip_relocation, ventura:       "82f644415b19dca70793250c79dbf54320432d51195eeb7bec3c8e9353a83247"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "67e269be170b5cddb5b4df3a0213fc72f1b3ac9af5e680b11ae35ca6cc55cf7c"
-  end
+  version "4.1.32"
+  sha256 "04e177b776adce71f0b483cf6a7142acf2ecb08c41dc7575e77032cc16866df9"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.32](https://codeberg.org/PurpleBooth/readable-name-generator/compare/d8157752a2ea118aeac64d8468d700e04fda8bd5..v4.1.32) - 2025-02-15
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to fdff417 - ([d815775](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d8157752a2ea118aeac64d8468d700e04fda8bd5)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.32 [skip ci] - ([caca91d](https://codeberg.org/PurpleBooth/readable-name-generator/commit/caca91da423d68e541596a38f6b1e84fb34a7dac)) - SolaceRenovateFox

