### PR TITLE
fix: upgrade readable-name-generator to 4.1.33

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.32"
-  sha256 "04e177b776adce71f0b483cf6a7142acf2ecb08c41dc7575e77032cc16866df9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.32"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a96655c4c625ef912c029301af1633475c0dc5e4009cf6efc57af38315fc58df"
-    sha256 cellar: :any_skip_relocation, ventura:       "f7b9a9e71e87a887eb0e9238a8fde47e4dc229e0f8462e8e68e76b5e4846370a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "62022ee868855d715e750063c6aa201e74170edc830ea31c3a0f31dadd6bef06"
-  end
+  version "4.1.33"
+  sha256 "74569242b8d5560686633cd59df5e006aa7f0d3009fd3d9e06cd2c9712bd27f8"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.33](https://codeberg.org/PurpleBooth/readable-name-generator/compare/216927b5281f961961710ee045e5e0295c4c07ee..v4.1.33) - 2025-02-18
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.30 - ([216927b](https://codeberg.org/PurpleBooth/readable-name-generator/commit/216927b5281f961961710ee045e5e0295c4c07ee)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.33 [skip ci] - ([a5aeb71](https://codeberg.org/PurpleBooth/readable-name-generator/commit/a5aeb7192da303a4084073d02de04d66ed845de5)) - SolaceRenovateFox

