### PR TITLE
fix: upgrade readable-name-generator to 4.1.34

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.32"
-  sha256 "04e177b776adce71f0b483cf6a7142acf2ecb08c41dc7575e77032cc16866df9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.32"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a96655c4c625ef912c029301af1633475c0dc5e4009cf6efc57af38315fc58df"
-    sha256 cellar: :any_skip_relocation, ventura:       "f7b9a9e71e87a887eb0e9238a8fde47e4dc229e0f8462e8e68e76b5e4846370a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "62022ee868855d715e750063c6aa201e74170edc830ea31c3a0f31dadd6bef06"
-  end
+  version "4.1.34"
+  sha256 "4290a6ef3d3fc6ccae998fcf4b817354661d6d497759ee378c049b238695b522"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.34](https://codeberg.org/PurpleBooth/readable-name-generator/compare/9c33320fbcbc1ef38fd7c9a16b1c2a995962b288..v4.1.34) - 2025-02-18
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.45 - ([9c33320](https://codeberg.org/PurpleBooth/readable-name-generator/commit/9c33320fbcbc1ef38fd7c9a16b1c2a995962b288)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.34 [skip ci] - ([1f1733b](https://codeberg.org/PurpleBooth/readable-name-generator/commit/1f1733bc71211099b4b730ea4722499d94ffacb9)) - SolaceRenovateFox

