### PR TITLE
fix: upgrade fast-conventional to 2.3.83

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.82"
-  sha256 "58b0d0ac1130cf7dffbae72b9fb8d70657f167ba493d78f285b570d1c512fd55"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.82"
-    sha256 cellar: :any,                 ventura:      "0f1fae3a76da490d0faf6fe6853075890d40735be8e7081e7792575354abf9c3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7f6326e5cdf174cede22c5f45d640cb3ded840bc36ac2ca271d229a6cb6b35d0"
-  end
+  version "2.3.83"
+  sha256 "6f427d0af556ecc9d34633868eef7a3d8415bd5af406cdce061655ecf33157cd"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.83](https://codeberg.org/PurpleBooth/git-mit/compare/e38590ea418eccfaaac46604fd55ce5de9217594..v2.3.83) - 2025-02-18
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.30 - ([e38590e](https://codeberg.org/PurpleBooth/git-mit/commit/e38590ea418eccfaaac46604fd55ce5de9217594)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.83 [skip ci] - ([cd034d0](https://codeberg.org/PurpleBooth/git-mit/commit/cd034d0b27f6374d71b426f2d7f93291edfd5ce8)) - SolaceRenovateFox

