### PR TITLE
fix: upgrade fast-conventional to 2.3.84

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.83"
-  sha256 "6f427d0af556ecc9d34633868eef7a3d8415bd5af406cdce061655ecf33157cd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.83"
-    sha256 cellar: :any,                 ventura:      "896b27eeea96362d022ef22c164244fc55c378e41d290370d1ab9b8ca1f9f35a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "839a705e1cdb698f1870dbd8e86e642146cc19aa1be41eafcbea8afade44c186"
-  end
+  version "2.3.84"
+  sha256 "168b143538b2bcb702aa69fdf05bc3fc8562ff9a443becc60c959a78a1067801"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.84](https://codeberg.org/PurpleBooth/git-mit/compare/fd29c9186de385a10054dd13c9b5a067a37ef394..v2.3.84) - 2025-02-20
#### Bug Fixes
- **(deps)** update rust crate serde to v1.0.218 - ([5e0c69a](https://codeberg.org/PurpleBooth/git-mit/commit/5e0c69a80e49688e61fcfecfad5d9860b18ea278)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 4f08b22 - ([bb57ed0](https://codeberg.org/PurpleBooth/git-mit/commit/bb57ed0e452a96099ef5ac5adf9b6f6766c66bb3)) - Solace System Renovate Fox
- **(deps)** update https://code.forgejo.org/actions/cache digest to 0c907a7 - ([fd29c91](https://codeberg.org/PurpleBooth/git-mit/commit/fd29c9186de385a10054dd13c9b5a067a37ef394)) - Solace System Renovate Fox
- **(version)** v2.3.84 [skip ci] - ([9fb330c](https://codeberg.org/PurpleBooth/git-mit/commit/9fb330c001208fadd54066618779656c9a6a46c7)) - SolaceRenovateFox

