### PR TITLE
fix: upgrade readable-name-generator to 4.1.35

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.34"
-  sha256 "4290a6ef3d3fc6ccae998fcf4b817354661d6d497759ee378c049b238695b522"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.34"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "755db3170ac301e5988baf22289b305a8ea4082a86ac128615561e0107e496e7"
-    sha256 cellar: :any_skip_relocation, ventura:       "8a1f230049726d35c236f7ce2cb144c4a0405c4f41078ef13410b4432513214a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1849eb00db0b46c508b2930d72ae8499d16071d89c6070adb10203e7510098ba"
-  end
+  version "4.1.35"
+  sha256 "07024db15fd39c44c39cfa9a76b2dc2a4fbbe61bb568d9b1ce671faf9376adfd"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.35](https://codeberg.org/PurpleBooth/readable-name-generator/compare/6ccaa194eb5360491d0011ea366fed9985eb7b26..v4.1.35) - 2025-02-21
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to b11ea81 - ([c72f58f](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c72f58f571080bc60fc0f6ecdb233c5626dc422a)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 4f08b22 - ([f0a0fef](https://codeberg.org/PurpleBooth/readable-name-generator/commit/f0a0feffa251af32791fbffd3be300d5e53632e4)) - Solace System Renovate Fox
- **(deps)** update https://code.forgejo.org/actions/cache digest to 0c907a7 - ([6ccaa19](https://codeberg.org/PurpleBooth/readable-name-generator/commit/6ccaa194eb5360491d0011ea366fed9985eb7b26)) - Solace System Renovate Fox
- **(version)** v4.1.35 [skip ci] - ([bd894b9](https://codeberg.org/PurpleBooth/readable-name-generator/commit/bd894b979548a4d33f00fb55a99935dcfc3f598d)) - SolaceRenovateFox

