### PR TITLE
fix: upgrade fast-conventional to 2.3.85

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.84"
-  sha256 "168b143538b2bcb702aa69fdf05bc3fc8562ff9a443becc60c959a78a1067801"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.84"
-    sha256 cellar: :any,                 ventura:      "54089b73972a252fa404664fcbe9c0e2f051379fdfffe7680c9688b7aedba0c7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "af115458ad492998c244aff9a925d90430349eff7b0f9ccc05c953ecf356a0ec"
-  end
+  version "2.3.85"
+  sha256 "5a3fda80d9bc0bf9335c1511532444616341b58575cb58bad910aa9b25ffb06e"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.85](https://codeberg.org/PurpleBooth/git-mit/compare/f63fe0e0236e0093471a1b1cc8b3b558c68e2afe..v2.3.85) - 2025-02-21
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to b11ea81 - ([f63fe0e](https://codeberg.org/PurpleBooth/git-mit/commit/f63fe0e0236e0093471a1b1cc8b3b558c68e2afe)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.85 [skip ci] - ([bdcd5fd](https://codeberg.org/PurpleBooth/git-mit/commit/bdcd5fdd9b6d1e1dde53b288fc09eb998f3d6741)) - SolaceRenovateFox

