### PR TITLE
fix: upgrade readable-name-generator to 4.1.36

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.35"
-  sha256 "07024db15fd39c44c39cfa9a76b2dc2a4fbbe61bb568d9b1ce671faf9376adfd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.35"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "48d5d91cfd89656328df993dc2ee1fd4e2485cc5fe7f5ca56b2fbbe879eecbff"
-    sha256 cellar: :any_skip_relocation, ventura:       "60f9a0c168d1708ee574b65c35153f4a1e8c5f055bd929eb01582c8803a6ca06"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e48271fb79e493ecf89eae63b2e7d7ff9aeacc8bfa923225cf49186a04d64a7d"
-  end
+  version "4.1.36"
+  sha256 "fae04f4f0db9394e12193f777e2f4f92fa7eadfb543b1167ba0108e2124709d9"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.36](https://codeberg.org/PurpleBooth/readable-name-generator/compare/4d52a786002bffd9a5c8cf1d768ebc8432272cf3..v4.1.36) - 2025-02-21
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 64d3fbc - ([4d52a78](https://codeberg.org/PurpleBooth/readable-name-generator/commit/4d52a786002bffd9a5c8cf1d768ebc8432272cf3)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.36 [skip ci] - ([fe63402](https://codeberg.org/PurpleBooth/readable-name-generator/commit/fe6340244e24528322d2412d417d121fbaa67173)) - SolaceRenovateFox

