### PR TITLE
fix: upgrade fast-conventional to 2.3.87

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.86"
-  sha256 "f4ca4a24bc1de89df604e3bc72209c4ca0967df45ed3c2fd4c9a7ef56ab24a7c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.86"
-    sha256 cellar: :any,                 ventura:      "874efec11e288a7423cf76e492e6350bfed3bbab83babd972d614f9bbf8fa278"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "49950d87444682bad32f8b1941e5a52c82cc7a5ad03120c2756191453a75f870"
-  end
+  version "2.3.87"
+  sha256 "e377c858d3a5c9bd7e9dd16e328a4175e620198ee56f51a7f02e26170abb44ba"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.87](https://codeberg.org/PurpleBooth/git-mit/compare/ed641284cc1a537fcacde0586609e56551e30e95..v2.3.87) - 2025-02-24
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.31 - ([ed64128](https://codeberg.org/PurpleBooth/git-mit/commit/ed641284cc1a537fcacde0586609e56551e30e95)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.87 [skip ci] - ([bef133f](https://codeberg.org/PurpleBooth/git-mit/commit/bef133f8cf40611873d3f4aef9fb13b70009e615)) - SolaceRenovateFox

