### PR TITLE
fix: upgrade readable-name-generator to 4.1.37

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.36"
-  sha256 "fae04f4f0db9394e12193f777e2f4f92fa7eadfb543b1167ba0108e2124709d9"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.36"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2e1e09160cbab1487c9dcf0ed7a780b557dc569c5af8a480d8083bc9bd1a3d9d"
-    sha256 cellar: :any_skip_relocation, ventura:       "d570aa12894dbd2d3971b21ccdcdb90d1e9b924a8106563711ec7aa6bf5ffe9d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "11c6a1e4330aa1f3909e1837efe114f2aff71aa04f1ee82ee027add6f46b87ad"
-  end
+  version "4.1.37"
+  sha256 "94d16b47f14e946fae37b763b642f91b15a09fa53c4539b77cafc8d1b24a6178"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.37](https://codeberg.org/PurpleBooth/readable-name-generator/compare/2ec1282ca1082d435390c10b16543a9a1084ab05..v4.1.37) - 2025-02-24
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.31 - ([2ec1282](https://codeberg.org/PurpleBooth/readable-name-generator/commit/2ec1282ca1082d435390c10b16543a9a1084ab05)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.37 [skip ci] - ([205883b](https://codeberg.org/PurpleBooth/readable-name-generator/commit/205883b631dfe41ff379b17cdad91c00203f46a4)) - SolaceRenovateFox

