### PR TITLE
fix: upgrade fast-conventional to 2.3.88

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.87"
-  sha256 "e377c858d3a5c9bd7e9dd16e328a4175e620198ee56f51a7f02e26170abb44ba"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.87"
-    sha256 cellar: :any,                 ventura:      "121786da9f7600ef8242265414b02ba4919a890e377ea35f716c62a95994c2db"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "dcb6ac5afd3b2a63f7d505c043638f26053f39aea7798fe45a4a1c24c13a6cd8"
-  end
+  version "2.3.88"
+  sha256 "9448417718b1ae99644e2e39e41575aac2bd7c6f2019d5e866fc0b0c11d4fafd"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.88](https://codeberg.org/PurpleBooth/git-mit/compare/c0d451f3c64d6b2351d42b285d1cadd4e493e2a0..v2.3.88) - 2025-02-25
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.46 - ([c0d451f](https://codeberg.org/PurpleBooth/git-mit/commit/c0d451f3c64d6b2351d42b285d1cadd4e493e2a0)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.88 [skip ci] - ([10e98d6](https://codeberg.org/PurpleBooth/git-mit/commit/10e98d6d89becad4826f50a403aecace4b096069)) - SolaceRenovateFox

