### PR TITLE
fix: upgrade fast-conventional to 2.3.89

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.88"
-  sha256 "9448417718b1ae99644e2e39e41575aac2bd7c6f2019d5e866fc0b0c11d4fafd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.88"
-    sha256 cellar: :any,                 ventura:      "6df575ef5863f91b6148de6007110f07ef980e88cdddaabb7eba0751dc3484be"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c7dbdb3d544ab7864bfb0a7b3fddb97ef0949d7fdaac9c8171fde8e9d78638c8"
-  end
+  version "2.3.89"
+  sha256 "973a4e06599606bbc3a48c8b9e18fe49f3c3698cd634cb64ff5b0594211fc0e0"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.89](https://codeberg.org/PurpleBooth/git-mit/compare/9efe56c16a4636bbccb0eef3aab30f32764fbca9..v2.3.89) - 2025-02-28
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to 5612c15 - ([03659bf](https://codeberg.org/PurpleBooth/git-mit/commit/03659bf2ee85bf32b0ac4f8d5d1b73453d8a2c6c)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/setup-buildx-action digest to b5ca514 - ([74f9881](https://codeberg.org/PurpleBooth/git-mit/commit/74f988134ef6e59badae0378a4b69a37421d5dad)) - Solace System Renovate Fox
- **(deps)** update https://code.forgejo.org/actions/cache digest to d4323d4 - ([8abd664](https://codeberg.org/PurpleBooth/git-mit/commit/8abd66420fd3e8285b6478b8281786491242878b)) - Solace System Renovate Fox
- **(deps)** update https://code.forgejo.org/docker/metadata-action digest to 902fa8e - ([c39d882](https://codeberg.org/PurpleBooth/git-mit/commit/c39d8821cf7b8486d9a633eed90d1bc50cf07607)) - Solace System Renovate Fox
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 4ba453f - ([9efe56c](https://codeberg.org/PurpleBooth/git-mit/commit/9efe56c16a4636bbccb0eef3aab30f32764fbca9)) - Solace System Renovate Fox
- **(version)** v2.3.89 [skip ci] - ([641588a](https://codeberg.org/PurpleBooth/git-mit/commit/641588a1b37b4fd8c214bc412bb590fadd8da5be)) - SolaceRenovateFox

