### PR TITLE
fix: upgrade readable-name-generator to 4.1.40

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.39"
-  sha256 "475e6d59ff7a64ad4a916171c5a4aaff24431c5f024c8e5370f2e53056d8924f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.39"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f98d669e0bdbdeb78a51a6e436465fc271be6478b8c4bf35c75b5ad58e36b603"
-    sha256 cellar: :any_skip_relocation, ventura:       "7515ec2e3a7d3a932cef76a21c91d1b17462b1e82c8a9f17b66459d6ce103e30"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b483a0b1cea704a398c4dc114003e71566fc4d10d57d1ab1f0ee06b42fe5347c"
-  end
+  version "4.1.40"
+  sha256 "4dd389109a5bef870a2e87ba0c85085b09f06e81328b4520cf57ae1682f44825"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.40](https://codeberg.org/PurpleBooth/readable-name-generator/compare/181d35ab98e528282eb5da9b23006b933e1c1277..v4.1.40) - 2025-03-04
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 1030547 - ([181d35a](https://codeberg.org/PurpleBooth/readable-name-generator/commit/181d35ab98e528282eb5da9b23006b933e1c1277)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.40 [skip ci] - ([8c92024](https://codeberg.org/PurpleBooth/readable-name-generator/commit/8c920248f19b99ea90d4c77fd548db46e487077e)) - SolaceRenovateFox

