### PR TITLE
fix: upgrade fast-conventional to 2.3.91

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.90"
-  sha256 "970b976f0e131cd40171213318ea8ae9be93d6237bc050c737d4e5f7d6b5686c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.90"
-    sha256 cellar: :any,                 ventura:      "40588e32b5bf835b41c7579a55d2ac2919dc0edcc201a70fa4303d5ec431ed0d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "83f9f770beaaee51854efed05a6c82142d728e1cb59d8c2c0ba3aae7a140b571"
-  end
+  version "2.3.91"
+  sha256 "3fd82dd7a969c80939ecaf1f4ea25111304845f5f1ae336b283ea45b45869e74"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.91](https://codeberg.org/PurpleBooth/git-mit/compare/79c356b46fd7a71dcfcb28679bc07c46e873c948..v2.3.91) - 2025-03-04
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 1030547 - ([79c356b](https://codeberg.org/PurpleBooth/git-mit/commit/79c356b46fd7a71dcfcb28679bc07c46e873c948)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.91 [skip ci] - ([75e7185](https://codeberg.org/PurpleBooth/git-mit/commit/75e7185904d2859d222dceb33d5787420a918519)) - SolaceRenovateFox

