### PR TITLE
fix: upgrade fast-conventional to 2.3.92

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.91"
-  sha256 "3fd82dd7a969c80939ecaf1f4ea25111304845f5f1ae336b283ea45b45869e74"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.91"
-    sha256 cellar: :any,                 ventura:      "578268735bc24499758d2e604624bb6d26fdfb949504dfb86bd18c081b79eab2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e71f238ed5d6d1529fe705edfe7faefbdf925e0c310ae5834bd33532979969a1"
-  end
+  version "2.3.92"
+  sha256 "56c0148ee67c48aea35ade7edeae0fb36a74504caaf224e3abaed3a23ba2a554"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.92](https://codeberg.org/PurpleBooth/git-mit/compare/8a1c5b562cbfdec458619454e6ff1510a1502a52..v2.3.92) - 2025-03-05
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to bea885d - ([8a1c5b5](https://codeberg.org/PurpleBooth/git-mit/commit/8a1c5b562cbfdec458619454e6ff1510a1502a52)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.92 [skip ci] - ([546ca98](https://codeberg.org/PurpleBooth/git-mit/commit/546ca98f6dc82b39bf5520ef2578f87588b9e31b)) - SolaceRenovateFox

