### PR TITLE
fix: upgrade readable-name-generator to 4.1.41

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.40"
-  sha256 "4dd389109a5bef870a2e87ba0c85085b09f06e81328b4520cf57ae1682f44825"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.40"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1e5c7f6cd904a0240017d81e42ce60cf962dcafe60704b004307e1b51d4352ec"
-    sha256 cellar: :any_skip_relocation, ventura:       "46a20d800b8798ba0de6204ede998679504d47fd82170e9f1f9be9bd36d583cc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d0135c44208a582b4a26e6668970e96b3312a08acd33a4d0a84ffdc01aed3f94"
-  end
+  version "4.1.41"
+  sha256 "2e7023b70c5939879a48162f3bb77dd477946c2574db79caaad608d0b5fcda09"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.41](https://codeberg.org/PurpleBooth/readable-name-generator/compare/1821b00d0865b7632a2bb4707f7ffec63c4b22f6..v4.1.41) - 2025-03-05
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to bea885d - ([1821b00](https://codeberg.org/PurpleBooth/readable-name-generator/commit/1821b00d0865b7632a2bb4707f7ffec63c4b22f6)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.41 [skip ci] - ([40bcf94](https://codeberg.org/PurpleBooth/readable-name-generator/commit/40bcf94ccd2700019890a600d4f92dee214f1aae)) - SolaceRenovateFox

