### PR TITLE
fix: upgrade fast-conventional to 2.3.94

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.93"
-  sha256 "39f7b9b8801b1d01f4d89bbf724761901c86c174267c1bab658103ca7e4944d5"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.93"
-    sha256 cellar: :any,                 ventura:      "9e3c5d91e433ab4cddccbfd39615b0949ee1f3dc8820f839abca8831c780e6f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "67548ed6ab66bff26936ddd7b2d359907a34ded830a8b634b0ac1ff504298b4b"
-  end
+  version "2.3.94"
+  sha256 "9e514046428d57ac00b5f0d70d984009f9018a4ae16358154b36273d34ead5e0"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.94](https://codeberg.org/PurpleBooth/git-mit/compare/48963bcb15eccfb5c68de101a399fa4a2552372b..v2.3.94) - 2025-03-14
#### Bug Fixes
- **(deps)** update rust crate serde to v1.0.219 - ([a16c8fa](https://codeberg.org/PurpleBooth/git-mit/commit/a16c8fad3817e2d59a479118c0e2ffb40f26b0ac)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update rust crate tempfile to v3.19.0 - ([6366862](https://codeberg.org/PurpleBooth/git-mit/commit/636686268dc919c5643bf930aa810980c7eb3c25)) - Solace System Renovate Fox
- **(deps)** update rust crate tempfile to v3.18.0 - ([48963bc](https://codeberg.org/PurpleBooth/git-mit/commit/48963bcb15eccfb5c68de101a399fa4a2552372b)) - Solace System Renovate Fox
- **(version)** v2.3.94 [skip ci] - ([6c535c3](https://codeberg.org/PurpleBooth/git-mit/commit/6c535c3fc83c5ab15bf024024d25813ecc6f19f1)) - SolaceRenovateFox

