### PR TITLE
fix: upgrade readable-name-generator to 4.1.43

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.42"
-  sha256 "2c102c9477759ebe9a3d3e47ef026988764156be2a5e6a9341dafaee467dc6e5"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.42"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5dcf21c793ecda96d5dca92d943c34f1e5e315ed8bb63b21af4770ed6e8dce1e"
-    sha256 cellar: :any_skip_relocation, ventura:       "1c2e952f2c6264e0b40efa4eab1110f36747f80e366414d0ca5b842500ac01f0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "474a3277a8452a4eff9ad35aac34c6dd84b86533c7e52be237599b49908ea1a1"
-  end
+  version "4.1.43"
+  sha256 "86c0f9c6cc680ab23670594e6821b3b11985fdf335dc5b64e42fad01f1542b28"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.43](https://codeberg.org/PurpleBooth/readable-name-generator/compare/ce479b3059d096884a80f7e760e2c5e91ff5b0f5..v4.1.43) - 2025-03-19
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 9b8f32b - ([306b85e](https://codeberg.org/PurpleBooth/readable-name-generator/commit/306b85e7856d63b33b1714fe3fadbfc317cc00c1)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/login-action digest to 74a5d14 - ([ce479b3](https://codeberg.org/PurpleBooth/readable-name-generator/commit/ce479b3059d096884a80f7e760e2c5e91ff5b0f5)) - Solace System Renovate Fox
- **(version)** v4.1.43 [skip ci] - ([03edaca](https://codeberg.org/PurpleBooth/readable-name-generator/commit/03edaca29640ea40a28e652a5511c3b9e320d300)) - SolaceRenovateFox

