### PR TITLE
fix: upgrade fast-conventional to 2.3.96

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.95"
-  sha256 "3f2f2e6f5bee87c3e06ddea32b9d2faaf51d4f966575cdae6fe1ab543c86304e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.95"
-    sha256 cellar: :any,                 ventura:      "29822e103513640e5adee4677523b3bb99ad77f968695dc7d93f590e05ee14e3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6c7c3a1e28786d3fdd4985ba2c73d3bb6cef3f6faec40b226366a742dcd3da86"
-  end
+  version "2.3.96"
+  sha256 "bcb534ce6f6cdf96c3665bf33313c70c3c46c719d9a5445f06ecb30962a5b2eb"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.96](https://codeberg.org/PurpleBooth/git-mit/compare/0229295e4df9e083c8b491c2576eb0f7e677093e..v2.3.96) - 2025-03-19
#### Bug Fixes
- **(deps)** update rust crate git2 to v0.20.1 - ([0229295](https://codeberg.org/PurpleBooth/git-mit/commit/0229295e4df9e083c8b491c2576eb0f7e677093e)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.96 [skip ci] - ([4fc6715](https://codeberg.org/PurpleBooth/git-mit/commit/4fc671518858bea5e220a57ca1732cc87a78d21f)) - SolaceRenovateFox

