### PR TITLE
fix: upgrade fast-conventional to 2.3.97

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.96"
-  sha256 "bcb534ce6f6cdf96c3665bf33313c70c3c46c719d9a5445f06ecb30962a5b2eb"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.96"
-    sha256 cellar: :any,                 ventura:      "695c92710fb46b536d518c9e5f4ec54192c798e9d79aeacd8feadefd382eabca"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "91922a53b06e6e25a811ad7783b5e2d97f23443d7d0e2d1ffbe899c405334ae2"
-  end
+  version "2.3.97"
+  sha256 "4b8a16b55919f30801e9315d9b6527389890866f66dc6ba000f649854c2f7749"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.97](https://codeberg.org/PurpleBooth/git-mit/compare/a55153424259310d11c3723f4bf00ae0f2dcddbe..v2.3.97) - 2025-03-19
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 4333721 - ([a551534](https://codeberg.org/PurpleBooth/git-mit/commit/a55153424259310d11c3723f4bf00ae0f2dcddbe)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.97 [skip ci] - ([52b683c](https://codeberg.org/PurpleBooth/git-mit/commit/52b683cb5d945992e9bc20dc34ef11ec854b2c85)) - SolaceRenovateFox

