### PR TITLE
fix: upgrade fast-conventional to 2.3.98

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.97"
-  sha256 "4b8a16b55919f30801e9315d9b6527389890866f66dc6ba000f649854c2f7749"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.97"
-    sha256 cellar: :any,                 ventura:      "cc7fa1b3df3de03b07c0c72f4cd1359e48e6698512fcb2ee6ad7badfa9981624"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ae26a389c6c4671f39e67052a127a27a1965fa468561cfbb1f4f1178733b6c4d"
-  end
+  version "2.3.98"
+  sha256 "4546f6644882a741dd1b7df3e038ad144cfc11306dd45c8bc503ed6e2346cbf7"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.98](https://codeberg.org/PurpleBooth/git-mit/compare/6bface6e1b1b9b38c607ca519c65c7c20da976d8..v2.3.98) - 2025-03-26
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.33 - ([91988d4](https://codeberg.org/PurpleBooth/git-mit/commit/91988d4e1a5908c0ad496cf38d3f151d9241f6d3)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update rust crate tempfile to v3.19.1 - ([6bface6](https://codeberg.org/PurpleBooth/git-mit/commit/6bface6e1b1b9b38c607ca519c65c7c20da976d8)) - Solace System Renovate Fox
- **(version)** v2.3.98 [skip ci] - ([73f9edf](https://codeberg.org/PurpleBooth/git-mit/commit/73f9edf438cdcb5b18b4736eeb719ac1721ab1b2)) - SolaceRenovateFox

