### PR TITLE
fix: upgrade readable-name-generator to 4.1.45

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.44"
-  sha256 "dc5de7ab4f1469d3283e7609c512c4d132147c9674242683a2821aebb1d73025"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.44"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7dfc573a60c5954c1c9875e31196d82a69f9e3123c807ee3f53dfe3a65570ab8"
-    sha256 cellar: :any_skip_relocation, ventura:       "5c49a31e777a68de9bef01883a660ed6290b350c0303db8e82aab36c807dab33"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "53d604943a17dddbb5038f5eb64c2ce876d5d3f8a68c9c7bf99ebbea15233205"
-  end
+  version "4.1.45"
+  sha256 "5dbcbf4bdc950d4e12acc0591963eccfc559153316b3a761dbf4984025ab01d7"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.45](https://codeberg.org/PurpleBooth/readable-name-generator/compare/f1966ea9b4b0287c9da3b01c3a1a8330db120c76..v4.1.45) - 2025-03-26
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.33 - ([2e4694c](https://codeberg.org/PurpleBooth/readable-name-generator/commit/2e4694c0f04c82da10cf7d5ba58157ce5b947fcb)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/actions/cache digest to 5a3ec84 - ([f1966ea](https://codeberg.org/PurpleBooth/readable-name-generator/commit/f1966ea9b4b0287c9da3b01c3a1a8330db120c76)) - Solace System Renovate Fox
- **(version)** v4.1.45 [skip ci] - ([b0af9d2](https://codeberg.org/PurpleBooth/readable-name-generator/commit/b0af9d2e0c5c4889cd684f898f1d2df33f915cc4)) - SolaceRenovateFox

