### PR TITLE
fix: upgrade fast-conventional to 2.3.99

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.98"
-  sha256 "4546f6644882a741dd1b7df3e038ad144cfc11306dd45c8bc503ed6e2346cbf7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.98"
-    sha256 cellar: :any,                 ventura:      "7186a42da987b74f9de2bc53d4016b825ef11e614768f48444e15db9102d63cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1a844b36ffb82e3f35c6b122cd7b1e82f8cda876c292d286bfea7a7e7c2d7108"
-  end
+  version "2.3.99"
+  sha256 "d4935cb547062a05d014c3835a2402f9391690137847564971087772e4ee4edf"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.99](https://codeberg.org/PurpleBooth/git-mit/compare/16ce7493cf35aeff6096a200a108d9a3b6d4278f..v2.3.99) - 2025-03-27
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.47 - ([16ce749](https://codeberg.org/PurpleBooth/git-mit/commit/16ce7493cf35aeff6096a200a108d9a3b6d4278f)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.99 [skip ci] - ([cbeba3e](https://codeberg.org/PurpleBooth/git-mit/commit/cbeba3e4b059796da35a4568f5bbfff3f2eca930)) - SolaceRenovateFox

