### PR TITLE
fix: upgrade readable-name-generator to 4.1.46

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.45"
-  sha256 "5dbcbf4bdc950d4e12acc0591963eccfc559153316b3a761dbf4984025ab01d7"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.45"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3cf1c4f6c6dfc8a1086ee10f24ac951999c0f21d69fcc639e2e64cba1caaa719"
-    sha256 cellar: :any_skip_relocation, ventura:       "22f41878b26541be656a9f4c7a0d5d9ccbbfe9c6b479094628a0ac1888c58f26"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0a998521080f9577246859c1f52adc9f60c5b59fc0900a1d47d65036346dc036"
-  end
+  version "4.1.46"
+  sha256 "748985834fa978fc49d8a6e604c30b7793c6a6c45ea19ac84b9c8bc60799b733"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.46](https://codeberg.org/PurpleBooth/readable-name-generator/compare/75f9761aac0962a90a13ef1339e1f90f9396a07c..v4.1.46) - 2025-03-27
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.47 - ([75f9761](https://codeberg.org/PurpleBooth/readable-name-generator/commit/75f9761aac0962a90a13ef1339e1f90f9396a07c)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.46 [skip ci] - ([07b9c02](https://codeberg.org/PurpleBooth/readable-name-generator/commit/07b9c026ca0a49c746306547e7b26ecafa88cc0d)) - SolaceRenovateFox

