### PR TITLE
fix: upgrade readable-name-generator to 4.1.47

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.46"
-  sha256 "748985834fa978fc49d8a6e604c30b7793c6a6c45ea19ac84b9c8bc60799b733"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.46"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "57572ac83b89002a5bb5be6dbe8f2b4f5ca992bb1f6175feb836f65fd3c123c3"
-    sha256 cellar: :any_skip_relocation, ventura:       "bab963320a36790a94c18622375a3119223e0c3431f576c4f0088534f611cae2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "135c679cd409e1d4f05807cf732ee4fd6803e6acf69d96b9f952337756ce537f"
-  end
+  version "4.1.47"
+  sha256 "edc2f8d9cad4577e607457063a53707a5a36cbb16dff17070157ef7820329f49"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.47](https://codeberg.org/PurpleBooth/readable-name-generator/compare/76ca89f133a319c5593aa239187a30e30f0c6238..v4.1.47) - 2025-03-27
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.34 - ([76ca89f](https://codeberg.org/PurpleBooth/readable-name-generator/commit/76ca89f133a319c5593aa239187a30e30f0c6238)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.47 [skip ci] - ([0fff588](https://codeberg.org/PurpleBooth/readable-name-generator/commit/0fff588aae29461b5dba0eb9f926a3e34ed4abef)) - SolaceRenovateFox

