### PR TITLE
fix: upgrade readable-name-generator to 4.1.48

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.47"
-  sha256 "edc2f8d9cad4577e607457063a53707a5a36cbb16dff17070157ef7820329f49"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.47"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3ef87c47c6d5f12051939ec670b63ed5815ecb6b0dbdb21a25a0cfabbef03454"
-    sha256 cellar: :any_skip_relocation, ventura:       "f4063eb8e68fb3e9b0b7e4970ac2053513bc06ca75c48625cff498acb07765d3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b3b99aa27a4a28bad8dd3194ebe7a2824d286500c8cea14520a4f42eb6465f1e"
-  end
+  version "4.1.48"
+  sha256 "3fdaeb728485fc5ff88e0717defeff573b6578f5bac57e531efad58aaa8e2b4b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.48](https://codeberg.org/PurpleBooth/readable-name-generator/compare/0e1d7588e0c760cde927f2ac9221b9a2e048a2a6..v4.1.48) - 2025-03-29
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to 44ab1c1 - ([0e1d758](https://codeberg.org/PurpleBooth/readable-name-generator/commit/0e1d7588e0c760cde927f2ac9221b9a2e048a2a6)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.48 [skip ci] - ([64ac452](https://codeberg.org/PurpleBooth/readable-name-generator/commit/64ac45292e23de097990a83c9a9e041843d751bd)) - SolaceRenovateFox

