### PR TITLE
fix: upgrade readable-name-generator to 4.1.49

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.48"
-  sha256 "3fdaeb728485fc5ff88e0717defeff573b6578f5bac57e531efad58aaa8e2b4b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.48"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a3a867251e72d53e8e466dc9e7314415e2ea18d25f1532c136e9f402ea1409b2"
-    sha256 cellar: :any_skip_relocation, ventura:       "6c57eaea84cb04082c741ccc3b30575b20f7f747002a42cc1711248ef7f0fe28"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "30b255efa5689dc9d372b7d3be1dbca31daef2ff404b5594590ba2463fe6d2d8"
-  end
+  version "4.1.49"
+  sha256 "1a5c2906722892114f6e2b7f5b075d3ec16ace1e9b8036fec660558f28f894dc"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.49](https://codeberg.org/PurpleBooth/readable-name-generator/compare/ec39560a5c90d44f99aef5ade340159c2f8c0295..v4.1.49) - 2025-04-03
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 541a172 - ([ec39560](https://codeberg.org/PurpleBooth/readable-name-generator/commit/ec39560a5c90d44f99aef5ade340159c2f8c0295)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.49 [skip ci] - ([9c53e44](https://codeberg.org/PurpleBooth/readable-name-generator/commit/9c53e44910877090e3812d3069a0e89f4f5b9535)) - SolaceRenovateFox

