### PR TITLE
fix: upgrade readable-name-generator to 4.1.50

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.49"
-  sha256 "1a5c2906722892114f6e2b7f5b075d3ec16ace1e9b8036fec660558f28f894dc"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.49"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7b971f1a980680bfb994b25d95889c8157ff94dec7188728d24f781f6082550a"
-    sha256 cellar: :any_skip_relocation, ventura:       "8ebe725eb4f0a6b90ed8c3b39f1b42f6fec10dee14e1b56ff651ae755e6d61c9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e0107fdfe1b80e92b119bba31aed50c87bb041b9794794879c66979d762a831b"
-  end
+  version "4.1.50"
+  sha256 "7f2d4771beab92c3cfc55cada1370c89ac56b575f1176559b7362f3106b6f5b2"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.50](https://codeberg.org/PurpleBooth/readable-name-generator/compare/f9fa0237ddccc91f14fb92a5f4e34b16df681fee..v4.1.50) - 2025-04-04
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.35 - ([f9fa023](https://codeberg.org/PurpleBooth/readable-name-generator/commit/f9fa0237ddccc91f14fb92a5f4e34b16df681fee)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.50 [skip ci] - ([a9bdad2](https://codeberg.org/PurpleBooth/readable-name-generator/commit/a9bdad2ebaa3a3b2f6098fb09af4b323e68ffdc7)) - SolaceRenovateFox

