### PR TITLE
fix: upgrade readable-name-generator to 4.1.51

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.50"
-  sha256 "7f2d4771beab92c3cfc55cada1370c89ac56b575f1176559b7362f3106b6f5b2"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.50"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "eb374615ae7b3112cbf535e676c0f6ee05c1ad4f49d05915347bdd53b79b8d97"
-    sha256 cellar: :any_skip_relocation, ventura:       "13f9ee0010473f98fc55259fc92e7d0cf664def2f37641f6963ed6e50c7935ea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "504ff84b0885f6abb107b4b47b0c67e81cd085e8eb0d028ff5bf4b4bbec1d1a7"
-  end
+  version "4.1.51"
+  sha256 "d8839139b035d437a044797552550c73b8f6a7457210179fc8078b9731cb4ee5"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.51](https://codeberg.org/PurpleBooth/readable-name-generator/compare/5c19e5b03e4a2fad92d1370d78a63d949f18fc8f..v4.1.51) - 2025-04-11
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.36 - ([5c19e5b](https://codeberg.org/PurpleBooth/readable-name-generator/commit/5c19e5b03e4a2fad92d1370d78a63d949f18fc8f)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.51 [skip ci] - ([6a3f932](https://codeberg.org/PurpleBooth/readable-name-generator/commit/6a3f932317def39da0c2a9eb72bec16b48e4b29b)) - SolaceRenovateFox

