### PR TITLE
fix: upgrade readable-name-generator to 4.1.52

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.51"
-  sha256 "d8839139b035d437a044797552550c73b8f6a7457210179fc8078b9731cb4ee5"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.51"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "700d2f54eeb03e1019dc18897ad9e43f479e44636dd40d9dcb23b294e9ca970d"
-    sha256 cellar: :any_skip_relocation, ventura:       "619706230698518b94a6a353d436789de383c17668e07e3720c151231bcb36a7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2e106ac9bf14297f28ba430dc5df642e198bdec8fbd37cb3846f28ce646b9445"
-  end
+  version "4.1.52"
+  sha256 "76740fee3a4475c35ca4b7b9ad4e561884c34b5b0979939086af1d3dc20138de"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.52](https://codeberg.org/PurpleBooth/readable-name-generator/compare/1a6a0cdd120f6344b5f71a70ec4e6d100fe6b1b0..v4.1.52) - 2025-04-17
#### Bug Fixes
- **(deps)** update rust crate rand to v0.9.1 - ([1a6a0cd](https://codeberg.org/PurpleBooth/readable-name-generator/commit/1a6a0cdd120f6344b5f71a70ec4e6d100fe6b1b0)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.52 [skip ci] - ([2f9a25c](https://codeberg.org/PurpleBooth/readable-name-generator/commit/2f9a25c5d5396e6c1d5f603ebf830435ec44a55e)) - SolaceRenovateFox

