### PR TITLE
fix: upgrade readable-name-generator to 4.1.53

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.52"
-  sha256 "76740fee3a4475c35ca4b7b9ad4e561884c34b5b0979939086af1d3dc20138de"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.52"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6cc8b6a115cc6bc8f1062ce66e61bd279e2f84613f68202dd002a91e257ba854"
-    sha256 cellar: :any_skip_relocation, ventura:       "2b8e59efe70cf2b9718e497558fbbf7f482c259648a7c92de1407503aaa756ba"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3a899c74b41d706c13551aa2ef4b750f8df28b7363459d4400865b6cef88687e"
-  end
+  version "4.1.53"
+  sha256 "3728bdaf04245832a4af855cf75d84f0935ea752b30e3d73f3bf7e95f09d93aa"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.53](https://codeberg.org/PurpleBooth/readable-name-generator/compare/62ae8bb5bab47766eab5c9a0a5a9ab2886ca5c0e..v4.1.53) - 2025-04-24
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.37 - ([62ae8bb](https://codeberg.org/PurpleBooth/readable-name-generator/commit/62ae8bb5bab47766eab5c9a0a5a9ab2886ca5c0e)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 76f9fa3 - ([cfc1700](https://codeberg.org/PurpleBooth/readable-name-generator/commit/cfc17007b966022a3cdc92217fd90596622a673b)) - Solace System Renovate Fox
- **(version)** v4.1.53 [skip ci] - ([74f2ab7](https://codeberg.org/PurpleBooth/readable-name-generator/commit/74f2ab7103089f7e519b92813dac6248f32ca337)) - SolaceRenovateFox

