### PR TITLE
fix: upgrade fast-conventional to 2.3.104

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.103"
-  sha256 "b4f7f4ee2de3ca65b2966a211483552cda993b84ac8ef6c6075c4acfe9a98b3d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.103"
-    sha256 cellar: :any,                 ventura:      "6fcc2b6a66e9fbcafed2859ef8accc1455a1b2baee7ed091dc8fa0d3d191aae9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2947c69b6264bb989a39a517c47fca58a047974440f3fd18337da09dd3b30a52"
-  end
+  version "2.3.104"
+  sha256 "b542ebfe23c076f718d96ac09c80fea3a8e8bbba56c3b770e82f217f75700e40"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.104](https://codeberg.org/PurpleBooth/git-mit/compare/4bdbc353247ecf0b678780b1ce5da821ce29a561..v2.3.104) - 2025-04-24
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.37 - ([5a8c894](https://codeberg.org/PurpleBooth/git-mit/commit/5a8c89466e8a8bc7d3951e73fa05c2f3df33a4a2)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 76f9fa3 - ([4bdbc35](https://codeberg.org/PurpleBooth/git-mit/commit/4bdbc353247ecf0b678780b1ce5da821ce29a561)) - Solace System Renovate Fox
- **(version)** v2.3.104 [skip ci] - ([4395300](https://codeberg.org/PurpleBooth/git-mit/commit/4395300ffdf1b8d1f1d8d24336d2023259d19dfc)) - SolaceRenovateFox

