### PR TITLE
fix: upgrade fast-conventional to 2.3.105

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.104"
-  sha256 "b542ebfe23c076f718d96ac09c80fea3a8e8bbba56c3b770e82f217f75700e40"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.104"
-    sha256 cellar: :any,                 ventura:      "a45477c52e31ea0ba68906fd941a26f4114833bfee432f2f117c8155ff6c2a03"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6105c42ce2fa7cb6db1e4ebbe4c25e67858be6808606f654a9444eb009b23221"
-  end
+  version "2.3.105"
+  sha256 "d2c64116462d3b7d9fefe3178b13fdd5fd35a00eda313f8c0d81ff3bae017c9e"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.105](https://codeberg.org/PurpleBooth/git-mit/compare/2b36e265e789758df4352af0f90185fb418e6650..v2.3.105) - 2025-04-27
#### Bug Fixes
- **(deps)** update rust crate miette to v7.6.0 - ([2b36e26](https://codeberg.org/PurpleBooth/git-mit/commit/2b36e265e789758df4352af0f90185fb418e6650)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.105 [skip ci] - ([59df040](https://codeberg.org/PurpleBooth/git-mit/commit/59df040413b07fa8b21302b2a9269f522bfe03d4)) - SolaceRenovateFox

