### PR TITLE
fix: upgrade fast-conventional to 2.3.106

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.105"
-  sha256 "d2c64116462d3b7d9fefe3178b13fdd5fd35a00eda313f8c0d81ff3bae017c9e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.105"
-    sha256 cellar: :any,                 ventura:      "08d4fac961b49791aaf272265a79fc3685532c8f9abce5f28e6aa7e168fc6869"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f834b57c43d4d9e4c74cc61976cb4de31c1acb4ab80d3cb7fa092b6375149b20"
-  end
+  version "2.3.106"
+  sha256 "94d8edb8cf3b9231040159e72773d0c712cb22c634d31afd431e75149499a08f"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.106](https://codeberg.org/PurpleBooth/git-mit/compare/900b099897d880a8d2282407237486456e608404..v2.3.106) - 2025-04-28
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.48 - ([900b099](https://codeberg.org/PurpleBooth/git-mit/commit/900b099897d880a8d2282407237486456e608404)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.106 [skip ci] - ([d089df5](https://codeberg.org/PurpleBooth/git-mit/commit/d089df5e97fc9b1a44ea51efbf8cf952ab33bec3)) - SolaceRenovateFox

