### PR TITLE
fix: upgrade readable-name-generator to 4.1.55

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.54"
-  sha256 "180eaf709cede226a2ca3062bcfcdec49824b3e7e82708afdbbc842d3e886a7d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.54"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5c98849a225d133569bd40a9817568e0a76803f24ca83e7473fae7a2862f203c"
-    sha256 cellar: :any_skip_relocation, ventura:       "b34cd51e259216db77376935b88c337789165c5ac6881f907501d39f49095a6f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2450dc3978c74ac83524d431741625c7d57d2eb9fe1d94b55057adc12ad9e70f"
-  end
+  version "4.1.55"
+  sha256 "65069b0eaf34378b961a70d35f60db014aafc8c86fac3598574b269bba9c9aca"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.55](https://codeberg.org/PurpleBooth/readable-name-generator/compare/51ecafa71781af3ef5d7c14256fcff2be1ae3964..v4.1.55) - 2025-04-28
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.48 - ([51ecafa](https://codeberg.org/PurpleBooth/readable-name-generator/commit/51ecafa71781af3ef5d7c14256fcff2be1ae3964)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.55 [skip ci] - ([c58f8b6](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c58f8b6adfbfaca740f57724fdd137bdb84b5b99)) - SolaceRenovateFox

