### PR TITLE
fix: upgrade readable-name-generator to 4.1.56

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.55"
-  sha256 "65069b0eaf34378b961a70d35f60db014aafc8c86fac3598574b269bba9c9aca"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.55"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a9ffc80094c9460c7b551588f8bdc8a8fdfce50f227aa1a88f400bf42590a0f9"
-    sha256 cellar: :any_skip_relocation, ventura:       "8f47fc412f0197bfd548e931bd1167ab4d6b97bb06be7d24702497a95b16c380"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "91d87d22cd616a799a667ab6e3421067074915745010cd484f2773de821d7878"
-  end
+  version "4.1.56"
+  sha256 "0497e0921e4b530af842d510b2a9c6a0cc19db71ee8ab5d5333e880f39408163"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.56](https://codeberg.org/PurpleBooth/readable-name-generator/compare/c87fc364e6667dbbe5b535908aed134021ec17cf..v4.1.56) - 2025-05-05
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 8c042ca - ([2aa005a](https://codeberg.org/PurpleBooth/readable-name-generator/commit/2aa005a853ba4ca453538fc17695bec23581ba6b)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.56 [skip ci] - ([724aa42](https://codeberg.org/PurpleBooth/readable-name-generator/commit/724aa42cff501d9d48b2341aee8dad15b300a391)) - SolaceRenovateFox
#### Refactoring
- name generation and add comprehensive tests - ([c87fc36](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c87fc364e6667dbbe5b535908aed134021ec17cf)) - Billie Thompson

