### PR TITLE
fix: upgrade fast-conventional to 2.3.108

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.107"
-  sha256 "4f7867425343fcb554e786cad7ee4234c35bda74cb6dd643e41ae63c8b07d56d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.107"
-    sha256 cellar: :any,                 ventura:      "cac59d52fe23b9550b0c25e12612a965b2e5cdc2a5751e7644ed10ebac69876c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "98f47c7a151c0dd77ef4420b1bf97862695a047a667cf49fe2a0170471ca0fc1"
-  end
+  version "2.3.108"
+  sha256 "9401d12e6e6667fde247e3aa2607b2e31451041eaa6d8c6f39e96277ac29c953"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.108](https://codeberg.org/PurpleBooth/git-mit/compare/bcaee076d143d90306bf42a083a435781b2852d6..v2.3.108) - 2025-05-06
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 8c042ca - ([85002c0](https://codeberg.org/PurpleBooth/git-mit/commit/85002c00a14dc4c3ddc7aa513d7b85cbc8153fd4)) - Solace System Renovate Fox
- **(deps)** update rust crate clap_complete to v4.5.49 - ([bcaee07](https://codeberg.org/PurpleBooth/git-mit/commit/bcaee076d143d90306bf42a083a435781b2852d6)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.108 [skip ci] - ([3e1afe9](https://codeberg.org/PurpleBooth/git-mit/commit/3e1afe9f2c0c2b8b33174275da4acf2f5766f416)) - SolaceRenovateFox

