### PR TITLE
fix: upgrade readable-name-generator to 4.1.57

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.56"
-  sha256 "0497e0921e4b530af842d510b2a9c6a0cc19db71ee8ab5d5333e880f39408163"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.56"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "52a4dfa74b7dd4ce1e6d523986cd48ea00a8c939c12e8c6758c36d16db3ae23f"
-    sha256 cellar: :any_skip_relocation, ventura:       "49f469a6afc32f9228de09665ddd0665088771604c90b28cbf3403426820c2e0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dc7f5915cad72fe9bdbe9611afec5f27949993fde9211f9f71ff7d9d0935ed83"
-  end
+  version "4.1.57"
+  sha256 "32183dc0e85e057ca3d276562d6c3d0063ec288930dd9c30933a4bb0155daf8b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.57](https://codeberg.org/PurpleBooth/readable-name-generator/compare/9ec0fcf265d1940479beecbd63b86197e2443263..v4.1.57) - 2025-05-06
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.49 - ([9ec0fcf](https://codeberg.org/PurpleBooth/readable-name-generator/commit/9ec0fcf265d1940479beecbd63b86197e2443263)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.57 [skip ci] - ([c056f40](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c056f4000f04588501e0481b55403058cf275cbb)) - SolaceRenovateFox

