### PR TITLE
fix: upgrade fast-conventional to 2.3.109

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.108"
-  sha256 "9401d12e6e6667fde247e3aa2607b2e31451041eaa6d8c6f39e96277ac29c953"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.108"
-    sha256 cellar: :any,                 ventura:      "c6bb93f5dc2bce6e91e56e5ae4988b2ad751516c3a8f19f83ff1113e08ff6396"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "cee1e9b799c8fc9e8d60df710117c86b41b1f78bb10d310bf5b43469fd71607e"
-  end
+  version "2.3.109"
+  sha256 "c67f7dfe23562c6db527b5e68898a1d369733160c19ff397f4a77049f458d43c"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.109](https://codeberg.org/PurpleBooth/git-mit/compare/cac01d28a96492d33b09e0e4f716593707fee55b..v2.3.109) - 2025-05-06
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 661d708 - ([cac01d2](https://codeberg.org/PurpleBooth/git-mit/commit/cac01d28a96492d33b09e0e4f716593707fee55b)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.109 [skip ci] - ([3782a06](https://codeberg.org/PurpleBooth/git-mit/commit/3782a06faead84c669581e83c6c8be81b71238cf)) - SolaceRenovateFox

