### PR TITLE
fix: upgrade readable-name-generator to 4.1.59

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.58"
-  sha256 "a13963afca3b123a4d32025ff139b9e5352f07aced890406ff465e7dd7408c54"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.58"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0dd1d78e090ba817b8b3d478f920e68f7544db08cf6b160928977b981215043f"
-    sha256 cellar: :any_skip_relocation, ventura:       "f34a126938cce16aad5305c5d69601eb1c39e9dc0a0c6c0992dc28ef7869d49b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cd2e60f0db7095c7d32455241f67d8fa78cbd24be913c266b0c309be517c0e87"
-  end
+  version "4.1.59"
+  sha256 "0918833658699d41fb7523f4b8032825930674b56afa0fa8f463eb99a4eb7f88"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.59](https://codeberg.org/PurpleBooth/readable-name-generator/compare/f82eabbd5bf95e589cbc3df3e151588e6478acbd..v4.1.59) - 2025-05-06
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.50 - ([f82eabb](https://codeberg.org/PurpleBooth/readable-name-generator/commit/f82eabbd5bf95e589cbc3df3e151588e6478acbd)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.59 [skip ci] - ([309a8e9](https://codeberg.org/PurpleBooth/readable-name-generator/commit/309a8e90ea9acbefc50445f9b581f3076cc61759)) - SolaceRenovateFox

