### PR TITLE
fix: upgrade fast-conventional to 2.3.111

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.110"
-  sha256 "956805de694b2d2809ebb5833c563004b01bf3801e4ebeba9d04a06e77a89b6e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.110"
-    sha256 cellar: :any,                 ventura:      "0a962e8547a82ca93abf5a64bec4b6e475d9ecf48a0f32e63977c42053a9d8fd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "daff9bf0f478cf31968a5f9551662c9ab91951d9b0a11f0fd7d959682fbf9629"
-  end
+  version "2.3.111"
+  sha256 "15ba7204d4bf1bc41e96a34a4f3f286531c74a3363d76e08e4ea9960592cc067"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.111](https://codeberg.org/PurpleBooth/git-mit/compare/4acb14a066fc11f1026f95ce196ea615081479d0..v2.3.111) - 2025-05-10
#### Bug Fixes
- **(deps)** update rust crate mit-commit to v3.2.2 - ([4acb14a](https://codeberg.org/PurpleBooth/git-mit/commit/4acb14a066fc11f1026f95ce196ea615081479d0)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.111 [skip ci] - ([a17d43a](https://codeberg.org/PurpleBooth/git-mit/commit/a17d43aa9c6b7eba40b1f6f1551f73b0edf29098)) - SolaceRenovateFox

