### PR TITLE
fix: upgrade fast-conventional to 2.3.112

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.111"
-  sha256 "15ba7204d4bf1bc41e96a34a4f3f286531c74a3363d76e08e4ea9960592cc067"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.111"
-    sha256 cellar: :any,                 ventura:      "ecebceb0982e18532ca2a98d5dfb0eb0c35af6c33f2d0725969fb2c596b3f856"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "deecc39abd447c3729cef81538f57c03525f92bce44fb89e6ce1a3642538e440"
-  end
+  version "2.3.112"
+  sha256 "5b1b005934e83e5bd384c5b70d3697420b1fe74d4a1e1594964c25fdb4338b81"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.112](https://codeberg.org/PurpleBooth/git-mit/compare/dfba529ea01d1fd4fdd5d60586fe9f6123e1f147..v2.3.112) - 2025-05-11
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.38 - ([dfba529](https://codeberg.org/PurpleBooth/git-mit/commit/dfba529ea01d1fd4fdd5d60586fe9f6123e1f147)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.112 [skip ci] - ([5bfd70b](https://codeberg.org/PurpleBooth/git-mit/commit/5bfd70b91fe30279077886c1bee7771d66b81312)) - SolaceRenovateFox

