### PR TITLE
fix: upgrade readable-name-generator to 4.1.60

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.59"
-  sha256 "0918833658699d41fb7523f4b8032825930674b56afa0fa8f463eb99a4eb7f88"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.59"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ee2cc1a0fef21d814b97f98f5c5acd2e03459e648ccb6e20153a721a4516a214"
-    sha256 cellar: :any_skip_relocation, ventura:       "879db6dde518a6d1679731cb34fe9797bd12c241b0adc660d3466faf4ba2b8cd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e4ee70f43686524d62728486d2812841cadbd2b179e4265755fcd55d9bfb0445"
-  end
+  version "4.1.60"
+  sha256 "d45c26fbf3fb722bc7cfb9d7831a59d0b202bafabf84f9b60eba999eacf0e49f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.60](https://codeberg.org/PurpleBooth/readable-name-generator/compare/0c8d6c9a0b9654e7ccfb76faf7cdf924a634ea4d..v4.1.60) - 2025-05-11
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.38 - ([0c8d6c9](https://codeberg.org/PurpleBooth/readable-name-generator/commit/0c8d6c9a0b9654e7ccfb76faf7cdf924a634ea4d)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.60 [skip ci] - ([620fc69](https://codeberg.org/PurpleBooth/readable-name-generator/commit/620fc6999d20d89109a7f4020735e241763689a5)) - SolaceRenovateFox

