### PR TITLE
fix: upgrade readable-name-generator to 4.1.61

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.60"
-  sha256 "d45c26fbf3fb722bc7cfb9d7831a59d0b202bafabf84f9b60eba999eacf0e49f"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.60"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8d0802fdb033096e703affabe65e0f0ced3dfaad159b7e6177afa55665f8a515"
-    sha256 cellar: :any_skip_relocation, ventura:       "521526b3ba7a8d8c8e67b182bd353ee8865603054e4205b48624ab8f9955160e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "77bd9adaee7491d1797652b26ccb4220333fd39e23e320081fbe8db0daadcca0"
-  end
+  version "4.1.61"
+  sha256 "f42bb5f4f8db8d76d4437de09e790aa87c575e5dc21ace174b554182713f4c77"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.61](https://codeberg.org/PurpleBooth/readable-name-generator/compare/5c0fe79e97266d3d4e6fc1a0ccf84e7703021683..v4.1.61) - 2025-05-11
#### Bug Fixes
- **(deps)** update rust crate anarchist-readable-name-generator-lib to v0.1.5 - ([23fc641](https://codeberg.org/PurpleBooth/readable-name-generator/commit/23fc641efc980b86da878bb4b25bed2b8b272771)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.61 [skip ci] - ([30f4241](https://codeberg.org/PurpleBooth/readable-name-generator/commit/30f4241c7d7b31079122d0a7b7758f9e4745c72d)) - SolaceRenovateFox
- update .gitignore and simplify Justfile cargo commands - ([5c0fe79](https://codeberg.org/PurpleBooth/readable-name-generator/commit/5c0fe79e97266d3d4e6fc1a0ccf84e7703021683)) - Billie Thompson

