### PR TITLE
fix: upgrade git-moves-together to 2.7.0

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -1,15 +1,9 @@
 class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
-  homepage "https://github.com/PurpleBooth/git-moves-together"
-  url "https://github.com/PurpleBooth/git-moves-together/archive/refs/tags/v2.6.3.tar.gz"
-  sha256 "98880f26ebd8380289afd2d543c53c2c9b300bba979561c825f5235a503394ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.6.3"
-    sha256 cellar: :any,                 arm64_sonoma: "ecdb8629facd812cbfbf43a3ac7c37da84e271998607c4ce9a8de306b05c6520"
-    sha256 cellar: :any,                 ventura:      "b7489e79f64eebdcbd3eeeda8b98f707e1840755ad83880ab73abcf1fb979c51"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2b15f237bf575ef4b2b548a7a2ba20b30e9fa4f2321850556064620195c25529"
-  end
+  homepage "https://codeberg.org/PurpleBooth/git-moves-together"
+  url "https://codeberg.org/PurpleBooth/git-moves-together/archive/main.tar.gz"
+  version "2.7.0"
+  sha256 "018d70842ebc729036cc9b1aaba9769134e59d07460ec6ff9419d43f02c83cc6"
 
   depends_on "rust" => :build
   depends_on "openssl@3"
@@ -22,7 +16,7 @@ class GitMovesTogether < Formula
   end
 
   test do
-    system "git", "clone", "https://github.com/PurpleBooth/git-moves-together.git"
+    system "git", "clone", "https://codeberg.org/PurpleBooth/git-moves-together.git"
     system "#{bin}/git-moves-together", "git-moves-together"
   end
 end


### PR DESCRIPTION
## [v2.7.0](https://github.com/PurpleBooth/git-moves-together/compare/b5bfc29644d554cf0d29f06fa7eae2d622b60eae..v2.7.0) - 2025-05-11
#### Features
- add docker-bake.hcl for multi-platform builds - ([09995b0](https://github.com/PurpleBooth/git-moves-together/commit/09995b07373a916def2245bcd0f445f1cfff6410)) - Billie Thompson
#### Miscellaneous Chores
- **(deps)** update rust:alpine docker digest to d6e876c - ([be95dcb](https://github.com/PurpleBooth/git-moves-together/commit/be95dcb913cf3a13bee03c02205d07ba69623592)) - renovate[bot]
- **(deps)** update rust:alpine docker digest to d57abe5 - ([203a47f](https://github.com/PurpleBooth/git-moves-together/commit/203a47f53ad04c7efa5b056b092c18245491a46b)) - renovate[bot]
- **(deps)** update rust:alpine docker digest to e4ab5bd - ([b5bfc29](https://github.com/PurpleBooth/git-moves-together/commit/b5bfc29644d554cf0d29f06fa7eae2d622b60eae)) - renovate[bot]
- **(version)** v2.7.0 [skip ci] - ([972fa32](https://github.com/PurpleBooth/git-moves-together/commit/972fa32c068c31d24d377ff18379f37bedeaaa5b)) - PurpleBooth
- Update repository URLs from GitHub to Codeberg - ([bcf381f](https://github.com/PurpleBooth/git-moves-together/commit/bcf381f8fb03eaf8719447beaef69c0f252b3c66)) - Billie Thompson
- Update Dockerfile to use latest rust:alpine image - ([92b1735](https://github.com/PurpleBooth/git-moves-together/commit/92b1735be22215d8b603ef298e3e2150ef1d26e4)) - Billie Thompson
- update dependencies and refactor code - ([e9a1753](https://github.com/PurpleBooth/git-moves-together/commit/e9a175315fb0a1496570c7a6cab506d20c0ab0e6)) - Billie Thompson
#### Refactoring
- Restore original test block in homebrew formula - ([956c55b](https://github.com/PurpleBooth/git-moves-together/commit/956c55be76e94c0604362e7469222d2286ed499c)) - Billie Thompson (aider)
- update formula template to match whatismyip style - ([eaea71c](https://github.com/PurpleBooth/git-moves-together/commit/eaea71cc14d1afb52f474953610c17807e8a93ff)) - Billie Thompson (aider)

