### PR TITLE
fix: upgrade git-moves-together to 2.8.0

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -2,15 +2,8 @@ class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://codeberg.org/PurpleBooth/git-moves-together"
   url "https://codeberg.org/PurpleBooth/git-moves-together/archive/main.tar.gz"
-  version "2.7.0"
-  sha256 "018d70842ebc729036cc9b1aaba9769134e59d07460ec6ff9419d43f02c83cc6"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.7.0"
-    sha256 cellar: :any,                 arm64_sequoia: "c8d34ae141ffde3733e0aac7ba10e0e6a5f603e897a3e6b66839b92d49023e18"
-    sha256 cellar: :any,                 ventura:       "fb62ffeb708e15470a241fd02c884bc49c37f80ffd760e1b2c32d721221707c9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d2453366fa2cc8dce852863659e17754c4f4ec06a7db634f1d50792834311442"
-  end
+  version "2.8.0"
+  sha256 "15423fdc66f5d01ed91c51b2d5d1d0ebe744ff95f14270c6344da25b8b7fbb5b"
 
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v2.8.0](https://codeberg.org/PurpleBooth/git-moves-together/compare/ac1b9cc6521d47f4190a4edf841805b8364f5630..v2.8.0) - 2025-05-13
#### Bug Fixes
- **(deps)** update rust crate git2 to 0.20.0 - ([31e1861](https://codeberg.org/PurpleBooth/git-moves-together/commit/31e1861954670ddb77db72ad6733116b9821f8bf)) - Solace System Renovate Fox
- update rand imports and random string generation - ([608fb06](https://codeberg.org/PurpleBooth/git-moves-together/commit/608fb06a3ca7e79a10d7988b790256983a7528fd)) - Billie Thompson (aider)
- update rand crate imports and usage in contract_test.rs - ([d537ed5](https://codeberg.org/PurpleBooth/git-moves-together/commit/d537ed5abaa33124448368e9d36ebfb2376776f1)) - Billie Thompson (aider)
- resolve rand import and deprecation issues in contract_test.rs - ([f0bff0a](https://codeberg.org/PurpleBooth/git-moves-together/commit/f0bff0a842ef59dc1d488bc15daf87edda30388f)) - Billie Thompson (aider)
- remove shell expansion in Dockerfile COPY instructions - ([957b77a](https://codeberg.org/PurpleBooth/git-moves-together/commit/957b77ae7b9b4dcfac5cbd78c4ea148c39f42982)) - Billie Thompson (aider)
- update Dockerfiles for cross-compilation with xx-cargo - ([27bab15](https://codeberg.org/PurpleBooth/git-moves-together/commit/27bab150e1f80dab7b10aa77934ee7f521e8a4df)) - Billie Thompson
- install cargo-chef in builder stage for cross-compilation - ([08f4049](https://codeberg.org/PurpleBooth/git-moves-together/commit/08f40494dc026ca916a3994a36e40eacb893ac24)) - Billie Thompson (aider)
#### Features
- add platform-specific binary handling in Dockerfiles - ([c5ec669](https://codeberg.org/PurpleBooth/git-moves-together/commit/c5ec669d4dfa3f4a7dc0d16647729b9cac73ac78)) - Billie Thompson (aider)
- integrate cargo-chef for optimized Docker build caching - ([00ac223](https://codeberg.org/PurpleBooth/git-moves-together/commit/00ac223626b4a0baecb1f01336968eb83408b92f)) - Billie Thompson (aider)
#### Miscellaneous Chores
- **(deps)** update rust crate rand to 0.9.0 - ([14ed1d3](https://codeberg.org/PurpleBooth/git-moves-together/commit/14ed1d3d6cf62348dac3a8148af925befc16fbae)) - Solace System Renovate Fox
- **(version)** v2.8.0 [skip ci] - ([356940f](https://codeberg.org/PurpleBooth/git-moves-together/commit/356940f83451c84cb92977687af11e7ea5d7e204)) - PurpleBooth
- add nfpm.yaml to dockerignore - ([4ab2e35](https://codeberg.org/PurpleBooth/git-moves-together/commit/4ab2e35bf1c895c55513734b106d368fb6f7fc6a)) - Billie Thompson
- remove Dockerfile and update Cargo.lock dependencies - ([128c4e3](https://codeberg.org/PurpleBooth/git-moves-together/commit/128c4e33cedae9a91ae3f0179ff49d274f8b3f02)) - Billie Thompson
- update repository URLs from GitHub to Codeberg in README.md - ([6073182](https://codeberg.org/PurpleBooth/git-moves-together/commit/6073182b94e7ecacce03376c154edf4607f46c6a)) - Billie Thompson (aider)
- Update nfpm.yaml description to reflect actual functionality - ([ac1b9cc](https://codeberg.org/PurpleBooth/git-moves-together/commit/ac1b9cc6521d47f4190a4edf841805b8364f5630)) - Billie Thompson (aider)
#### Refactoring
- update random generation method in git_add_file function - ([d6c8b18](https://codeberg.org/PurpleBooth/git-moves-together/commit/d6c8b18c46f65ce05a468f3325a49510745ae010)) - Billie Thompson

