### PR TITLE
fix: upgrade whatismyip to 0.14.2

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -2,15 +2,8 @@ class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
   url "https://codeberg.org/PurpleBooth/whatismyip/archive/main.tar.gz"
-  version "0.13.12"
-  sha256 "402c0f5fd5fb278e133f1f779c8125b22f7bead25e5a17d04fe63c2144ef0fdd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.13.12"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6482d768f1d40f94aa35e485aa6ded8a243cc3d629b17525758431e67f12cb1a"
-    sha256 cellar: :any_skip_relocation, ventura:       "f4d9a05f1d71725123316e87552092f36e0e84812dc42841ab79fbf4b3f43108"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "16275d984b4611b06d73f6f0e85f26bc823f2ea7546fe322e1349a055f05fa57"
-  end
+  version "0.14.2"
+  sha256 "5574955200951ccea1d0119548c135f8c6dbb06b22b1d47d2f657edcba024490"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.14.2 - 2025-05-16
#### Bug Fixes
- add sudo to chmod command in GitHub CLI installation script - (970644e) - Billie Thompson
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 212c367 - (7ce234a) - Solace System Renovate Fox
- **(version)** v0.14.2 [skip ci] - (0d61659) - PurpleBooth
- update Renovate config to use specific config preset - (b51e0c0) - Billie Thompson

