### PR TITLE
fix: upgrade readable-name-generator to 4.1.62

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.61"
-  sha256 "f42bb5f4f8db8d76d4437de09e790aa87c575e5dc21ace174b554182713f4c77"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.61"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "864a963267a762b622f2dce825888bc13c6193d3dc6ededf403eebd29186b1df"
-    sha256 cellar: :any_skip_relocation, ventura:       "46775e4247c97e38faada3cee8b7437e1ba023ea340478377ac604078fbb2284"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f7432241a199f54b41617d8f3e492c91fb5c40ecca2b27e8240ec55e0a3f8b66"
-  end
+  version "4.1.62"
+  sha256 "f879dc66737723e45a6613ac1586480d5a3bd55f540597dd21a6d4d78a854592"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.62](https://codeberg.org/PurpleBooth/readable-name-generator/compare/0ba05b48b044f5ce6a44e4dc833076b0db6dedbe..v4.1.62) - 2025-05-16
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to fa7c285 - ([a2bbdac](https://codeberg.org/PurpleBooth/readable-name-generator/commit/a2bbdac8521eb2e50215b6b212214a2c87e80501)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 212c367 - ([0ba05b4](https://codeberg.org/PurpleBooth/readable-name-generator/commit/0ba05b48b044f5ce6a44e4dc833076b0db6dedbe)) - Solace System Renovate Fox
- **(version)** v4.1.62 [skip ci] - ([f535aa9](https://codeberg.org/PurpleBooth/readable-name-generator/commit/f535aa910cf34826833114efe3914b77c12f748c)) - SolaceRenovateFox
- update Renovate config to use app-specific preset - ([b65d101](https://codeberg.org/PurpleBooth/readable-name-generator/commit/b65d1012d94d7cc6ca9b00003f91b4ebeef7e6f6)) - Billie Thompson

