### PR TITLE
fix: upgrade readable-name-generator to 4.1.63

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.62"
-  sha256 "f879dc66737723e45a6613ac1586480d5a3bd55f540597dd21a6d4d78a854592"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.62"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "01f8a0891fb1fe98920bc9ab47906572481c37c356a3d9b7a150d5b25d1f454b"
-    sha256 cellar: :any_skip_relocation, ventura:       "fe6001ae3739e8bbd34a0e796f5e5242620bdf6c5c66fccd3ef2e124c46b8152"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3427d3a8154b4d72e6d4974cb09b1599afd63988d135428cbd78d9b16d205228"
-  end
+  version "4.1.63"
+  sha256 "cba49768a0c392ed577b73b7e52671730996e91cbfc28e5b5a125beedcff8f70"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.63](https://codeberg.org/PurpleBooth/readable-name-generator/compare/bde8bc33b5eb3ee37b92156ae7de21c49edd93f5..v4.1.63) - 2025-05-21
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to 10f7efb - ([bde8bc3](https://codeberg.org/PurpleBooth/readable-name-generator/commit/bde8bc33b5eb3ee37b92156ae7de21c49edd93f5)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.63 [skip ci] - ([c6f1b82](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c6f1b82166caf204d47fe85abd3e85e937ec0091)) - SolaceRenovateFox

