### PR TITLE
fix: upgrade fast-conventional to 2.3.113

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.112"
-  sha256 "5b1b005934e83e5bd384c5b70d3697420b1fe74d4a1e1594964c25fdb4338b81"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.112"
-    sha256 cellar: :any,                 ventura:      "93690adb189f1885900f43f49fc11ad2e3756839eaa3978a70530035fc0670b8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "45d0f712fcbd82f3287970dd88435d95c91c5a1318be4c3274a8dd8fc36e6284"
-  end
+  version "2.3.113"
+  sha256 "c22bf352316955e7d6fed7cbe367ca4671d554f7a570cb1bf222ff79b29bc433"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.113](https://codeberg.org/PurpleBooth/git-mit/compare/b39fea7288a258328475787ee6c026a9b799b389..v2.3.113) - 2025-05-21
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to 10f7efb - ([499c395](https://codeberg.org/PurpleBooth/git-mit/commit/499c3954faa57074e9634ad17c3adfae48c9e5a1)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update rust:alpine docker digest to fa7c285 - ([0a71ccd](https://codeberg.org/PurpleBooth/git-mit/commit/0a71ccd0df468334400c74ceae172206aadb846d)) - Solace System Renovate Fox
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 212c367 - ([079863b](https://codeberg.org/PurpleBooth/git-mit/commit/079863be58da9fca7fb9b1dee8fc7681a229e224)) - Solace System Renovate Fox
- **(deps)** update rust crate tempfile to v3.20.0 - ([b39fea7](https://codeberg.org/PurpleBooth/git-mit/commit/b39fea7288a258328475787ee6c026a9b799b389)) - Solace System Renovate Fox
- **(version)** v2.3.113 [skip ci] - ([f520175](https://codeberg.org/PurpleBooth/git-mit/commit/f5201753407fdc822ad74867c6e9aef8fe6ecb16)) - SolaceRenovateFox

