### PR TITLE
fix: Update git-mit to v6.0.1

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.14.2.tar.gz"
-  sha256 "19bea4f9d83c5b31d8db0eb9208437b668270b9459897614c32310a7d66ed99c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.14.2"
-    sha256 cellar: :any,                 arm64_sequoia: "434507e516dd442be558af0221cbdd1481436c84638f2d84af8f23d6039b351d"
-    sha256 cellar: :any,                 ventura:       "19cf1a39122c8bfe8fdff327a1187a1066cda7edb69d1f1b527d38bd4b5cec41"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e73998422ebbdbdb4f4bc1441ec7c3cb43779b88d4df81591fcc6b4ae6e2ae39"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.0.1.tar.gz"
+  sha256 "483fe20fb5684195a57d3beac4bbe858c306321be955f8959d1771330f2e7b2d"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v6.0.1](https://github.com/PurpleBooth/git-mit/compare/...v6.0.1) (2025-05-26)

### Deps

#### Fix

- Update rust crate tokio to v1.45.1 (#1580) ([`b57e8e4`](https://github.com/PurpleBooth/git-mit/commit/b57e8e4c4e1d2ccbc3a2956d5e1c627f6584f333))


### Version

#### Chore

- V6.0.1 ([`8f3e3a4`](https://github.com/PurpleBooth/git-mit/commit/8f3e3a48ce4895eb6a0a76f152ac4524a9ac2053))


