### PR TITLE
fix: upgrade fast-conventional to 2.3.114

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.113"
-  sha256 "c22bf352316955e7d6fed7cbe367ca4671d554f7a570cb1bf222ff79b29bc433"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.113"
-    sha256 cellar: :any,                 ventura:      "012368e3c72626a473b667b627d6af4817703cebf430844349e8c280b48fce00"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "427be4791d98a7cdbba0bb18da2505b7b3c25ac456512e0dc188c74ba97dcd3e"
-  end
+  version "2.3.114"
+  sha256 "aa0e22eb9aa2fe2d2c89b95ce27c4ed6e361dba1514e7364adc8fe5ff2470c87"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.114](https://codeberg.org/PurpleBooth/git-mit/compare/ad559b981cd340c19c1d55cc76e51b19fae1fcb6..v2.3.114) - 2025-05-26
#### Bug Fixes
- **(deps)** update rust crate mit-commit to v3.2.3 - ([ad559b9](https://codeberg.org/PurpleBooth/git-mit/commit/ad559b981cd340c19c1d55cc76e51b19fae1fcb6)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.114 [skip ci] - ([cfbf806](https://codeberg.org/PurpleBooth/git-mit/commit/cfbf8062b68cc06096587315bc7f8422feeafde0)) - SolaceRenovateFox

