### PR TITLE
fix: upgrade fast-conventional to 2.3.115

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.114"
-  sha256 "aa0e22eb9aa2fe2d2c89b95ce27c4ed6e361dba1514e7364adc8fe5ff2470c87"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.114"
-    sha256 cellar: :any,                 ventura:      "cb63780745132fa47d4bf5f3f5dcf0d8ca62fa0df823a7ca1063adb5acc087cf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6d3d16f1dc798000b69f9e00abbaf8208eb3e50d8b0acef7ae434124618917fc"
-  end
+  version "2.3.115"
+  sha256 "eab107c362e4baabe82fd0a331332c6e067abe8dbcfd1ec07b3173113c3e8df6"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.115](https://codeberg.org/PurpleBooth/git-mit/compare/3a86701b277fab2ec73afcb21fd989cb4a4b068b..v2.3.115) - 2025-05-27
#### Bug Fixes
- **(deps)** update rust crate mit-commit to v3.3.0 - ([3a86701](https://codeberg.org/PurpleBooth/git-mit/commit/3a86701b277fab2ec73afcb21fd989cb4a4b068b)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.115 [skip ci] - ([7f8e527](https://codeberg.org/PurpleBooth/git-mit/commit/7f8e5278e5c759224bf1f19b9cda51d7ae7a6f18)) - SolaceRenovateFox

