### PR TITLE
fix: upgrade readable-name-generator to 4.1.65

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.63"
-  sha256 "cba49768a0c392ed577b73b7e52671730996e91cbfc28e5b5a125beedcff8f70"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.63"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f64276b9ae522d06d9eaf38d508a5922cecb760f4ef99eadf48aaaa55154cde4"
-    sha256 cellar: :any_skip_relocation, ventura:       "2f2aa8e7756786244f5306ee850ccd2c9457126c99aeae77035724a102a06354"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2a79bda9e21cbdfcb734737068f92c5d7f183d0e153e2d9247aaf61d812274cd"
-  end
+  version "4.1.65"
+  sha256 "e356401b7bbe3c9e632daca4b09e4f760d3ecdf20b01c9aebd133ea0cd36d73c"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.65](https://codeberg.org/PurpleBooth/readable-name-generator/compare/2600ab3a20276f6e5820195925814ec80e98baf3..v4.1.65) - 2025-05-27
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.39 - ([2600ab3](https://codeberg.org/PurpleBooth/readable-name-generator/commit/2600ab3a20276f6e5820195925814ec80e98baf3)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.65 [skip ci] - ([217b15d](https://codeberg.org/PurpleBooth/readable-name-generator/commit/217b15deb88ccad01d5c77ca4a3aa7c0a11f4bc1)) - SolaceRenovateFox

