### PR TITLE
fix: upgrade fast-conventional to 2.3.117

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.116"
-  sha256 "e7531098b1de243c8d67d8dc5855514c98a9a7ae809a33744e2eee3adcfb18d4"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.116"
-    sha256 cellar: :any,                 ventura:      "f35a15c4e2a9242f7f7fda671255cd3370942b254e150c577562986ebe66f5cf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "60c0c3ae0454da6b7680382e9ba244cb476a3865178e5b3b0e37a08ec99ca4e0"
-  end
+  version "2.3.117"
+  sha256 "747af42af9557643b72284da0556b415992d0206e82400ee3d83171236918b98"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.117](https://codeberg.org/PurpleBooth/git-mit/compare/80e3619839d07b7b609ad1e8061fc7f2558562bd..v2.3.117) - 2025-05-30
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.52 - ([ae548bd](https://codeberg.org/PurpleBooth/git-mit/commit/ae548bd5e74c77451ae0797975a9d349cab46dc4)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 37816e7 - ([80e3619](https://codeberg.org/PurpleBooth/git-mit/commit/80e3619839d07b7b609ad1e8061fc7f2558562bd)) - Solace System Renovate Fox
- **(version)** v2.3.117 [skip ci] - ([9e6b462](https://codeberg.org/PurpleBooth/git-mit/commit/9e6b462e7e49f989bede4d1c3d6f9e682e195eed)) - SolaceRenovateFox

