### PR TITLE
fix: upgrade readable-name-generator to 4.1.66

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.65"
-  sha256 "e356401b7bbe3c9e632daca4b09e4f760d3ecdf20b01c9aebd133ea0cd36d73c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.65"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d87453779a9258f8760a81570eb2890f4424c216054a1e0e65cf2bd4d3e30f7f"
-    sha256 cellar: :any_skip_relocation, ventura:       "2cc68776fb3f0d727cff79822557fbad3394411e10e520e475e279a40756ee4e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d86f5abf7b9fa0fee14d682fc39daead11486e6fdbcb124e590567360edb4ef0"
-  end
+  version "4.1.66"
+  sha256 "1cffb84c3a17c09e76cec7d2a3c122d1fd9dd7fb50ce27c86be3238db5780681"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.66](https://codeberg.org/PurpleBooth/readable-name-generator/compare/5b50d3d16443ef52557a2952f3244d3e423c3ddf..v4.1.66) - 2025-05-30
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.52 - ([d16d6e1](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d16d6e12317c88de337e6941d51b56a8a6b1e210)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 37816e7 - ([5b50d3d](https://codeberg.org/PurpleBooth/readable-name-generator/commit/5b50d3d16443ef52557a2952f3244d3e423c3ddf)) - Solace System Renovate Fox
- **(version)** v4.1.66 [skip ci] - ([d14c631](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d14c631246dc5c4eb149aeeab64d1e081a322c2d)) - SolaceRenovateFox

