### PR TITLE
fix: upgrade readable-name-generator to 4.1.67

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.66"
-  sha256 "1cffb84c3a17c09e76cec7d2a3c122d1fd9dd7fb50ce27c86be3238db5780681"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.66"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "110385a9943f8dfc5b57e1916de7cbd08f80869aaa7d0fb6369dc7861a9661ba"
-    sha256 cellar: :any_skip_relocation, ventura:       "0573c1d26cb3dd4bdeeed48f288b5487edcfe9fb582f3f2f495b13590d3a6e9b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "659ce33198a32ff38d2430f8eaf688331ad167184d67ecdd4df7884287317700"
-  end
+  version "4.1.67"
+  sha256 "7a1de8041ddfcf37e63d6b004c2bdb17d9cebc3a07b38df1bde8892b9e08722e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.67](https://codeberg.org/PurpleBooth/readable-name-generator/compare/0f62b0c8cb983f9efaf08da384d718e2d0318a1c..v4.1.67) - 2025-05-31
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 126df0f - ([0f62b0c](https://codeberg.org/PurpleBooth/readable-name-generator/commit/0f62b0c8cb983f9efaf08da384d718e2d0318a1c)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.67 [skip ci] - ([507c5ab](https://codeberg.org/PurpleBooth/readable-name-generator/commit/507c5ab8d62516c62dba57f0358c587a327e78a5)) - SolaceRenovateFox

