### PR TITLE
fix: upgrade readable-name-generator to 4.1.68

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.67"
-  sha256 "7a1de8041ddfcf37e63d6b004c2bdb17d9cebc3a07b38df1bde8892b9e08722e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.67"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "08a8616e469888375898f062fd1351f048cf84d7e3b5b31483d8c6cdacc487c6"
-    sha256 cellar: :any_skip_relocation, ventura:       "bb0206fe7611a19bc51936156978ea9596dc8be1a9199981f5aff8b667622b8d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2d7daedb53b3bc6d65eef29e1b8c179f10a506559847fe32790e26845129e074"
-  end
+  version "4.1.68"
+  sha256 "34f664490fb17232809d4a2731341421b9107e94c34cbbde6b9bbae748a6b541"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.68](https://codeberg.org/PurpleBooth/readable-name-generator/compare/dde663783d95efef4023af0806442a42071a5044..v4.1.68) - 2025-06-07
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to 929e105 - ([dde6637](https://codeberg.org/PurpleBooth/readable-name-generator/commit/dde663783d95efef4023af0806442a42071a5044)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.68 [skip ci] - ([a223e27](https://codeberg.org/PurpleBooth/readable-name-generator/commit/a223e275f99dcb5d73f72626abb6b0abdc1bc1e3)) - SolaceRenovateFox

