### PR TITLE
fix: upgrade readable-name-generator to 4.1.69

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.68"
-  sha256 "34f664490fb17232809d4a2731341421b9107e94c34cbbde6b9bbae748a6b541"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.68"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a9f7a137d8197d1cd5585e40aed8a53dd06778e6ea555ca52f0cf67d1ef64ad7"
-    sha256 cellar: :any_skip_relocation, ventura:       "01b6bbb0230c2efdf2cc85722f1135b85dc613def92a69acf60d7c47ae55bd2b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "35e97811063a295f168480baef1f03a1a2e9c540bf085b7f57ddc588cd7af93b"
-  end
+  version "4.1.69"
+  sha256 "007fcaad93bc855f38bb41fac7100e7d5c28cb7e0604936cdcbe270759fd1395"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.69](https://codeberg.org/PurpleBooth/readable-name-generator/compare/34dc969cfa76b9fcad54fd0fc1dc0d74fb5f645b..v4.1.69) - 2025-06-09
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.53 - ([7b37396](https://codeberg.org/PurpleBooth/readable-name-generator/commit/7b37396069d751880d692cf9a0cd1d0f83068dc5)) - Solace System Renovate Fox
- **(deps)** update rust crate clap to v4.5.40 - ([34dc969](https://codeberg.org/PurpleBooth/readable-name-generator/commit/34dc969cfa76b9fcad54fd0fc1dc0d74fb5f645b)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.69 [skip ci] - ([cc6d63e](https://codeberg.org/PurpleBooth/readable-name-generator/commit/cc6d63e0098f7aead58b94c34113ec40740fd8f3)) - SolaceRenovateFox

