### PR TITLE
fix: upgrade fast-conventional to 2.3.118

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -2,14 +2,8 @@ class FastConventional < Formula
   desc "Make conventional commits, faster, and consistently name scopes"
   homepage "https://codeberg.org/PurpleBooth/fast-conventional"
   url "https://codeberg.org/PurpleBooth/fast-conventional/archive/main.tar.gz"
-  version "2.3.117"
-  sha256 "747af42af9557643b72284da0556b415992d0206e82400ee3d83171236918b98"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/fast-conventional-2.3.117"
-    sha256 cellar: :any,                 ventura:      "a1a3434b1774f3508dd18969c1b0d1671367b867932f6ea182e5226bd5a841a6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c9de396a0527bdcb12d3d424f3e04f4955908578d3db7c347c89af8abe8f4d9a"
-  end
+  version "2.3.118"
+  sha256 "9c3bbb186ec7debf674081a0b174aa06ad92cc57d913b04f30fe57b6b1fd5071"
 
   depends_on "help2man" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
## [v2.3.118](https://codeberg.org/PurpleBooth/git-mit/compare/d9cd5b919906c9699fd68175ccd79f5937a94a8a..v2.3.118) - 2025-06-10
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.54 - ([8a85efa](https://codeberg.org/PurpleBooth/git-mit/commit/8a85efae7b5ee9fc6ea8070294748f909f2f387a)) - Solace System Renovate Fox
- **(deps)** update rust crate clap_complete to v4.5.53 - ([9bcda46](https://codeberg.org/PurpleBooth/git-mit/commit/9bcda468f36872710edf013e7e3e71f070587340)) - Solace System Renovate Fox
- **(deps)** update rust crate clap to v4.5.40 - ([1c4e651](https://codeberg.org/PurpleBooth/git-mit/commit/1c4e6515775148c9c456d7d7b275de740659ef7d)) - Solace System Renovate Fox
- **(deps)** update goreleaser/nfpm docker digest to 929e105 - ([6f0956e](https://codeberg.org/PurpleBooth/git-mit/commit/6f0956e1a312ff32643383584a63b84b4c8ff703)) - Solace System Renovate Fox
- **(deps)** update rust:alpine docker digest to 126df0f - ([d9cd5b9](https://codeberg.org/PurpleBooth/git-mit/commit/d9cd5b919906c9699fd68175ccd79f5937a94a8a)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v2.3.118 [skip ci] - ([7ed2560](https://codeberg.org/PurpleBooth/git-mit/commit/7ed256002fbb97962bf6a4e02669f829032baf7b)) - SolaceRenovateFox
#### Refactoring
- enhance linting and code clarity - ([c78f42d](https://codeberg.org/PurpleBooth/git-mit/commit/c78f42d9f190d5c24fa09ad35f82f4787b182fe9)) - Billie Thompson

