### PR TITLE
fix: upgrade readable-name-generator to 4.1.70

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.69"
-  sha256 "007fcaad93bc855f38bb41fac7100e7d5c28cb7e0604936cdcbe270759fd1395"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.69"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "62a02b5d8a409e48bc250c850e9d9de63c617adb5956e0b936686ac2a48789bf"
-    sha256 cellar: :any_skip_relocation, ventura:       "0136f46d2790e5f0b43b41b9c2d35964b53d677ed1d2e9f38cadce96e6c74cc0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "73eb5cfbadde73f8edcb24342eec0068c1eaec2a798b203d93b66094d3c804df"
-  end
+  version "4.1.70"
+  sha256 "e0fce909130987b2b324b7ff3298cc1a3221895aee13f1260acb25ef3e29a59b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.70](https://codeberg.org/PurpleBooth/readable-name-generator/compare/1e4fe15abf9f625dfba59a6474adf02ca0b29573..v4.1.70) - 2025-06-10
#### Bug Fixes
- **(deps)** update rust crate clap_complete to v4.5.54 - ([1e4fe15](https://codeberg.org/PurpleBooth/readable-name-generator/commit/1e4fe15abf9f625dfba59a6474adf02ca0b29573)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.1.70 [skip ci] - ([9c031e0](https://codeberg.org/PurpleBooth/readable-name-generator/commit/9c031e02974349264d976af667c867bb812dec7c)) - SolaceRenovateFox

