### PR TITLE
fix: upgrade whatismyip to 0.14.3

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -2,15 +2,8 @@ class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
   url "https://codeberg.org/PurpleBooth/whatismyip/archive/main.tar.gz"
-  version "0.14.2"
-  sha256 "5574955200951ccea1d0119548c135f8c6dbb06b22b1d47d2f657edcba024490"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.14.2"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "70a39fe62f9a5a9f93a7dc7bda22af11ee893929c18b3728a4fd213396dbf693"
-    sha256 cellar: :any_skip_relocation, ventura:       "218e120c6702fbe837909575e4b8acf2be68367ef055a57a44c4ab7fe2ca0c30"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9e7163cc6a8a1cd0ae85e46ebfe1445e857b94317d97885f85bebf488743ca68"
-  end
+  version "0.14.3"
+  sha256 "774cee1b8017e537e19e943a7a6f41884902ba6104e701a67a00cb6ca71c9241"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.14.3 - 2025-06-13
#### Bug Fixes
- **(deps)** update rust crate tokio to v1.45.1 - (6ce91e3) - Solace System Renovate Fox
- **(deps)** update rust crate clap to v4.5.40 - (daadf19) - Solace System Renovate Fox
- **(deps)** update rust:alpine docker digest to 126df0f - (fbc2535) - Solace System Renovate Fox
- **(deps)** update goreleaser/nfpm docker digest to 929e105 - (f19e675) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 37816e7 - (23417ca) - Solace System Renovate Fox
- **(deps)** update rust crate criterion to v0.6.0 - (8ca8552) - Solace System Renovate Fox
- **(version)** v0.14.3 [skip ci] - (3782caf) - SolaceRenovateFox

