### PR TITLE
fix: Update git-mit to v6.0.3

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.14.2.tar.gz"
-  sha256 "19bea4f9d83c5b31d8db0eb9208437b668270b9459897614c32310a7d66ed99c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.14.2"
-    sha256 cellar: :any,                 arm64_sequoia: "434507e516dd442be558af0221cbdd1481436c84638f2d84af8f23d6039b351d"
-    sha256 cellar: :any,                 ventura:       "19cf1a39122c8bfe8fdff327a1187a1066cda7edb69d1f1b527d38bd4b5cec41"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e73998422ebbdbdb4f4bc1441ec7c3cb43779b88d4df81591fcc6b4ae6e2ae39"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.0.3.tar.gz"
+  sha256 "30f1f84332393b6e448bbfcb67115954cfa62d7ec3b8144e6a89fa7cd75efefd"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v6.0.3](https://github.com/PurpleBooth/git-mit/compare/...v6.0.3) (2025-06-17)

### Deps

#### Chore

- Update actions/attest-build-provenance digest to e8998f9 ([`23ba3b3`](https://github.com/PurpleBooth/git-mit/commit/23ba3b3c2bdce86f261ee8760f8441e9fc99e248))

#### Fix

- Update rust crate toml to v0.8.23 ([`fd723e5`](https://github.com/PurpleBooth/git-mit/commit/fd723e5385e31225bb38b476a69fb8099717bf46))
- Update rust crate which to v8 ([`5fbfc5e`](https://github.com/PurpleBooth/git-mit/commit/5fbfc5ef7008d331fcb5cecf2f1d882ff5989b84))
- Update rust crate openssl to v0.10.73 ([`759fd92`](https://github.com/PurpleBooth/git-mit/commit/759fd9250ac7190bb590653fcba6e6408cbc25ce))
- Update rust crate clap_complete to v4.5.54 ([`a263964`](https://github.com/PurpleBooth/git-mit/commit/a263964a1cebdc601def688c4f802530a0bed5f5))
- Update docker/dockerfile docker tag to v1.16 ([`0dd9402`](https://github.com/PurpleBooth/git-mit/commit/0dd9402d502695604ea42c7d65b8ada59386497c))
- Update rust docker tag to v1.87.0 ([`c0ef4c6`](https://github.com/PurpleBooth/git-mit/commit/c0ef4c68287f35fd44973307b73bd0fe1f0f451d))


### Version

#### Chore

- V6.0.3 ([`6caa79f`](https://github.com/PurpleBooth/git-mit/commit/6caa79f334e2e3ae0ac5806d5cfac6c427aca47a))


