### PR TITLE
fix: Update git-mit to v6.0.5

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,15 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v5.14.2.tar.gz"
-  sha256 "19bea4f9d83c5b31d8db0eb9208437b668270b9459897614c32310a7d66ed99c"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-5.14.2"
-    sha256 cellar: :any,                 arm64_sequoia: "434507e516dd442be558af0221cbdd1481436c84638f2d84af8f23d6039b351d"
-    sha256 cellar: :any,                 ventura:       "19cf1a39122c8bfe8fdff327a1187a1066cda7edb69d1f1b527d38bd4b5cec41"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e73998422ebbdbdb4f4bc1441ec7c3cb43779b88d4df81591fcc6b4ae6e2ae39"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.0.5.tar.gz"
+  sha256 "7ca19b224a8e2dd37b26066fc6a23aaf67b64a14a8f68cc4275f5e3acc01d3ff"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## Changelog
### [v6.0.5](https://github.com/PurpleBooth/git-mit/compare/...v6.0.5) (2025-06-17)

### Deps

#### Fix

- Update docker/dockerfile docker tag to v1.17 ([`3533c78`](https://github.com/PurpleBooth/git-mit/commit/3533c78c4c50547355e63de9fef01341096612e4))


### Version

#### Chore

- V6.0.5 ([`1a6149a`](https://github.com/PurpleBooth/git-mit/commit/1a6149adba1d63b4c1a022914371a4a9c5341102))


