### PR TITLE
fix: upgrade git-moves-together to 2.8.2

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -2,15 +2,8 @@ class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://codeberg.org/PurpleBooth/git-moves-together"
   url "https://codeberg.org/PurpleBooth/git-moves-together/archive/main.tar.gz"
-  version "2.8.1"
-  sha256 "5090f9dc84ba08dc6840ccdc771780dc0c6ec1012772e1d554aea372495deb32"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.8.1"
-    sha256 cellar: :any,                 arm64_sequoia: "02d61179de0165b787dbbc1638555f6a6ac5d07d7873f4d6c3683028fe769343"
-    sha256 cellar: :any,                 ventura:       "711476e522e2bc7156e9693a62c54434e0857af4dc89a9aa3f9bbfb673a0618e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "afcb2a9f3c20aad12799b1333c4ac0de9c1372ae6c764fc869006fd898edcaf5"
-  end
+  version "2.8.2"
+  sha256 "cc9a62a866e7c0f42208d09c863158a791bf1d28668fd82136ffdb4d810dd1b3"
 
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v2.8.2](https://codeberg.org/PurpleBooth/git-moves-together/compare/de1129986116662bf19d390c8d83a4406a364937..v2.8.2) - 2025-06-19
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to 929e105 - ([e89d55c](https://codeberg.org/PurpleBooth/git-moves-together/commit/e89d55cd0ada38eaefcc265168237b3a3d49f638)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/setup-buildx-action digest to e468171 - ([de11299](https://codeberg.org/PurpleBooth/git-moves-together/commit/de1129986116662bf19d390c8d83a4406a364937)) - Solace System Renovate Fox
- **(version)** v2.8.2 [skip ci] - ([a0da80a](https://codeberg.org/PurpleBooth/git-moves-together/commit/a0da80afb593bd8fa86877d62e22060fd5e5f78f)) - PurpleBooth

