### PR TITLE
fix: upgrade readable-name-generator to 4.1.71

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.70"
-  sha256 "e0fce909130987b2b324b7ff3298cc1a3221895aee13f1260acb25ef3e29a59b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.70"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9d95f7fbab9f39e955a7ca9daf5b0c34058f52ae96a06976a066ace7292d79f1"
-    sha256 cellar: :any_skip_relocation, ventura:       "ffd2d7cffed15dcd1d841717397c182558733611be8168b7ba4ecb8d33efe1ae"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "53ec886eba8b09dc0554bfea05affdf5cca23951233cc417b0bd709d706660a6"
-  end
+  version "4.1.71"
+  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.1.71](https://codeberg.org/PurpleBooth/readable-name-generator/compare/228201d2be4af8ab94628ebd4fcfe436ce3c03fe..v4.1.71) - 2025-06-27
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to ec0413a - ([d6107d7](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d6107d7ae5d78d2171eb715f5e3eb585c4636506)) - Solace System Renovate Fox
#### Continuous Integration
- run less often - ([1302f62](https://codeberg.org/PurpleBooth/readable-name-generator/commit/1302f62b60600394c9519d14b20ead6a084ae08c)) - PurpleBooth
- set a lower retension - ([d5cd242](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d5cd2424225a710c4225394fd5afcf4915e48bdc)) - PurpleBooth
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/setup-buildx-action digest to e468171 - ([93d7935](https://codeberg.org/PurpleBooth/readable-name-generator/commit/93d79352c3c60324a6c99b94caf46087de2e34ae)) - Solace System Renovate Fox
- **(deps)** update https://code.forgejo.org/docker/setup-buildx-action digest to 18ce135 - ([228201d](https://codeberg.org/PurpleBooth/readable-name-generator/commit/228201d2be4af8ab94628ebd4fcfe436ce3c03fe)) - Solace System Renovate Fox
- **(version)** v4.1.71 [skip ci] - ([05b248c](https://codeberg.org/PurpleBooth/readable-name-generator/commit/05b248c7472e02dc9e27b86223e9a09eb01bfafc)) - SolaceRenovateFox

