### PR TITLE
fix: upgrade whatismyip to 0.14.5

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -2,15 +2,8 @@ class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
   url "https://codeberg.org/PurpleBooth/whatismyip/archive/main.tar.gz"
-  version "0.14.4"
-  sha256 "a724366db3bc49267a332010423390aa20f87097b0449fee3dd376317bf5f76b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.14.4"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8eab2fbf1de23da0103e47a22f2cec316e0a62b8d65be9d972c4dcab6dcec6e8"
-    sha256 cellar: :any_skip_relocation, ventura:       "53b67b1e0b4b4f9a45a9c61f94ce1feca793c9f1684fce8795b097f503c26158"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "567b36f3990055fd052af74ab326a414ecfdc87cb03369acf2d30a8b02ca3b79"
-  end
+  version "0.14.5"
+  sha256 "a0642d63e76558cd3b37cd3b9a73d282a4f6209607884d9f7fdf109dcd625298"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.14.5 - 2025-07-08
#### Bug Fixes
- **(deps)** update rust crate tokio to v1.46.1 - (e28f3ce) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v0.14.5 [skip ci] - (2748670) - PurpleBooth
- update dockerignore and dockerfile, remove build.rs - (a7c3d61) - Billie Thompson

