### PR TITLE
fix: upgrade whatismyip to 0.14.6

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -2,15 +2,8 @@ class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
   url "https://codeberg.org/PurpleBooth/whatismyip/archive/main.tar.gz"
-  version "0.14.4"
-  sha256 "a724366db3bc49267a332010423390aa20f87097b0449fee3dd376317bf5f76b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.14.4"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8eab2fbf1de23da0103e47a22f2cec316e0a62b8d65be9d972c4dcab6dcec6e8"
-    sha256 cellar: :any_skip_relocation, ventura:       "53b67b1e0b4b4f9a45a9c61f94ce1feca793c9f1684fce8795b097f503c26158"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "567b36f3990055fd052af74ab326a414ecfdc87cb03369acf2d30a8b02ca3b79"
-  end
+  version "0.14.6"
+  sha256 "c9b31a07f204eff8dae9d3fcf20689b633e33c0503ae8db5a9d44f61fe7a4342"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.14.6 - 2025-07-10
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.41 - (ca3524e) - Solace System Renovate Fox
#### Build system
- update Dockerfile and build configuration for cross-platform support - (8b2a707) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v0.14.6 [skip ci] - (47a338b) - PurpleBooth
- remove Dockerfile.bins and Dockerfile.container - (cf82233) - Billie Thompson
#### Refactoring
- optimize Dockerfile cross-compilation platform handling - (4fe0ef3) - Billie Thompson
- Optimize Dockerfile with multi-stage build and cargo-chef - (377822e) - Billie Thompson

