### PR TITLE
fix: upgrade readable-name-generator to 4.2.0

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  version "4.2.0"
+  sha256 "5deb2b06ebb95655bd09661e94ccb0413666b8925c632743472d170163bf4b10"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.2.0](https://codeberg.org/PurpleBooth/readable-name-generator/compare/1a734afaaa76035fd2836f2e8586c2ab9a365299..v4.2.0) - 2025-07-10
#### Bug Fixes
- **(deps)** update rust crate anarchist-readable-name-generator-lib to 0.2.0 - ([3aa7040](https://codeberg.org/PurpleBooth/readable-name-generator/commit/3aa7040361c983ef3c97e9acc30d8b437e2e65c2)) - Solace System Renovate Fox
#### Features
- add suffix option to generate names with random number - ([f1283fc](https://codeberg.org/PurpleBooth/readable-name-generator/commit/f1283fc42e555f42177921cad6844d42baf81c03)) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v4.2.0 [skip ci] - ([7725e9a](https://codeberg.org/PurpleBooth/readable-name-generator/commit/7725e9a8d7ebc217c8156ecaca3699fcccda2cfe)) - PurpleBooth
#### Refactoring
- consolidate Dockerfiles and update build configuration - ([1a734af](https://codeberg.org/PurpleBooth/readable-name-generator/commit/1a734afaaa76035fd2836f2e8586c2ab9a365299)) - Billie Thompson

