### PR TITLE
fix: upgrade readable-name-generator to 4.2.2

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -2,15 +2,8 @@ class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
   url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  version "4.2.2"
+  sha256 "3ecab226ca216d5909e20a9413ab39521a74ec99a7a8ecc53432a9d62e499c3a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.2.2](https://codeberg.org/PurpleBooth/readable-name-generator/compare/9106874de69ad740272c185380a6eeba4f03f59e..v4.2.2) - 2025-07-21
#### Bug Fixes
- **(deps)** update rust:alpine docker digest to 6398523 - ([9106874](https://codeberg.org/PurpleBooth/readable-name-generator/commit/9106874de69ad740272c185380a6eeba4f03f59e)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.2.2 [skip ci] - ([92f6e7a](https://codeberg.org/PurpleBooth/readable-name-generator/commit/92f6e7a8e2f29df626a133e564978b47518df3c3)) - SolaceRenovateFox

