### PR TITLE
fix: upgrade whatismyip to 0.15.0

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,16 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/main.tar.gz"
-  version "0.14.4"
-  sha256 "a724366db3bc49267a332010423390aa20f87097b0449fee3dd376317bf5f76b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.14.4"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8eab2fbf1de23da0103e47a22f2cec316e0a62b8d65be9d972c4dcab6dcec6e8"
-    sha256 cellar: :any_skip_relocation, ventura:       "53b67b1e0b4b4f9a45a9c61f94ce1feca793c9f1684fce8795b097f503c26158"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "567b36f3990055fd052af74ab326a414ecfdc87cb03369acf2d30a8b02ca3b79"
-  end
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.14.6.tar.gz"
+  sha256 "c9b31a07f204eff8dae9d3fcf20689b633e33c0503ae8db5a9d44f61fe7a4342"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.0 - 2025-07-24
#### Bug Fixes
- **(deps)** pin dependencies - (86c1e5d) - Solace System Renovate Fox
- **(deps)** pin dependencies - (11942ec) - Solace System Renovate Fox
- Ersetze wlinuxbrewget durch wget in Dockerfile - (315d6e2) - Billie Thompson
- Dockerfile-Formatierung und Berechtigungskorrektur bereinigen - (d78f0d4) - Billie Thompson
- Dockerfile-Schritte für korrekte Cargo-Abhängigkeiten und Kopiervorgang anpassen - (9080db5) - Billie Thompson
#### Build system
- Rust-Ziele vor Cross-Plattform-Build explizit hinzufügen - (f5c956e) - Billie Thompson
- improve error handling for unsupported target platforms in docker-bake.hcl - (03c6adb) - Billie Thompson
#### Continuous Integration
- Homebrew-Formel-Generierung und -Prüfung mit Docker Buildx aktualisieren - (10a707e) - Billie Thompson
- Erweitere Pipeline um Bake-Schritt für Paketerstellung - (c5a61e2) - Billie Thompson
- reduce the concurrency of docker bake - (7c3fe52) - Billie Thompson
- update workflow to use docker runners with ubuntu image - (9241a99) - Billie Thompson
#### Features
- Homebrew-Formel für whatismyip-Projekt hinzufügen - (f05e545) - Billie Thompson
- change how we do cross platform builds - (5495714) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v0.15.0 [skip ci] - (6848ae2) - PurpleBooth
- update Zig installation to use less verbose tar extraction - (4f3ae55) - Billie Thompson
- update Docker and CI configuration for cross-platform builds - (f1e9912) - Billie Thompson
#### Refactoring
- Dockerfile verbessern und Rust-Ziele dynamisch basierend auf Plattform hinzufügen - (09f5a51) - Billie Thompson
- Entferne auskommentierte macOS SDK-Konfiguration aus Dockerfile und Build-Skript - (3c9b57c) - Billie Thompson
- simplify CI pipeline and Dockerfile with Docker Bake targets - (fa63d60) - Billie Thompson

