### PR TITLE
fix: upgrade whatismyip to 0.15.1

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,16 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/main.tar.gz"
-  version "0.14.4"
-  sha256 "a724366db3bc49267a332010423390aa20f87097b0449fee3dd376317bf5f76b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.14.4"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8eab2fbf1de23da0103e47a22f2cec316e0a62b8d65be9d972c4dcab6dcec6e8"
-    sha256 cellar: :any_skip_relocation, ventura:       "53b67b1e0b4b4f9a45a9c61f94ce1feca793c9f1684fce8795b097f503c26158"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "567b36f3990055fd052af74ab326a414ecfdc87cb03369acf2d30a8b02ca3b79"
-  end
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
+  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.1 - 2025-07-25
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to ff07e85 - (0569958) - Solace System Renovate Fox
- **(deps)** pin rust docker tag to 9dfaae4 - (d0e7030) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update dependency mikefarah/yq to v4.47.1 - (004a382) - Solace System Renovate Fox
- **(version)** v0.15.1 [skip ci] - (76e1803) - PurpleBooth

