### PR TITLE
fix: upgrade whatismyip to 0.15.2

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,8 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
-  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.1.tar.gz"
+  sha256 "31b24c395c87897976e8f92cb2c074206c5173c817740d8dd1d44f9cfc55b726"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.2 - 2025-07-29
#### Bug Fixes
- **(deps)** update rust crate tokio to v1.47.0 - (dc23f26) - Solace System Renovate Fox
#### Continuous Integration
- Vereinfache Pfadverarbeitung in Workflow-Skripten - (e61125d) - Billie Thompson
- Teile Build-Prozess in separate Bake-Schritte auf - (6148052) - Billie Thompson
#### Miscellaneous Chores
- **(deps)** update rust crate criterion to v0.7.0 - (b2012f8) - Solace System Renovate Fox
- **(version)** v0.15.2 [skip ci] - (0bebd9b) - PurpleBooth

