### PR TITLE
fix: upgrade whatismyip to 0.15.3

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,8 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
-  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.2.tar.gz"
+  sha256 "d712e47396d1ffe2e727c09de028e8adeb7358362c767be6d5ef9e25f3be80c2"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.3 - 2025-07-29
#### Bug Fixes
- try and reolve release asset problem - (f43eb3a) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v0.15.3 [skip ci] - (e57c64d) - PurpleBooth

