### PR TITLE
fix: upgrade git-moves-together to 2.8.3

### DIFF
--- a/Formula/git-moves-together.rb
+++ b/Formula/git-moves-together.rb
@@ -2,15 +2,8 @@ class GitMovesTogether < Formula
   desc "Find coupling in git repositories"
   homepage "https://codeberg.org/PurpleBooth/git-moves-together"
   url "https://codeberg.org/PurpleBooth/git-moves-together/archive/main.tar.gz"
-  version "2.8.2"
-  sha256 "cc9a62a866e7c0f42208d09c863158a791bf1d28668fd82136ffdb4d810dd1b3"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-moves-together-2.8.2"
-    sha256 cellar: :any,                 arm64_sequoia: "39ba9ec7cf20964cf2f9b6dd1c8d003f89be9fc459f8e66cfa97e94f9b366726"
-    sha256 cellar: :any,                 ventura:       "1e2204fc258e6dbf546fc9a1a8a9fa9c84651923b138e01e8f3b225a39e6b045"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "99057de7b455cce7e267da98fc4c387f9d1a494c29117163f173a5aa48f34d1e"
-  end
+  version "2.8.3"
+  sha256 "f146c542105759fe88f8d8e6fbc92c9ca2b377f8ca3db6014ca4d448cab6ba8d"
 
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v2.8.3](https://codeberg.org/PurpleBooth/git-moves-together/compare/6aaeced12feea51d73bd04bcf56506c99cb495b7..v2.8.3) - 2025-08-04
#### Bug Fixes
- **(deps)** update rust crate tokio to v1.47.0 - ([3f0a426](https://codeberg.org/PurpleBooth/git-moves-together/commit/3f0a426cca42849f95820a6fccec733a34b25ee8)) - Solace System Renovate Fox
#### Continuous Integration
- run less often - ([0ed0c01](https://codeberg.org/PurpleBooth/git-moves-together/commit/0ed0c0128bde49d7b8e6524513c46b0e772c6314)) - PurpleBooth
- set a lower retension - ([6aaeced](https://codeberg.org/PurpleBooth/git-moves-together/commit/6aaeced12feea51d73bd04bcf56506c99cb495b7)) - PurpleBooth
#### Miscellaneous Chores
- **(deps)** update rust crate cargo-chef to v0.1.72 - ([d5e4252](https://codeberg.org/PurpleBooth/git-moves-together/commit/d5e42522e8604a0f433f933c63c2dba1033df020)) - Solace System Renovate Fox
- **(version)** v2.8.3 [skip ci] - ([3b219cb](https://codeberg.org/PurpleBooth/git-moves-together/commit/3b219cb8f596af9ecfb9f98bbda0e89431e33063)) - SolaceRenovateFox
#### Refactoring
- optimize Dockerfile cross-compilation build stages - ([7f260b3](https://codeberg.org/PurpleBooth/git-moves-together/commit/7f260b36d217d9cd1c1da95e47a465c1e2e99c6d)) - Billie Thompson
- optimize Dockerfile with multi-stage build and cargo-chef - ([126f930](https://codeberg.org/PurpleBooth/git-moves-together/commit/126f9308238772258b26c4d5202b8dd6dac5a169)) - Billie Thompson

