### PR TITLE
fix: upgrade whatismyip to 0.15.4

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,8 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
-  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.3.tar.gz"
+  sha256 "bcf71700882fc41e84e7e26d895f653f2bf8e110f3558a0757d11a2cf4e4a24a"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.4 - 2025-08-04
#### Bug Fixes
- **(deps)** update rust crate clap to v4.5.42 - (8fc5e64) - Solace System Renovate Fox
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to 0202c99 - (907035e) - Solace System Renovate Fox
#### Build system
- Rust-Entwicklungstools im Dockerfile hinzufügen - (72ae7eb) - Billie Thompson
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/metadata-action digest to c1e5197 - (f1dfca4) - Solace System Renovate Fox
- **(version)** v0.15.4 [skip ci] - (26c0dec) - SolaceRenovateFox

