### PR TITLE
fix: upgrade readable-name-generator to 4.3.1

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.0.tar.gz"
+  sha256 "26e92c6c4952e2924bda31480137684bbe7d74f9e44f2456f1d97a8384bd0df1"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.1](https://codeberg.org/PurpleBooth/readable-name-generator/compare/d2a0905847df16dcee2427eac4e2de8f6575ef4c..v4.3.1) - 2025-08-05
#### Bug Fixes
- **(deps)** pin ghcr.io/catthehacker/ubuntu docker tag to 0202c99 - ([02b67c8](https://codeberg.org/PurpleBooth/readable-name-generator/commit/02b67c81268763b302bf0a58cb23eb9f900ff8b7)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/login-action digest to 184bdaa - ([d2a0905](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d2a0905847df16dcee2427eac4e2de8f6575ef4c)) - Solace System Renovate Fox
- **(version)** v4.3.1 [skip ci] - ([302491e](https://codeberg.org/PurpleBooth/readable-name-generator/commit/302491e10458a9ddb397f8e9020e0bb7ce05d4d4)) - PurpleBooth

