### PR TITLE
fix: upgrade whatismyip to 0.15.5

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,8 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
-  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.4.tar.gz"
+  sha256 "a74d3d7e41cbd79f72dae7cc06d9fb70693c3706c767ed8862fcc6602368fba9"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.5 - 2025-08-06
#### Bug Fixes
- **(deps)** update rust crate tokio to v1.47.1 - (b75d1fd) - Solace System Renovate Fox
#### Continuous Integration
- Update CI pipeline with Docker image signing and platform support - (11e5b5f) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v0.15.5 [skip ci] - (0830645) - PurpleBooth

