### PR TITLE
fix: upgrade readable-name-generator to 4.3.2

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.1.tar.gz"
+  sha256 "3e82815021a860ac9fe6c316a87cc948fc1aefbfa80e36450edcff81299bcdf8"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.2](https://codeberg.org/PurpleBooth/readable-name-generator/compare/e043066d32331d9019d67abc690ebc84e74fa6f5..v4.3.2) - 2025-08-10
#### Bug Fixes
- **(deps)** pin dependencies - ([d4f4ef6](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d4f4ef65e26df3de90f3399a0d6e055e98865218)) - Solace System Renovate Fox
#### Build system
- Dockerfile bereinigen und nicht benötigte Pakete entfernen - ([b0fd6ab](https://codeberg.org/PurpleBooth/readable-name-generator/commit/b0fd6abcb43adcc00b10cddebde4b203fa8cd108)) - Billie Thompson
- Dockerfile und Build-Skript auf Ubuntu und Zig aktualisieren - ([831eb23](https://codeberg.org/PurpleBooth/readable-name-generator/commit/831eb2340b889e75b6b0f602ba6a13850075da7f)) - Billie Thompson
- Ersetze zigbuild durch standard cargo build und vereinfache RUSTFLAGS - ([77fedd1](https://codeberg.org/PurpleBooth/readable-name-generator/commit/77fedd16dd3d9a538dceb07146c8b35b7a013c65)) - Billie Thompson
- Umstellung auf Zig-Build und optimierte Rust-Kompilierungsflags - ([9ef41e2](https://codeberg.org/PurpleBooth/readable-name-generator/commit/9ef41e29e3093453eec9ad296540646e07ae3f19)) - Billie Thompson
- Aktualisiere Cross-Platform-Build-Skript für whatismyip-Projekt - ([ab8db11](https://codeberg.org/PurpleBooth/readable-name-generator/commit/ab8db1155e33a6c18d37cf948b623d4ecf833298)) - Billie Thompson
- Statische Rust-Binärkompilierung mit RUSTFLAGS hinzufügen - ([353a79c](https://codeberg.org/PurpleBooth/readable-name-generator/commit/353a79c32825485fec56a70e5eef7fa4a171b0e1)) - Billie Thompson
- Erweitere Docker-Build-Plattformen um linux/amd64 und linux/arm64 - ([e043066](https://codeberg.org/PurpleBooth/readable-name-generator/commit/e043066d32331d9019d67abc690ebc84e74fa6f5)) - Billie Thompson
#### Continuous Integration
- Lizenzen für Docker-Images hinzufügen - ([7c2bb50](https://codeberg.org/PurpleBooth/readable-name-generator/commit/7c2bb50cf2b204aca99dc932ccd0b4d00a6a7181)) - Billie Thompson
- docker pull hinzufügen vor cosign sign - ([c5dae4d](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c5dae4da853d5707d151031fc479b574ed9161ac)) - Billie Thompson
- Verbessere Cosign-Image-Signierung mit SHA-Digest-Verarbeitung - ([b38d95d](https://codeberg.org/PurpleBooth/readable-name-generator/commit/b38d95d566fef1b8e2283487007f66155ca2dc03)) - Billie Thompson
- Docker-Images mit Cosign signieren - ([71c8a11](https://codeberg.org/PurpleBooth/readable-name-generator/commit/71c8a116d94a17d1b20112fcbe85e8a614204cdb)) - Billie Thompson
- Cosign-Installation zu CI-Workflow hinzufügen - ([c24028f](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c24028f8a8a784463703b25da1a727c8c2970db1)) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v4.3.2 [skip ci] - ([52877aa](https://codeberg.org/PurpleBooth/readable-name-generator/commit/52877aa54f88e72fba513653b81c49eeac9ca27b)) - SolaceRenovateFox

