### PR TITLE
fix: upgrade whatismyip to 0.15.6

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,8 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
-  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.5.tar.gz"
+  sha256 "ca1ca9e326a7be3a85f55a6cd3a70915b17a369b3d85beecdc517c959d92a90c"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.6 - 2025-08-10
#### Bug Fixes
- **(deps)** pin dependencies - (1fa1d25) - Solace System Renovate Fox
#### Build system
- Dockerfile und Build-Skript auf Ubuntu und Debian umstellen - (3a4413a) - Billie Thompson
- Optimiere Cross-Plattform-Build-Konfiguration und Rust-Compiler-Flags - (d97545e) - Billie Thompson
- Statische Rust-Binärkompilierung mit RUSTFLAGS hinzufügen - (971b7ee) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v0.15.6 [skip ci] - (6ec0a9a) - SolaceRenovateFox
- Dockerfile-Abhängigkeiten bereinigen und reduzieren - (0ccc2ba) - Billie Thompson

