### PR TITLE
fix: upgrade readable-name-generator to 4.3.3

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.2.tar.gz"
+  sha256 "9c1cfa016a699a90b8fbe139c1fd77eb9fb9860f370f84aa6c8d5ef1a0fecaab"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.3](https://codeberg.org/PurpleBooth/readable-name-generator/compare/c288533290ff301610e439fc31f8e3c16be97206..v4.3.3) - 2025-08-11
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to 3ac21d9 - ([c288533](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c288533290ff301610e439fc31f8e3c16be97206)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.3.3 [skip ci] - ([57ed108](https://codeberg.org/PurpleBooth/readable-name-generator/commit/57ed108a3dd77e36e4f080610c7f90134373b6b9)) - SolaceRenovateFox

