### PR TITLE
fix: upgrade whatismyip to 0.15.7

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,8 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
-  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.6.tar.gz"
+  sha256 "1b43c5c968d0abf6f63d9acc2327892c836cfb2419d29b79d0d00954f501d19e"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.7 - 2025-08-11
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to 3ac21d9 - (ca0f4f1) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v0.15.7 [skip ci] - (749b24c) - SolaceRenovateFox

