### PR TITLE
fix: upgrade readable-name-generator to 4.3.4

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.3.tar.gz"
+  sha256 "61beb664a921f77ffd82640cd1898ee9424738baba1f3175306a2af6d9dbd5d1"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.4](https://codeberg.org/PurpleBooth/readable-name-generator/compare/91dd6ab50bd016b0a668c5af9afe29ae7abc425f..v4.3.4) - 2025-08-18
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to 25811a7 - ([03b768b](https://codeberg.org/PurpleBooth/readable-name-generator/commit/03b768b0bd7518c6a8d7ff693f2946b3ca14f4d2)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/actions/checkout digest to 08eba0b - ([91dd6ab](https://codeberg.org/PurpleBooth/readable-name-generator/commit/91dd6ab50bd016b0a668c5af9afe29ae7abc425f)) - Solace System Renovate Fox
- **(version)** v4.3.4 [skip ci] - ([feff142](https://codeberg.org/PurpleBooth/readable-name-generator/commit/feff142bbeda45cbb44b0b2affc849a8049c4afc)) - SolaceRenovateFox

