### PR TITLE
fix: upgrade readable-name-generator to 4.3.5

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.4.tar.gz"
+  sha256 "09b5999b205f59852d4dccd4f87edd14d5172705e7e9dfeea8d0128e073b653e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.5](https://codeberg.org/PurpleBooth/readable-name-generator/compare/932e2716e482895dc187a5419f51cbc612106cd5..v4.3.5) - 2025-08-27
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to 576a953 - ([6dde750](https://codeberg.org/PurpleBooth/readable-name-generator/commit/6dde750091b3e01720d87e79a424450a8b937cc4)) - Solace System Renovate Fox
#### Build system
- Dockerfile um mingw-w64 für Cross-Compilation erweitern - ([9d79321](https://codeberg.org/PurpleBooth/readable-name-generator/commit/9d793219793aca3ab410d72e02a5773e889050ff)) - Billie Thompson
#### Miscellaneous Chores
- **(version)** v4.3.5 [skip ci] - ([7de804d](https://codeberg.org/PurpleBooth/readable-name-generator/commit/7de804d575a8b69278ac2b834f6cb50ecc86f29f)) - PurpleBooth
- Abhängigkeiten auf neueste Versionen aktualisieren - ([932e271](https://codeberg.org/PurpleBooth/readable-name-generator/commit/932e2716e482895dc187a5419f51cbc612106cd5)) - Billie Thompson

