### PR TITLE
fix: upgrade whatismyip to 0.15.8

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,8 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
-  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.7.tar.gz"
+  sha256 "f9864f8a6b14b4c8ae18e0f7e01b5c6010b5997f748bd61a8d3034d11a8c7f21"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.8 - 2025-09-05
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to f1e9f1a - (d3c57d5) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/actions/checkout digest to 08eba0b - (8e3d2fa) - Solace System Renovate Fox
- **(version)** v0.15.8 [skip ci] - (0b658a9) - PurpleBooth
- Aktualisiere windows-sys Abhängigkeiten auf Version 0.60.2 - (909a585) - Billie Thompson
- Aktualisiere Abhängigkeiten auf neueste Versionen - (bec1560) - Billie Thompson
- Aktualisiere Abhängigkeiten und Cargo.lock - (fd9471a) - Billie Thompson

