### PR TITLE
fix: upgrade whatismyip to 0.15.9

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,8 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
-  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.8.tar.gz"
+  sha256 "5365414ece8e618c9f9da77ae5b0d597bc153cc4038feb67069c242d4d6818e6"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.9 - 2025-09-06
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to b6a6f9f - (6118725) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update dependency ziglang/zig to v0.15.1 - (200f4fa) - Solace System Renovate Fox
- **(version)** v0.15.9 [skip ci] - (f16cc11) - PurpleBooth

