### PR TITLE
fix: upgrade readable-name-generator to 4.3.6

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.5.tar.gz"
+  sha256 "407f6f660d586106956300d8923b177816af6b70f07a7f13cb48afcc7314bcf5"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.6](https://codeberg.org/PurpleBooth/readable-name-generator/compare/781ed4a94eac9e5229ade777f64ee44cd6ae770c..v4.3.6) - 2025-09-08
#### Bug Fixes
- **(deps)** update ubuntu docker digest to 9cbed75 - ([4edd9e6](https://codeberg.org/PurpleBooth/readable-name-generator/commit/4edd9e660e69f5b594c3e2a4afbf8e4672703855)) - Solace System Renovate Fox
- **(deps)** update rust crate clap to v4.5.47 - ([3cba12f](https://codeberg.org/PurpleBooth/readable-name-generator/commit/3cba12fc22b777e0ca44c1a12ac8f9104c3e4b16)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update dependency ziglang/zig to v0.15.1 - ([781ed4a](https://codeberg.org/PurpleBooth/readable-name-generator/commit/781ed4a94eac9e5229ade777f64ee44cd6ae770c)) - Solace System Renovate Fox
- **(version)** v4.3.6 [skip ci] - ([3c70393](https://codeberg.org/PurpleBooth/readable-name-generator/commit/3c70393576f5dec696a7844d9e484525b63ca5d9)) - SolaceRenovateFox
- Aktualisiere Cargo-Abhängigkeiten auf neueste Versionen - ([e6f2c26](https://codeberg.org/PurpleBooth/readable-name-generator/commit/e6f2c2602a598b871588fc2e5c6514e497745c17)) - Billie Thompson

