### PR TITLE
fix: upgrade readable-name-generator to 4.3.7

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.6.tar.gz"
+  sha256 "234945675182100ae6254cc0a9160d0ad9e3d4f2fd6efb7456c91eccf94ced0b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.7](https://codeberg.org/PurpleBooth/readable-name-generator/compare/1ed660fd70868b4ea9e68d300c7198272957affa..v4.3.7) - 2025-09-09
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to f1e9f1a - ([4491454](https://codeberg.org/PurpleBooth/readable-name-generator/commit/44914545b45c782c491bb40ae36c8c4c79ddbf34)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/bake-action digest to 3acf805 - ([0f92009](https://codeberg.org/PurpleBooth/readable-name-generator/commit/0f92009faf9e7ef2e270efc6ddc9aaa965de8462)) - Solace System Renovate Fox
- **(deps)** update dependency mikefarah/yq to v4.47.2 - ([1ed660f](https://codeberg.org/PurpleBooth/readable-name-generator/commit/1ed660fd70868b4ea9e68d300c7198272957affa)) - Solace System Renovate Fox
- **(version)** v4.3.7 [skip ci] - ([284c0f7](https://codeberg.org/PurpleBooth/readable-name-generator/commit/284c0f75e0c89a5a840a5e8d472e48b52d41e64d)) - PurpleBooth

