### PR TITLE
fix: upgrade readable-name-generator to 4.3.8

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.7.tar.gz"
+  sha256 "2d743daceab99656e28dd62dc60351e1c28a48bef51de15467c37a6d072bae57"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.8](https://codeberg.org/PurpleBooth/readable-name-generator/compare/e63b65cc8234efba8a78d70216b7021caeef192c..v4.3.8) - 2025-09-21
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to fce9eca - ([e63b65c](https://codeberg.org/PurpleBooth/readable-name-generator/commit/e63b65cc8234efba8a78d70216b7021caeef192c)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.3.8 [skip ci] - ([a998341](https://codeberg.org/PurpleBooth/readable-name-generator/commit/a9983413b46b31a358d6e86be3b0695db0f46642)) - SolaceRenovateFox

