### PR TITLE
fix: upgrade whatismyip to 0.15.12

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,8 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
-  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.11.tar.gz"
+  sha256 "c48e7ea5586b0cf7bc772ece9e9be54747b5c7dc678c7ea46c1c0fb32280c993"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.12 - 2025-09-22
#### Bug Fixes
- **(deps)** update ubuntu docker digest to 353675e - (ea91d27) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v0.15.12 [skip ci] - (6e51743) - SolaceRenovateFox

