### PR TITLE
fix: upgrade readable-name-generator to 4.3.10

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.9.tar.gz"
+  sha256 "e21e761965446b0232033dee03f876d89f883823027abae186e09086a46f695d"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.10](https://codeberg.org/PurpleBooth/readable-name-generator/compare/e4969837e5bbb147de56b7e3666611a1ebaa8fe5..v4.3.10) - 2025-09-27
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to fb52474 - ([daa948b](https://codeberg.org/PurpleBooth/readable-name-generator/commit/daa948b35f63cd6f8d978e670f10fbc466b153df)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update rust crate clap_complete to v4.5.58 - ([8ca1179](https://codeberg.org/PurpleBooth/readable-name-generator/commit/8ca1179e7176fb0f4d7b8442dd4a7d56aa08f2c9)) - Solace System Renovate Fox
- **(deps)** update rust crate clap to v4.5.48 - ([e496983](https://codeberg.org/PurpleBooth/readable-name-generator/commit/e4969837e5bbb147de56b7e3666611a1ebaa8fe5)) - Solace System Renovate Fox
- **(version)** v4.3.10 [skip ci] - ([d4c44b4](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d4c44b4f47744d58d5b16c5d7692c6b09b2fff5f)) - PurpleBooth

