### PR TITLE
fix: upgrade whatismyip to 0.15.13

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,8 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.0.tar.gz"
-  sha256 "ed03c739f2b71f0537f1b58e07d8d3013f7b052d96636746f0f674ea572273db"
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.12.tar.gz"
+  sha256 "efbbc7d1737d1c574fe5d2f7eb3c0a784d83347fade25ea28fd931abc49d5a5e"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.13 - 2025-09-27
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to fb52474 - (52255b7) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update rust crate clap to v4.5.48 - (4531f51) - Solace System Renovate Fox
- **(deps)** update dependency mikefarah/yq to v4.47.2 - (4002add) - Solace System Renovate Fox
- **(version)** v0.15.13 [skip ci] - (94ae48d) - PurpleBooth

