### PR TITLE
fix: upgrade readable-name-generator to 4.3.11

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.10.tar.gz"
+  sha256 "939b2839efe884eb77aaf2717cbed38ebef6fa9a2e99935d6891ccdf5c9a1c5e"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.11](https://codeberg.org/PurpleBooth/readable-name-generator/compare/6314eaa04c899b52d6d418f67c6559ad58c23e6c..v4.3.11) - 2025-10-03
#### Bug Fixes
- **(deps)** update ubuntu docker digest to 728785b - ([6314eaa](https://codeberg.org/PurpleBooth/readable-name-generator/commit/6314eaa04c899b52d6d418f67c6559ad58c23e6c)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/login-action digest to 5e57cd1 - ([35d4b13](https://codeberg.org/PurpleBooth/readable-name-generator/commit/35d4b13607384dbdd5aae9796e47d303597ae113)) - Solace System Renovate Fox
- **(version)** v4.3.11 [skip ci] - ([dbfc597](https://codeberg.org/PurpleBooth/readable-name-generator/commit/dbfc597d75f636f65e3cd0cfbd18062d9a00a290)) - PurpleBooth

