### PR TITLE
fix: upgrade whatismyip to 0.15.14

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.12.tar.gz"
-  sha256 "efbbc7d1737d1c574fe5d2f7eb3c0a784d83347fade25ea28fd931abc49d5a5e"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.15.12"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d575f6f0a2f9958eb9cbc939fed51eec6599ab890b39d6f6a3de2f928894bbde"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f6076fac579e3be0fa29ee3940aff54b316390cfaf106689079df52f88915013"
-  end
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.13.tar.gz"
+  sha256 "d66337f34876c9ec71c9b3813e41a99ffe4884ad55bf43eb9a7bdfd63657113b"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.14 - 2025-10-03
#### Bug Fixes
- **(deps)** update ubuntu docker digest to 728785b - (39e063c) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(deps)** update https://code.forgejo.org/docker/login-action digest to 5e57cd1 - (5ed4e5f) - Solace System Renovate Fox
- **(version)** v0.15.14 [skip ci] - (4cbe23c) - PurpleBooth

