### PR TITLE
fix: upgrade readable-name-generator to 4.3.12

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.11.tar.gz"
+  sha256 "eba5f6f0ce190631b52c3456a870bb2e09c5570b495b26dc9c9d8459215d987a"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.12](https://codeberg.org/PurpleBooth/readable-name-generator/compare/d7285a3cb30726c7098c93705d66b2baaceb21b3..v4.3.12) - 2025-10-03
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to 525d143 - ([d7285a3](https://codeberg.org/PurpleBooth/readable-name-generator/commit/d7285a3cb30726c7098c93705d66b2baaceb21b3)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.3.12 [skip ci] - ([b771f1b](https://codeberg.org/PurpleBooth/readable-name-generator/commit/b771f1b17eff8f629f871d8eeab90079c1bc6c41)) - PurpleBooth

