### PR TITLE
fix: upgrade whatismyip to 0.15.15

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.13.tar.gz"
-  sha256 "d66337f34876c9ec71c9b3813e41a99ffe4884ad55bf43eb9a7bdfd63657113b"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.15.13"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c02851b8da0d7dca566192cac15dc5ba369c63543b5d5237aa388d69f3cbec35"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "09fd2cb146fd7743d7c92b6c263c4a5379f7ca2b6a8e60ab28e9c38de3740f85"
-  end
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.14.tar.gz"
+  sha256 "1f73a34b5e1846345589048b379ff7f10bd66bd2c3fa94d2dec6041e9cdff8c5"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.15 - 2025-10-03
#### Bug Fixes
- **(deps)** update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to 525d143 - (957af1c) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v0.15.15 [skip ci] - (b99e924) - PurpleBooth

