### PR TITLE
fix: upgrade whatismyip to 0.15.16

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.14.tar.gz"
-  sha256 "1f73a34b5e1846345589048b379ff7f10bd66bd2c3fa94d2dec6041e9cdff8c5"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.15.14"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3a3f61ea33e1c2c9a061c81f1a9fe2cc2ee316a422056e1146819b64648c6d89"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "17632b31130d550c3c2a93e3d613357f3db9ac7668989403315ea4108ace17b7"
-  end
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.15.tar.gz"
+  sha256 "7e19014be6c243b288ace7c2552e298696ba6b06091db3a9a83a9b3c01579b73"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.16 - 2025-10-05
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to 40fb2e6 - (2824165) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v0.15.16 [skip ci] - (509ba13) - SolaceRenovateFox

