### PR TITLE
fix: upgrade readable-name-generator to 4.3.13

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.12.tar.gz"
+  sha256 "80a447287539d7ec14eb98f84e0e3b2f4a6ca7e0172a339e95189521b7e4c4b4"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.13](https://codeberg.org/PurpleBooth/readable-name-generator/compare/00f41166ee3904dba9d3c7abeeea0975e50bd2d4..v4.3.13) - 2025-10-07
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to 90720c4 - ([c4d089b](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c4d089ba697922ba3141446e447e9a960cc1fede)) - Solace System Renovate Fox
- **(deps)** update goreleaser/nfpm docker digest to 40fb2e6 - ([00f4116](https://codeberg.org/PurpleBooth/readable-name-generator/commit/00f41166ee3904dba9d3c7abeeea0975e50bd2d4)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.3.13 [skip ci] - ([c14a44d](https://codeberg.org/PurpleBooth/readable-name-generator/commit/c14a44d67ca131c5187617d395839f93160096a4)) - PurpleBooth

