### PR TITLE
fix: upgrade readable-name-generator to 4.3.14

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.13.tar.gz"
+  sha256 "fa2a2d6a16d188fe05ebf6821969be7022df0059d929e55ac610f2f584ff6a7b"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.14](https://codeberg.org/PurpleBooth/readable-name-generator/compare/433adc6af66f29dbd2549e6b3b151167c64e9464..v4.3.14) - 2025-10-10
#### Bug Fixes
- **(deps)** update ubuntu docker digest to 59a458b - ([433adc6](https://codeberg.org/PurpleBooth/readable-name-generator/commit/433adc6af66f29dbd2549e6b3b151167c64e9464)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.3.14 [skip ci] - ([6425a5f](https://codeberg.org/PurpleBooth/readable-name-generator/commit/6425a5f9fc035b052204045b2305a23070c615f5)) - PurpleBooth

