### PR TITLE
fix: upgrade readable-name-generator to 4.3.15

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.14.tar.gz"
+  sha256 "32a722c3c906693968b8241657dc9b4ac45ed83c1cc2bd7ab64fcd9f44c2217f"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.15](https://codeberg.org/PurpleBooth/readable-name-generator/compare/176043ea88333b56419ba57a8dd0a8fb53e36d68..v4.3.15) - 2025-10-11
#### Bug Fixes
- **(deps)** update goreleaser/nfpm docker digest to c3e0280 - ([176043e](https://codeberg.org/PurpleBooth/readable-name-generator/commit/176043ea88333b56419ba57a8dd0a8fb53e36d68)) - Solace System Renovate Fox
#### Miscellaneous Chores
- **(version)** v4.3.15 [skip ci] - ([9c6d6f1](https://codeberg.org/PurpleBooth/readable-name-generator/commit/9c6d6f1475b019d51e7d980f5b221ce1a02d7f51)) - PurpleBooth

