### PR TITLE
fix: upgrade readable-name-generator to 4.3.16

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.15.tar.gz"
+  sha256 "d0b63a939f409cbf6b8906950a21305c78ddc8aace8d551c8838aa0e6549a122"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.16](https://codeberg.org/PurpleBooth/readable-name-generator/compare/8f7336ce426017783c6ab1d249ff4d4f40c8768d..v4.3.16) - 2025-10-22
#### Bug Fixes
- (**deps**) update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to fbefcd3 - ([7f9b04e](https://codeberg.org/PurpleBooth/readable-name-generator/commit/7f9b04ead3c2c78a02f26764ac05b55a5a53d0d9)) - Solace System Renovate Fox
- (**deps**) update ubuntu docker digest to 66460d5 - ([143c0b8](https://codeberg.org/PurpleBooth/readable-name-generator/commit/143c0b8a21a63b93958c4ee4195fad2c9c82982a)) - Solace System Renovate Fox
#### Miscellaneous Chores
- (**version**) v4.3.16 [skip ci] - ([a17fe19](https://codeberg.org/PurpleBooth/readable-name-generator/commit/a17fe1975fe8895d866e5dffbd8abe60fd94686b)) - SolaceRenovateFox
#### Style
- (**yamlfix**) apply auto-fixes - ([8f7336c](https://codeberg.org/PurpleBooth/readable-name-generator/commit/8f7336ce426017783c6ab1d249ff4d4f40c8768d)) - Solace System Renovate Fox [bot]

