### PR TITLE
fix: upgrade readable-name-generator to 4.3.17

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.16.tar.gz"
+  sha256 "d4e8f823cc6f3644eaec6e81178a6b1c4900ab7e9e8303905ccab7d46da56848"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.17](https://codeberg.org/PurpleBooth/readable-name-generator/compare/b7312c4c49c8973720309b116d316afeae0ac3b1..v4.3.17) - 2025-10-29
#### Bug Fixes
- (**deps**) update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to fa551c9 - ([849d306](https://codeberg.org/PurpleBooth/readable-name-generator/commit/849d3068e677e579ec5f7816f185454eb0595b52)) - Solace System Renovate Fox
#### Miscellaneous Chores
- (**deps**) update dependency mikefarah/yq to v4.48.1 - ([78dfa04](https://codeberg.org/PurpleBooth/readable-name-generator/commit/78dfa0417abbbc940f2286e8b0f47f6f2a56dc8e)) - Solace System Renovate Fox
- (**deps**) update rust crate clap_complete to v4.5.59 - ([4addaf8](https://codeberg.org/PurpleBooth/readable-name-generator/commit/4addaf8a3772ee8b864542e9c9f83cbf2c4a05b6)) - Solace System Renovate Fox
- (**deps**) update rust crate clap to v4.5.50 - ([b7312c4](https://codeberg.org/PurpleBooth/readable-name-generator/commit/b7312c4c49c8973720309b116d316afeae0ac3b1)) - Solace System Renovate Fox
- (**version**) v4.3.17 [skip ci] - ([ac88626](https://codeberg.org/PurpleBooth/readable-name-generator/commit/ac8862644ace00c2db12487de219532bf73963e3)) - SolaceRenovateFox

