### PR TITLE
fix: upgrade whatismyip to 0.15.22

### DIFF
--- a/Formula/whatismyip.rb
+++ b/Formula/whatismyip.rb
@@ -1,14 +1,8 @@
 class Whatismyip < Formula
   desc "Work out what your IP is"
   homepage "https://codeberg.org/PurpleBooth/whatismyip"
-  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.20.tar.gz"
-  sha256 "719a2527953905fbd974dccbb5d4d820b792bd915ea7414b87011fff8a32069d"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/whatismyip-0.15.20"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "48fecbaaa1f4c7dcd712081f7cec2bacfd301310456000a99bf56fc4b8f89932"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "02c326af2a7fc0d79e1811650b2487362b82df97c5b37700c8b1f231216922a2"
-  end
+  url "https://codeberg.org/PurpleBooth/whatismyip/archive/v0.15.21.tar.gz"
+  sha256 "0eee4ebae3a1083cf39651c026c1ec48577defcb5f62fe3af75b8ae3d5b70e39"
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## v0.15.22 - 2025-10-30
#### Bug Fixes
- (**deps**) update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to fa551c9 - (0b920c1) - Solace System Renovate Fox
#### Miscellaneous Chores
- (**version**) v0.15.22 [skip ci] - (9317fd6) - SolaceRenovateFox

