### PR TITLE
fix: upgrade readable-name-generator to 4.3.18

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.17.tar.gz"
+  sha256 "42def53c265b94a8c973e263c7db5a48b5638eb8972e4726e520658f5ee03a30"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.18](https://codeberg.org/PurpleBooth/readable-name-generator/compare/bc73272caff30cc66185e8df7ed5e3675a52a632..v4.3.18) - 2025-11-01
#### Bug Fixes
- (**deps**) update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to a0e93a0 - ([7c4b4f0](https://codeberg.org/PurpleBooth/readable-name-generator/commit/7c4b4f02a36e32d235a763fffa458f36cd54afd5)) - Solace System Renovate Fox
#### Miscellaneous Chores
- (**deps**) update rust crate clap_complete to v4.5.60 - ([9f335db](https://codeberg.org/PurpleBooth/readable-name-generator/commit/9f335db4ac5bd9c0f6503955ddbf558fa73707a7)) - Solace System Renovate Fox
- (**deps**) update rust crate clap to v4.5.51 - ([bc73272](https://codeberg.org/PurpleBooth/readable-name-generator/commit/bc73272caff30cc66185e8df7ed5e3675a52a632)) - Solace System Renovate Fox
- (**version**) v4.3.18 [skip ci] - ([39cd8d9](https://codeberg.org/PurpleBooth/readable-name-generator/commit/39cd8d9467a7c8adf877b644ff52a22000628e53)) - SolaceRenovateFox

