### PR TITLE
fix: upgrade readable-name-generator to 4.3.19

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.18.tar.gz"
+  sha256 "a6535ad1ff151bd21b2daf9d97ed03e0b273027b374b49bf286494d15349b141"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.19](https://codeberg.org/PurpleBooth/readable-name-generator/compare/711f9ebdb1065333f4105956725bae9d6fc145a3..v4.3.19) - 2025-11-02
#### Bug Fixes
- (**deps**) update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to 2a52cbd - ([7ef61ad](https://codeberg.org/PurpleBooth/readable-name-generator/commit/7ef61ad1c197a205df3f11ac3727fda94f6b12a8)) - Solace System Renovate Fox
#### Miscellaneous Chores
- (**deps**) update rust crate anarchist-readable-name-generator-lib to v0.2.1 - ([711f9eb](https://codeberg.org/PurpleBooth/readable-name-generator/commit/711f9ebdb1065333f4105956725bae9d6fc145a3)) - Solace System Renovate Fox
- (**version**) v4.3.19 [skip ci] - ([a76de84](https://codeberg.org/PurpleBooth/readable-name-generator/commit/a76de84354dfc19a8ecd9117296121f753805bb7)) - SolaceRenovateFox

