### PR TITLE
fix: upgrade readable-name-generator to 4.3.20

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.19.tar.gz"
+  sha256 "26763fd27eb84bf3364c6464a3a7a931788e8b96507fcd7b3ca61b50df498733"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.20](https://codeberg.org/PurpleBooth/readable-name-generator/compare/ef493e1083f6a2edc689bd4d76583f0d91aeb7f8..v4.3.20) - 2025-11-08
#### Bug Fixes
- (**deps**) update ghcr.io/catthehacker/ubuntu:runner-latest docker digest to 8232b05 - ([e6dd009](https://codeberg.org/PurpleBooth/readable-name-generator/commit/e6dd00903172eef42b2c24421109ba3ba9e1e4db)) - Solace System Renovate Fox
#### Miscellaneous Chores
- (**deps**) update dependency cargo-audit to 0.22.0 - ([21a5f99](https://codeberg.org/PurpleBooth/readable-name-generator/commit/21a5f9999226607d55c9be15cb27b529cf7f66a1)) - Solace System Renovate Fox
- (**deps**) update https://code.forgejo.org/docker/metadata-action digest to 318604b - ([ef493e1](https://codeberg.org/PurpleBooth/readable-name-generator/commit/ef493e1083f6a2edc689bd4d76583f0d91aeb7f8)) - Solace System Renovate Fox
- (**version**) v4.3.20 [skip ci] - ([ea22198](https://codeberg.org/PurpleBooth/readable-name-generator/commit/ea221989defd18d6a8b8c03f5a3f3e7454358501)) - SolaceRenovateFox

