### PR TITLE
fix: upgrade readable-name-generator to 4.3.21

### DIFF
--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -1,16 +1,8 @@
 class ReadableNameGenerator < Formula
   desc "Generate a readable names suitable for infrastructure"
   homepage "https://codeberg.org/PurpleBooth/readable-name-generator"
-  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/main.tar.gz"
-  version "4.1.71"
-  sha256 "fdee12eddb4f20e6da9d4d6ae800f942758ffe9e21d5c45348946beeb0dff6ae"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/readable-name-generator-4.1.71"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e552e8a48758836e76c76e4d0edd60784d65715146114b4b2e2d46402869a399"
-    sha256 cellar: :any_skip_relocation, ventura:       "de27c5ed0432e1934dfe1432c2509e6458c889d61ebe46272d6db02c8786e1d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93e79503806464b305f7ed2971a9e2ddc773ade614ed590288c2a4511573b343"
-  end
+  url "https://codeberg.org/PurpleBooth/readable-name-generator/archive/v4.3.20.tar.gz"
+  sha256 "7187769fb419e10215b8b2ada1ef94e222c50fece88d02abc1354dbc4ae8f25d"
   depends_on "help2man" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
## [v4.3.21](https://codeberg.org/PurpleBooth/readable-name-generator/compare/fbd8410b4e5897c7a7e361d837981e2e89bf1b31..v4.3.21) - 2025-11-14
#### Bug Fixes
- (**deps**) update ubuntu docker digest to 4a5ffc0 - ([fbd8410](https://codeberg.org/PurpleBooth/readable-name-generator/commit/fbd8410b4e5897c7a7e361d837981e2e89bf1b31)) - Solace System Renovate Fox
#### Miscellaneous Chores
- (**version**) v4.3.21 [skip ci] - ([098e27d](https://codeberg.org/PurpleBooth/readable-name-generator/commit/098e27d8027c01758a9ea3818f0d2f557521f2aa)) - SolaceRenovateFox

