### PR TITLE
ci: update runner OS matrix for current GitHub Actions labels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-15]
+        os: [ubuntu-24.04, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
## Problem

The CI pipeline has been failing on every PR for over 6 months (last green run on main was Nov 2025). Two distinct failures:

1. **lint-pipeline** — actionlint rejects `macos-13` as an unknown runner label (GitHub deprecated it)
2. **test-bot (ubuntu-22.04)** — `brew doctor` fails during `--only-setup` because glibc 2.35 on ubuntu-22.04 is too old for Homebrew 6.x

## Fix

Update the OS matrix in `.github/workflows/tests.yml`:

| Before | After | Reason |
|--------|-------|--------|
| `ubuntu-22.04` | `ubuntu-24.04` | glibc 2.39 satisfies Homebrew's requirement |
| `macos-13` | `macos-14` | `macos-13` label removed by GitHub; `macos-14` is a valid ARM runner |
| `macos-15` | `macos-15` | unchanged |

The tap only ships `arm64_sequoia` and `x86_64_linux` bottles (no Intel macOS bottles), so `macos-14` (ARM) is consistent with the existing bottle strategy.

## Verification

Confirmed via `gh run view` that these are the exact root causes from the most recent failing run (#27413354710).