### PR TITLE
ci: fix Homebrew actions deprecation and cache Node.js 20 warning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
       packages: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@main
       - name: Pull bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
@@ -24,7 +24,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@main
         with:
           token: ${{ github.token }}
           branch: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
       - name: Cache Homebrew Bundler RubyGems
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash
@@ -30,7 +30,7 @@ jobs:
         if: github.event_name == 'pull_request'
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'


### PR DESCRIPTION
## Problem

Three Node.js 20 / deprecated-branch warnings in the CI pipeline that will become errors:

1. **Homebrew/actions/*\@master** — the `master` branch is deprecated and will stop syncing when Homebrew 5.2.0 ships. Affects `setup-homebrew`, `git-user-config`, and `git-try-push`.

2. **actions/cache\@v4** — runs on the deprecated Node.js 20 runtime (removed from runners Sept 2026).

3. **actions/upload-artifact\@v5** — v5 had "preliminary" Node 24 support but still defaulted to Node 20.

## Fix

- All `Homebrew/actions/*\@master` → `@main` in both `tests.yml` and `publish.yml`
- `actions/cache` v4 → v5 (Node.js 24 runtime)
- `actions/upload-artifact` v5 → v7 (v6 switches to Node.js 24 by default; v7 adds ESM + direct uploads, no impact on our `name`/`path` usage)

This supersedes the Renovate `major-github-artifact-actions` branch.