### PR TITLE
fix: Update git-mit to v6.2.0

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.0.6.tar.gz"
-  sha256 "8a933f093585ed9fd477e0cf8951f5077c73e1f482ce1b374d03bffba52ed0f0"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.2.0.tar.gz"
+  sha256 "10c84fb2bb3b95f83c87b48322405f5067c68d438ab8b718605fb7ffb44e65fd"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v6.2.0](https://github.com/PurpleBooth/git-mit/compare/7aebd531bfb690a7d09ce223424f632cc57663e3..v6.2.0) - 2026-06-13
#### Features
- support lefthook by falling back to COMMIT_EDITMSG - ([7aebd53](https://github.com/PurpleBooth/git-mit/commit/7aebd531bfb690a7d09ce223424f632cc57663e3)) - Billie Thompson
#### Bug Fixes
- remove platform-specific lefthook hook backup verification - ([57baf29](https://github.com/PurpleBooth/git-mit/commit/57baf29597455abfa29532b56d01315d80d7b508)) - Billie Thompson
- install lefthook on macos and windows CI runners - ([aa5fc9a](https://github.com/PurpleBooth/git-mit/commit/aa5fc9ad7f7d02a42185d6f45dc1c64315d16332)) - Billie Thompson
#### Miscellaneous Chores
- (**version**) v6.2.0 - ([2a3b6bf](https://github.com/PurpleBooth/git-mit/commit/2a3b6bf3d909542f5f374a7811b56b0ec5a0fa06)) - cog-bot


