### PR TITLE
fix: Update git-mit to v6.3.0

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.2.0.tar.gz"
-  sha256 "10c84fb2bb3b95f83c87b48322405f5067c68d438ab8b718605fb7ffb44e65fd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-6.2.0"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5976cbf8cfa53f80ede9d7b1e46220fe46ef06d089f4ac5bd1c9aa356c479e41"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "58fc80f8ceab1ed190f9b302c97d7a07a16eae8880eb95f4e55d3228c4e88336"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.3.0.tar.gz"
+  sha256 "e4563eca74b8731636de89eb4da25bf4ccf0fef9edddb78901d9a5304914895a"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v6.3.0](https://github.com/PurpleBooth/git-mit/compare/7672ec87658e62593cc5e54ff9b3ce89d14e8a5c..v6.3.0) - 2026-06-14
#### Features
- add available authors hint to no-author and stale-author errors - ([7672ec8](https://github.com/PurpleBooth/git-mit/commit/7672ec87658e62593cc5e54ff9b3ce89d14e8a5c)) - Billie Thompson
#### Miscellaneous Chores
- (**version**) v6.3.0 - ([36b8978](https://github.com/PurpleBooth/git-mit/commit/36b89783c7a14157d601bde64775f419a5b9bb0b)) - cog-bot


