### PR TITLE
fix: Update git-mit to v6.4.1

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.2.0.tar.gz"
-  sha256 "10c84fb2bb3b95f83c87b48322405f5067c68d438ab8b718605fb7ffb44e65fd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-6.2.0"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5976cbf8cfa53f80ede9d7b1e46220fe46ef06d089f4ac5bd1c9aa356c479e41"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "58fc80f8ceab1ed190f9b302c97d7a07a16eae8880eb95f4e55d3228c4e88336"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.4.1.tar.gz"
+  sha256 "316492d0ffd104122a3913f55d473fda0cb2f2e5e84df00a6fae7b74df485502"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v6.4.1](https://github.com/PurpleBooth/git-mit/compare/353b3e2ea1949097d403020950ec873e332fea73..v6.4.1) - 2026-06-15
#### Bug Fixes
- use shell wrapper instead of symlink on windows - ([e2d4174](https://github.com/PurpleBooth/git-mit/commit/e2d4174800784bdc9b9bd7c1524f87ff25a84f37)) - Billie Thompson
#### Documentation
- fix stale symlink references in README and storage docs - ([e0f059a](https://github.com/PurpleBooth/git-mit/commit/e0f059a0089eba4da8eb0e792457db001e6f5ddf)) - Billie Thompson
- describe windows shell wrapper hooks - ([e697a04](https://github.com/PurpleBooth/git-mit/commit/e697a0452b2a51a9f51d82226985773cda280f66)) - Billie Thompson
- make all documentation reachable via links - ([6a85ae4](https://github.com/PurpleBooth/git-mit/commit/6a85ae484c78e24bf1855445fbcdfaec2b3c5648)) - Billie Thompson
#### Tests
- add descriptive messages to all assertions - ([c3efe93](https://github.com/PurpleBooth/git-mit/commit/c3efe938c36208d2e7185c50fdca7c05960ea7a7)) - Billie Thompson
- cover 17 mutation testing gaps - ([596d170](https://github.com/PurpleBooth/git-mit/commit/596d170dc3ac913aa93a295479b33dc15505585e)) - Billie Thompson
#### Refactoring
- (**mit-lint**) Split bundled test cases into one test per function - ([b5a4719](https://github.com/PurpleBooth/git-mit/commit/b5a47197559abb26aead36f9c4364a9d004fe254)) - Billie Thompson
- remove duplicate tests from subject length check - ([d6ed777](https://github.com/PurpleBooth/git-mit/commit/d6ed77799b89122fe1cc22206be736425b5ea215)) - Billie Thompson
- split long task docs and inline unit tests - ([353b3e2](https://github.com/PurpleBooth/git-mit/commit/353b3e2ea1949097d403020950ec873e332fea73)) - Billie Thompson
#### Miscellaneous Chores
- (**version**) v6.4.1 - ([3a9430c](https://github.com/PurpleBooth/git-mit/commit/3a9430ce2bdadc39c8901711e0bbae2c8d383371)) - cog-bot


