### PR TITLE
fix: Update git-mit to v6.4.2

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.2.0.tar.gz"
-  sha256 "10c84fb2bb3b95f83c87b48322405f5067c68d438ab8b718605fb7ffb44e65fd"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-6.2.0"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5976cbf8cfa53f80ede9d7b1e46220fe46ef06d089f4ac5bd1c9aa356c479e41"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "58fc80f8ceab1ed190f9b302c97d7a07a16eae8880eb95f4e55d3228c4e88336"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.4.2.tar.gz"
+  sha256 "ba022f6a8cb70eaad20d03589e1a5002fe2520218d35991651bf9630ea237fce"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v6.4.2](https://github.com/PurpleBooth/git-mit/compare/46ecfd0a1abed28847552ecddd49897b857cb796..v6.4.2) - 2026-06-16
#### Bug Fixes
- (**deps**) update rust docker tag to v1.96.0 - ([b480655](https://github.com/PurpleBooth/git-mit/commit/b480655357284d50862ab03477fbd0db08ac22ea)) - renovate[bot]
- add gitlab lint - ([89aa435](https://github.com/PurpleBooth/git-mit/commit/89aa4351749ac9abf8bec2cfea6da408733c6a32)) - Billie Thompson
- quickcheck test skips comment lines - ([1f9ad84](https://github.com/PurpleBooth/git-mit/commit/1f9ad849e5fe1d47f501449b8d9c508eaea4c810)) - PurpleBooth
#### Documentation
- add gitlab id to homepage - ([be2262d](https://github.com/PurpleBooth/git-mit/commit/be2262d31773a22319cbf2ab90cbc72be1d834d4)) - Billie Thompson
- add JIRA comment test and update lint list - ([b321b89](https://github.com/PurpleBooth/git-mit/commit/b321b89091aa212b8a97fcae17d7327cb4581782)) - Billie Thompson
#### Miscellaneous Chores
- (**deps**) bump mit-commit and syn - ([11c7b59](https://github.com/PurpleBooth/git-mit/commit/11c7b5985a6fdb16f078a4a03d4f12227cd2d5a9)) - Billie Thompson
- (**deps**) loosen up the pins - ([de78357](https://github.com/PurpleBooth/git-mit/commit/de783572dc4a2d2fbb206782577eab59a0182947)) - Billie Thompson
- (**deps**) bump versions - ([46ecfd0](https://github.com/PurpleBooth/git-mit/commit/46ecfd0a1abed28847552ecddd49897b857cb796)) - Billie Thompson
- (**version**) v6.4.2 - ([07c8939](https://github.com/PurpleBooth/git-mit/commit/07c8939ea915b916be62516dc640fcd576238268)) - cog-bot
- update to 2024 - ([25256b0](https://github.com/PurpleBooth/git-mit/commit/25256b0e3a72f5e47ba50740c1253eb01426355c)) - Billie Thompson
- remove embedded mit-lint it is an external - ([6213aec](https://github.com/PurpleBooth/git-mit/commit/6213aec9bf718d7c335a3edcc3de36177bb41e06)) - Billie Thompson


