### PR TITLE
fix: Update git-mit to v6.5.0

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.4.2.tar.gz"
-  sha256 "ba022f6a8cb70eaad20d03589e1a5002fe2520218d35991651bf9630ea237fce"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-6.4.2"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7dd48a938d27ee8bec43c323ecfad84c9505963e012447384b0625895e48bda4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d6f20734c1410db89f081f3fa26c5a79ef02c4514946c381163deb659c01dc3e"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.5.0.tar.gz"
+  sha256 "643ed48d6881f2606516c65e4cb76ba78dd8a32bc588c6bb99cf4126066f24d9"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v6.5.0](https://github.com/PurpleBooth/git-mit/compare/9df04ebd420c40f738c71397c93a267ced775dd1..v6.5.0) - 2026-06-25
#### Features
- add --uninstall flag to git-mit-install - ([9df04eb](https://github.com/PurpleBooth/git-mit/commit/9df04ebd420c40f738c71397c93a267ced775dd1)) - Billie Thompson
#### Bug Fixes
- use test -e instead of test -L for Windows compatibility - ([48506f8](https://github.com/PurpleBooth/git-mit/commit/48506f87f0a6cc97e11947172967dc74e86d3f56)) - Billie Thompson
#### Miscellaneous Chores
- (**version**) v6.5.0 - ([75c4bc2](https://github.com/PurpleBooth/git-mit/commit/75c4bc2792303358b58204d98cecad37a6073ce5)) - cog-bot


