### PR TITLE
fix: remove redundant shells from generate_completions_from_executable

### DIFF
--- a/Formula/fast-conventional.rb
+++ b/Formula/fast-conventional.rb
@@ -25,7 +25,7 @@ class FastConventional < Formula
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
 
     # Install completion
-    generate_completions_from_executable(bin/"fast-conventional", "completion", shells: [:bash, :zsh, :fish])
+    generate_completions_from_executable(bin/"fast-conventional", "completion")
 
     # Man pages
     output = Utils.safe_popen_read("help2man", "#{bin}/fast-conventional")

--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -31,11 +31,7 @@ class GitMit < Formula
       system "cargo", "install", *std_cargo_args(path: "./#{binary}/")
 
       # Completions
-      generate_completions_from_executable(bin/binary.to_s, "--completion", shells: [
-        :bash,
-        :fish,
-        :zsh,
-      ])
+      generate_completions_from_executable(bin/binary.to_s, "--completion")
 
       # Man pages
       output = Utils.safe_popen_read("help2man", bin/binary.to_s)

--- a/Formula/readable-name-generator.rb
+++ b/Formula/readable-name-generator.rb
@@ -19,8 +19,7 @@ class ReadableNameGenerator < Formula
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
 
     # Completions
-    generate_completions_from_executable(bin/"readable-name-generator", "--completion-shell",
-shells: [:bash, :zsh, :fish])
+    generate_completions_from_executable(bin/"readable-name-generator", "--completion-shell")
 
     # Man pages
     output = Utils.safe_popen_read("help2man", bin/"readable-name-generator")


### PR DESCRIPTION
## Problem

Homebrew's `FormulaAudit/RedundantGenerateCompletionsShells` audit now flags passing the default shells (`:bash, :zsh, :fish`) to `generate_completions_from_executable` as redundant — those are already the defaults.

This was causing `brew test-bot --only-tap-syntax` to fail on `main` across all 3 runs (2026-06-26).

## Fix

Removed the explicit `shells:` parameter from:

- `Formula/fast-conventional.rb`
- `Formula/git-mit.rb`
- `Formula/readable-name-generator.rb`

## Root cause

The formula templates in the source repos also pass redundant shells. PRs to fix the templates:
- `PurpleBooth/fast-conventional` — `homebrew/formula.rb.j2`
- `PurpleBooth/readable-name-generator` — `homebrew/formula.rb.envsubstr`
- `PurpleBooth/git-mit` — `homebrew/formula.rb.j2`