### PR TITLE
fix: Update git-mit to v6.5.2

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,14 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.4.2.tar.gz"
-  sha256 "ba022f6a8cb70eaad20d03589e1a5002fe2520218d35991651bf9630ea237fce"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-6.4.2"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7dd48a938d27ee8bec43c323ecfad84c9505963e012447384b0625895e48bda4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d6f20734c1410db89f081f3fa26c5a79ef02c4514946c381163deb659c01dc3e"
-  end
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.5.2.tar.gz"
+  sha256 "0f3cd5886dc362fc0596b97a99d6c00d6bf590d8cd35984d84f9b860890aaf07"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v6.5.2](https://github.com/PurpleBooth/git-mit/compare/fb720628e6673c327f1b9ac11cd166a9592ccffe..v6.5.2) - 2026-06-29
#### Bug Fixes
- remove redundant shells from generate_completions_from_executable template - ([d160de2](https://github.com/PurpleBooth/git-mit/commit/d160de26088c52cb84a1ab977aba10cee783a2d8)) - PurpleBooth
#### Miscellaneous Chores
- (**deps**) update taiki-e/install-action digest to 2c7d624 (#1650) - ([65d73b5](https://github.com/PurpleBooth/git-mit/commit/65d73b5b66b8faba9dacade032ab5325cb848820)) - renovate[bot], renovate[bot]
- (**deps**) update actions/cache action to v6.1.0 (#1651) - ([345d6c7](https://github.com/PurpleBooth/git-mit/commit/345d6c7679dbed94451d134bbe71f17e7b3ceda3)) - renovate[bot], renovate[bot]
- (**deps**) update cargo-bins/cargo-binstall digest to 910d9e4 (#1649) - ([fb72062](https://github.com/PurpleBooth/git-mit/commit/fb720628e6673c327f1b9ac11cd166a9592ccffe)) - renovate[bot], renovate[bot]
- (**version**) v6.5.2 - ([6c0d9fb](https://github.com/PurpleBooth/git-mit/commit/6c0d9fb224f2f385280d9336d53b37b0add693d9)) - cog-bot


