### PR TITLE
fix: Update git-mit to v6.5.3

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -1,8 +1,8 @@
 class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
-  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.5.2.tar.gz"
-  sha256 "0f3cd5886dc362fc0596b97a99d6c00d6bf590d8cd35984d84f9b860890aaf07"
+  url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.5.3.tar.gz"
+  sha256 "369682acce5da0edb90d99d90173f8ed7eb84cbc4e9b0bd9421a75c974e5cad4"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v6.5.3](https://github.com/PurpleBooth/git-mit/compare/4a8137e60f3322af5362fa96f0180722524c0444..v6.5.3) - 2026-07-03
#### Bug Fixes
- (**deps**) update rust docker tag to v1.96.1 - ([da794c6](https://github.com/PurpleBooth/git-mit/commit/da794c655d987cf98bdc0b0b435b1183d7a4649f)) - renovate[bot]
#### Miscellaneous Chores
- (**deps**) update rust crate clap_complete to v4.6.7 - ([3da8948](https://github.com/PurpleBooth/git-mit/commit/3da89489399fe4fc79a0254f6114465493f6dc87)) - renovate[bot]
- (**deps**) update rust crate time to v0.3.53 - ([63eb24b](https://github.com/PurpleBooth/git-mit/commit/63eb24b0f634d7b2a9314fc3b9c05c1d44e3365a)) - renovate[bot]
- (**deps**) update rust crate rand to v0.10.2 - ([4a8137e](https://github.com/PurpleBooth/git-mit/commit/4a8137e60f3322af5362fa96f0180722524c0444)) - renovate[bot]
- (**version**) v6.5.3 - ([32c8812](https://github.com/PurpleBooth/git-mit/commit/32c881243b017211b9480aae361e43ec0becb628)) - cog-bot


