### PR TITLE
fix: Update git-mit to v6.5.3

### DIFF
--- a/Formula/git-mit.rb
+++ b/Formula/git-mit.rb
@@ -2,12 +2,7 @@ class GitMit < Formula
   desc "Minimalist set of hooks to aid pairing and link commits to issues"
   homepage "https://github.com/PurpleBooth/git-mit"
   url "https://github.com/PurpleBooth/git-mit/archive/refs/tags/v6.5.3.tar.gz"
-  sha256 "369682acce5da0edb90d99d90173f8ed7eb84cbc4e9b0bd9421a75c974e5cad4"
-
-  bottle do
-    root_url "https://github.com/PurpleBooth/homebrew-repo/releases/download/git-mit-6.5.3"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a520f144a6f8b99a0cb8e4d2e9d49f495eba0977ab3e152794284ab618aba664"
-  end
+  sha256 "393f0561dd185f43ca1f8490d1f2b95ee8af937946790ecc3074d6689644e760"
   depends_on "help2man" => :build
   depends_on "homebrew/core/rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
## [v6.5.3](https://github.com/PurpleBooth/git-mit/compare/7b549754d8fda36fd965e5babf0f6a7ada696f75..v6.5.3) - 2026-07-05
#### Bug Fixes
- (**deps**) update rust docker tag to v1.96.1 - ([7b54975](https://github.com/PurpleBooth/git-mit/commit/7b549754d8fda36fd965e5babf0f6a7ada696f75)) - renovate[bot]
#### Miscellaneous Chores
- (**deps**) update rust crate clap_complete to v4.6.7 - ([2eb1d08](https://github.com/PurpleBooth/git-mit/commit/2eb1d084d17b4e06ff06687df60c5e565be61c84)) - renovate[bot]
- (**deps**) update rust crate rand to v0.10.2 - ([f5cfff1](https://github.com/PurpleBooth/git-mit/commit/f5cfff1eb95bcfe6ba991b955a23dfd450a30421)) - renovate[bot]
- (**deps**) update rust crate time to v0.3.53 - ([d5e9a16](https://github.com/PurpleBooth/git-mit/commit/d5e9a164e5ed7a267311033a0a83bdfe04b0bf99)) - renovate[bot]
- (**version**) v6.5.3 - ([3ae445a](https://github.com/PurpleBooth/git-mit/commit/3ae445a4e055b1d7db71c473c60fdf7b671b9bde)) - cog-bot


